### PR TITLE
Fix bugs in space info creation.

### DIFF
--- a/src/lcm/__init__.py
+++ b/src/lcm/__init__.py
@@ -1,3 +1,8 @@
 import jax
 
+from lcm import mark
+
 jax.config.update("jax_platform_name", "cpu")
+
+
+__all__ = ["mark"]

--- a/src/lcm/discrete_emax.py
+++ b/src/lcm/discrete_emax.py
@@ -26,7 +26,7 @@ import jax
 import jax.numpy as jnp
 
 
-def get_emax_calculator(shock_type, variable_info):
+def get_emax_calculator(shock_type, variable_info, is_last_period):
     """Return a function that calculates the expected maximum of continuation values.
 
     The maximum is taken over the discrete choice variables in each state.
@@ -34,6 +34,7 @@ def get_emax_calculator(shock_type, variable_info):
     Args:
         shock_type (str or None): One of None, "extreme_value" and "nested_logit".
         variable_info (pd.DataFrame): DataFrame with information about the variables.
+        is_last_period (bool): Whether the function is created for the last period.
 
     Returns:
         callable: Function that calculates the expected maximum of conditional
@@ -46,6 +47,8 @@ def get_emax_calculator(shock_type, variable_info):
             - params (dict): Dictionary with model parameters.
 
     """
+    if is_last_period:
+        variable_info = variable_info.query("~is_auxiliary")
     choice_axes = _determine_discrete_choice_axes(variable_info)
     if shock_type is None:
         func = partial(_calculate_emax_no_shocks, choice_axes=choice_axes)

--- a/src/lcm/example_models_stochastic.py
+++ b/src/lcm/example_models_stochastic.py
@@ -1,0 +1,61 @@
+"""Define example model specifications."""
+import jax.numpy as jnp
+
+RETIREMENT_AGE = 65
+N_CHOICE_GRID_POINTS = 500
+N_STATE_GRID_POINTS = 100
+
+
+def phelps_deaton_utility(consumption, working, delta):
+    return jnp.log(consumption) - delta * working
+
+
+def working(retirement):
+    return 1 - retirement
+
+
+def next_wealth(wealth, consumption, working, wage, interest_rate):
+    return (1 + interest_rate) * (wealth - consumption) + wage * working
+
+
+# @lcm.mark.stochastic
+def next_wage(wage):
+    return wage
+
+
+def consumption_constraint(consumption, wealth):
+    return consumption <= wealth
+
+
+def age(period):
+    return period + 18
+
+
+PHELPS_DEATON = {
+    "functions": {
+        "utility": phelps_deaton_utility,
+        "next_wealth": next_wealth,
+        "next_wage": next_wage,
+        "consumption_constraint": consumption_constraint,
+        "working": working,
+    },
+    "choices": {
+        "retirement": {"options": [0, 1]},
+        "consumption": {
+            "grid_type": "linspace",
+            "start": 0,
+            "stop": 100,
+            "n_points": N_CHOICE_GRID_POINTS,
+        },
+    },
+    "states": {
+        "wage": {"options": [0, 1]},
+        "wealth": {
+            "grid_type": "linspace",
+            "start": 0,
+            "stop": 100,
+            "n_points": N_STATE_GRID_POINTS,
+        },
+    },
+    "n_periods": 20,
+}

--- a/src/lcm/example_models_stochastic.py
+++ b/src/lcm/example_models_stochastic.py
@@ -1,6 +1,8 @@
 """Define example model specifications."""
 import jax.numpy as jnp
 
+import lcm
+
 RETIREMENT_AGE = 65
 N_CHOICE_GRID_POINTS = 500
 N_STATE_GRID_POINTS = 100
@@ -18,7 +20,7 @@ def next_wealth(wealth, consumption, working, wage, interest_rate):
     return (1 + interest_rate) * (wealth - consumption) + wage * working
 
 
-# @lcm.mark.stochastic
+@lcm.mark.stochastic
 def next_wage(wage):
     return wage
 

--- a/src/lcm/mark.py
+++ b/src/lcm/mark.py
@@ -1,9 +1,10 @@
+"""Collection of LCM marking decorators."""
 import functools
 from typing import NamedTuple
 
 
 class StochasticInfo(NamedTuple):
-    pass
+    """Information on the stochastic nature of user provided functions."""
 
 
 def stochastic(
@@ -14,7 +15,9 @@ def stochastic(
     """Decorator to mark a function as stochastic and add information.
 
     Args:
-        func (callable): The function to be decorated
+        func (callable): The function to be decorated.
+        *args (list): Positional arguments to be passed to the StochasticInfo.
+        **kwargs (dict): Keyword arguments to be passed to the StochasticInfo.
 
     Returns:
         callable: The decorated function
@@ -27,11 +30,7 @@ def stochastic(
         def wrapper_mark_minimizer(*args, **kwargs):
             return func(*args, **kwargs)
 
-        wrapper_mark_minimizer._stochastic_info = stochastic_info
+        wrapper_mark_minimizer.stochastic_info = stochastic_info
         return wrapper_mark_minimizer
 
-    if callable(func):
-        return decorator_stochastic(func)
-
-    else:
-        return decorator_stochastic
+    return decorator_stochastic(func) if callable(func) else decorator_stochastic

--- a/src/lcm/mark.py
+++ b/src/lcm/mark.py
@@ -1,0 +1,37 @@
+import functools
+from typing import NamedTuple
+
+
+class StochasticInfo(NamedTuple):
+    pass
+
+
+def stochastic(
+    func,
+    *args,
+    **kwargs,
+):
+    """Decorator to mark a function as stochastic and add information.
+
+    Args:
+        func (callable): The function to be decorated
+
+    Returns:
+        callable: The decorated function
+
+    """
+    stochastic_info = StochasticInfo(*args, **kwargs)
+
+    def decorator_stochastic(func):
+        @functools.wraps(func)
+        def wrapper_mark_minimizer(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        wrapper_mark_minimizer._stochastic_info = stochastic_info
+        return wrapper_mark_minimizer
+
+    if callable(func):
+        return decorator_stochastic(func)
+
+    else:
+        return decorator_stochastic

--- a/src/lcm/process_model.py
+++ b/src/lcm/process_model.py
@@ -34,7 +34,11 @@ def process_model(user_model):
         function_info=_function_info,
         params=_params,
     )
-    _variable_info = _get_variable_info(user_model, function_info=_function_info)
+    _variable_info = _get_variable_info(
+        user_model,
+        function_info=_function_info,
+        functions=_functions,
+    )
     _gridspecs = _get_gridspecs(user_model, variable_info=_variable_info)
     _grids = _get_grids(gridspecs=_gridspecs, variable_info=_variable_info)
     return Model(
@@ -49,7 +53,7 @@ def process_model(user_model):
     )
 
 
-def _get_variable_info(user_model, function_info):
+def _get_variable_info(user_model, function_info, functions):
     """Derive information about all variables in the model.
 
     Args:
@@ -58,6 +62,12 @@ def _get_variable_info(user_model, function_info):
             functions in the model. The index contains the name of a function. The
             columns are booleans that are True if the function has the corresponding
             property. The columns are: is_filter, is_constraint, is_next.
+        functions (dict): Dictionary that maps names of functions to functions. The
+            functions differ from the user functions in that they all except the
+            filter functions take ``params`` as keyword argument. If the original
+            function depended on model parameters, those are automatically extracted
+            from ``params`` and passed to the original function. Otherwise, the
+            ``params`` argument is simply ignored.
 
     Returns:
         pandas.DataFrame: A table with information about all variables in the model.
@@ -79,6 +89,13 @@ def _get_variable_info(user_model, function_info):
     info["is_discrete"] = ["options" in spec for spec in _variables.values()]
     info["is_continuous"] = ~info["is_discrete"]
 
+    _auxiliary_variables = _get_auxiliary_variables(
+        state_variables=info.query("is_state").index.tolist(),
+        function_info=function_info,
+        functions=functions,
+    )
+    info["is_auxiliary"] = [var in _auxiliary_variables for var in _variables]
+
     _filtered_variables = set()
     _filter_names = function_info.query("is_filter").index.tolist()
 
@@ -99,6 +116,32 @@ def _get_variable_info(user_model, function_info):
         raise ValueError("Order and index do not match.")
 
     return info.loc[order]
+
+
+def _get_auxiliary_variables(state_variables, function_info, functions):
+    """Get state variables that only occur in next functions.
+
+    Args:
+        state_variables (list): List of state variable names.
+        function_info (pandas.DataFrame): A table with information about all
+            functions in the model. The index contains the name of a function. The
+            columns are booleans that are True if the function has the corresponding
+            property. The columns are: is_filter, is_constraint, is_next.
+        functions (dict): Dictionary that maps names of functions to functions. The
+            functions differ from the user functions in that they all except the
+            filter functions take ``params`` as keyword argument. If the original
+            function depended on model parameters, those are automatically extracted
+            from ``params`` and passed to the original function. Otherwise, the
+            ``params`` argument is simply ignored.
+
+    Returns:
+        list: List of state variable names that are only used in next functions.
+
+    """
+    non_next_functions = function_info.query("~is_next").index.tolist()
+    functions = {name: functions[name] for name in non_next_functions}
+    ancestors = get_ancestors(functions, targets=list(functions), include_targets=True)
+    return list(set(state_variables).difference(set(ancestors)))
 
 
 def _get_gridspecs(user_model, variable_info):

--- a/src/lcm/process_model.py
+++ b/src/lcm/process_model.py
@@ -252,3 +252,7 @@ def _get_function_with_dummy_params(func):
         return func(**_kwargs)
 
     return processed_func
+
+
+def _process_stochastic_functions(functions):
+    return [func for func in functions if hasattr(func, "_stochastic_info")]

--- a/src/lcm/process_model.py
+++ b/src/lcm/process_model.py
@@ -63,9 +63,9 @@ def _get_variable_info(user_model, function_info, functions):
             columns are booleans that are True if the function has the corresponding
             property. The columns are: is_filter, is_constraint, is_next.
         functions (dict): Dictionary that maps names of functions to functions. The
-            functions differ from the user functions in that they all except the
-            filter functions take ``params`` as keyword argument. If the original
-            function depended on model parameters, those are automatically extracted
+            functions differ from the user functions in that—except for filter
+            functions—they take ``params`` as a keyword argument. If the original
+            function depends on model parameters, those are automatically extracted
             from ``params`` and passed to the original function. Otherwise, the
             ``params`` argument is simply ignored.
 

--- a/src/lcm/state_space.py
+++ b/src/lcm/state_space.py
@@ -4,13 +4,32 @@ import inspect
 import jax
 import jax.numpy as jnp
 import numpy as np
-from dags import concatenate_functions
+from dags import concatenate_functions, get_ancestors
 
 from lcm.dispatchers import productmap, spacemap
 from lcm.interfaces import IndexerInfo, Space, SpaceInfo
 
 
-def create_state_choice_space(model, period, *, jit_filter):
+def reduce_variable_info(variable_info, function_info, functions):
+    """Drop state variables that only occur in next functions from the variable info.
+
+    Args:
+        vi (pandas.DataFrame): A table with information about all variables in the model
+        model (Model): A processed model.
+
+    Returns:
+        pandas.Dataframe: The reduced variable info data frame.
+
+    """
+    non_next_functions = function_info.query("~is_next").index.tolist()
+    functions = {name: functions[name] for name in non_next_functions}
+    ancestors = get_ancestors(functions, targets=list(functions), include_targets=True)
+    state_variables = variable_info.query("is_state").index.tolist()
+    irrelevant_state_variables = set(state_variables).difference(set(ancestors))
+    return variable_info.drop(index=irrelevant_state_variables)
+
+
+def create_state_choice_space(model, period, *, is_last_period, jit_filter):
     """Create a state choice space for the model.
 
     A state_choice_space is a compressed representation of all feasible states and the
@@ -47,6 +66,12 @@ def create_state_choice_space(model, period, *, jit_filter):
     # preparations
     # ==================================================================================
     vi = model.variable_info
+    if is_last_period:
+        vi = reduce_variable_info(
+            vi,
+            function_info=model.function_info,
+            functions=model.functions,
+        )
 
     has_sparse_states = (vi.is_sparse & vi.is_state).any()
     has_sparse_vars = vi.is_sparse.any()

--- a/tests/test_discrete_emax.py
+++ b/tests/test_discrete_emax.py
@@ -44,6 +44,7 @@ def test_aggregation_without_shocks(values, segment_info, collapse, n_extra_axes
     calculator = get_emax_calculator(
         shock_type=None,
         variable_info=var_info,
+        is_last_period=False,
     )
 
     calculated = calculator(
@@ -92,6 +93,7 @@ def test_aggregation_with_extreme_value_shocks(
     calculator = get_emax_calculator(
         shock_type="extreme_value",
         variable_info=var_info,
+        is_last_period=False,
     )
 
     calculated = calculator(
@@ -142,7 +144,11 @@ def test_get_emax_calculator_illustrative():
         },
     )  # leads to choice_axes = [1]
 
-    emax_calculator = get_emax_calculator(shock_type=None, variable_info=variable_info)
+    emax_calculator = get_emax_calculator(
+        shock_type=None,
+        variable_info=variable_info,
+        is_last_period=False,
+    )
 
     values = jnp.array(
         [

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -104,6 +104,7 @@ def test_create_compute_conditional_continuation_value():
     _, space_info, _, _ = create_state_choice_space(
         model=model,
         period=0,
+        is_last_period=False,
         jit_filter=False,
     )
 
@@ -150,6 +151,7 @@ def test_create_compute_conditional_continuation_policy():
     _, space_info, _, _ = create_state_choice_space(
         model=model,
         period=0,
+        is_last_period=False,
         jit_filter=False,
     )
 

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -54,6 +54,7 @@ def test_get_utility_and_feasibility_function():
     _, space_info, _, _ = create_state_choice_space(
         model=model,
         period=0,
+        is_last_period=False,
         jit_filter=False,
     )
 

--- a/tests/test_process_model.py
+++ b/tests/test_process_model.py
@@ -56,13 +56,18 @@ def test_get_function_info(user_model):
 
 def test_get_variable_info(user_model):
     function_info = _get_function_info(user_model)
-    got = _get_variable_info(user_model, function_info)
+    got = _get_variable_info(
+        user_model,
+        function_info,
+        functions=user_model["functions"],
+    )
     exp = pd.DataFrame(
         {
             "is_state": [False, True],
             "is_choice": [True, False],
             "is_discrete": [True, True],
             "is_continuous": [False, False],
+            "is_auxiliary": [False, True],
             "is_sparse": [False, False],
             "is_dense": [True, True],
         },
@@ -72,14 +77,22 @@ def test_get_variable_info(user_model):
 
 
 def test_get_gridspecs(user_model):
-    variable_info = _get_variable_info(user_model, _get_function_info(user_model))
+    variable_info = _get_variable_info(
+        user_model,
+        function_info=_get_function_info(user_model),
+        functions=user_model["functions"],
+    )
     got = _get_gridspecs(user_model, variable_info)
     exp = {"a": [0, 1], "c": [2, 3]}
     assert got == exp
 
 
 def test_get_grids(user_model):
-    variable_info = _get_variable_info(user_model, _get_function_info(user_model))
+    variable_info = _get_variable_info(
+        user_model,
+        function_info=_get_function_info(user_model),
+        functions=user_model["functions"],
+    )
     gridspecs = _get_gridspecs(user_model, variable_info)
     got = _get_grids(gridspecs, variable_info)
     assert_array_equal(got["a"], jnp.array([0, 1]))

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -37,6 +37,7 @@ def simulate_inputs():
     _, space_info, _, _ = create_state_choice_space(
         model=model,
         period=0,
+        is_last_period=False,
         jit_filter=False,
     )
 

--- a/tests/test_state_space.py
+++ b/tests/test_state_space.py
@@ -17,7 +17,12 @@ from numpy.testing import assert_array_almost_equal as aaae
 
 def test_create_state_choice_space():
     _model = process_model(PHELPS_DEATON_WITH_FILTERS)
-    create_state_choice_space(model=_model, period=0, jit_filter=False)
+    create_state_choice_space(
+        model=_model,
+        period=0,
+        is_last_period=False,
+        jit_filter=False,
+    )
 
 
 @pytest.fixture()

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -1,0 +1,19 @@
+from lcm.entry_point import (
+    get_lcm_function,
+)
+from lcm.example_models_stochastic import (
+    PHELPS_DEATON,
+)
+from pybaum import tree_map
+
+# ======================================================================================
+# Solve
+# ======================================================================================
+
+
+def test_get_lcm_function_with_solve_target():
+    solve_model, params_template = get_lcm_function(model=PHELPS_DEATON)
+
+    params = tree_map(lambda _: 0.2, params_template)
+
+    solve_model(params)


### PR DESCRIPTION
In creating lcm internal functions in `entry_point.py`, the space info was used for the wrong periods; in particular, in period t, one needs to use the space info of period t+1. We further needed to exclude certain auxiliary variables in the last period.