### PR TITLE
Implement allow_args and improve allow_kwargs decorator

### DIFF
--- a/src/lcm/dispatchers.py
+++ b/src/lcm/dispatchers.py
@@ -193,22 +193,21 @@ def allow_kwargs(func):
     def allow_kwargs_wrapper(*args, **kwargs):
         parameters = inspect.signature(func).parameters
 
-        # Separate keyword-only arguments
+        # Separate keyword-only arguments and remove from kwargs
         keyword_only = {
             k: v
             for k, v in kwargs.items()
             if k in parameters and parameters[k].kind == inspect.Parameter.KEYWORD_ONLY
         }
-        for kwarg_name in keyword_only:
-            kwargs.pop(kwarg_name)
-
-        positional = list(args) if args is not None else []
+        for k in keyword_only:
+            kwargs.pop(k)
 
         # Check if the total number of arguments matches the function signature
-        kwargs = {} if args is None else kwargs
         if len(args) + len(kwargs) + len(keyword_only) != len(parameters):
             raise ValueError("Not enough or too many arguments provided.")
 
+        # Separate positional arguments and convert keyword arguments to positional
+        positional = list(args)
         positional += convert_kwargs_to_args(kwargs, list(parameters))
 
         return func(*positional, **keyword_only)

--- a/src/lcm/dispatchers.py
+++ b/src/lcm/dispatchers.py
@@ -39,6 +39,8 @@ def spacemap(func, dense_vars, sparse_vars, *, dense_first):
             above but there might be additional dimensions.
 
     """
+    func = allow_args(func)  # vmap cannot deal with keyword-only arguments
+
     if not set(dense_vars).isdisjoint(sparse_vars):
         raise ValueError("dense_vars and sparse_vars overlap.")
 
@@ -96,6 +98,8 @@ def productmap(func, variables):
             might be additional dimensions.
 
     """
+    func = allow_args(func)  # vmap cannot deal with keyword-only arguments
+
     if len(variables) != len(set(variables)):
         raise ValueError("Same argument provided more than once.")
 

--- a/src/lcm/dispatchers.py
+++ b/src/lcm/dispatchers.py
@@ -206,6 +206,20 @@ def allow_kwargs(func):
     return allow_kwargs_wrapper
 
 
+def allow_args(func):
+    """Allow a function to be called with positional arguments.
+
+    Args:
+        func (callable): The function to be wrapped.
+
+    Returns:
+        callable: A callable with the same arguments as func (but with the additional
+            possibility to call it with positional arguments).
+
+    """
+    return func
+
+
 def convert_kwargs_to_args(kwargs, parameters):
     """Convert kwargs to args in the order of parameters.
 

--- a/src/lcm/dispatchers.py
+++ b/src/lcm/dispatchers.py
@@ -193,7 +193,7 @@ def allow_kwargs(func):
     def allow_kwargs_wrapper(*args, **kwargs):
         parameters = inspect.signature(func).parameters
 
-        # Separate keyword-only arguments and remove from kwargs
+        # Retrieve keyword-only arguments and remove from kwargs
         keyword_only = {
             k: v
             for k, v in kwargs.items()
@@ -231,6 +231,10 @@ def allow_args(func):
     def allow_args_wrapper(*args, **kwargs):
         parameters = inspect.signature(func).parameters
 
+        # Check if the total number of arguments matches the function signature
+        if len(args) + len(kwargs) != len(parameters):
+            raise ValueError("Not enough or too many arguments provided.")
+
         # Count the number of positional-only arguments
         n_positional_only_parameters = len(
             [
@@ -239,10 +243,6 @@ def allow_args(func):
                 if p.kind == inspect.Parameter.POSITIONAL_ONLY
             ],
         )
-
-        # Check if the total number of arguments matches the function signature
-        if len(args) + len(kwargs) != len(parameters):
-            raise ValueError("Not enough or too many arguments provided.")
 
         # Convert all arguments to positional arguments in correct order
         positional = list(args)

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -274,10 +274,24 @@ def test_allow_kwargs():
 
 
 def test_allow_kwargs_with_keyword_only_args():
-    def f(a, *, b):
+    def f(a, /, *, b):
         return a + b
 
+    with pytest.raises(TypeError):
+        f(a=1, b=2)
+
     assert allow_kwargs(f)(a=1, b=2) == 3
+
+
+def test_allow_kwargs_incorrect_number_of_args():
+    def f(a, /, b):
+        return a + b
+
+    with pytest.raises(ValueError, match="Not enough or too many arguments"):
+        allow_kwargs(f)(a=1, b=2, c=3)
+
+    with pytest.raises(ValueError, match="Not enough or too many arguments"):
+        allow_kwargs(f)(a=1)
 
 
 # ======================================================================================
@@ -290,6 +304,9 @@ def test_allow_args():
         # b is keyword-only
         return a + b
 
+    with pytest.raises(TypeError):
+        f(1, 2)
+
     assert allow_args(f)(1, 2) == 3
     assert allow_args(f)(1, b=2) == 3
     assert allow_args(f)(b=2, a=1) == 3
@@ -299,8 +316,22 @@ def test_allow_args_different_kwargs_order():
     def f(a, b, c, *, d):
         return a + b + c + d
 
+    with pytest.raises(TypeError):
+        f(1, 2, 3, 4)
+
     assert allow_args(f)(1, 2, 3, 4) == 10
     assert allow_args(f)(1, 2, d=4, c=3) == 10
+
+
+def test_allow_args_incorrect_number_of_args():
+    def f(a, *, b):
+        return a + b
+
+    with pytest.raises(ValueError, match="Not enough or too many arguments"):
+        allow_args(f)(1, 2, b=3)
+
+    with pytest.raises(ValueError, match="Not enough or too many arguments"):
+        allow_args(f)(1)
 
 
 # ======================================================================================

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -291,6 +291,16 @@ def test_allow_args():
         return a + b
 
     assert allow_args(f)(1, 2) == 3
+    assert allow_args(f)(1, b=2) == 3
+    assert allow_args(f)(b=2, a=1) == 3
+
+
+def test_allow_args_different_kwargs_order():
+    def f(a, b, c, *, d):
+        return a + b + c + d
+
+    assert allow_args(f)(1, 2, 3, 4) == 10
+    assert allow_args(f)(1, 2, d=4, c=3) == 10
 
 
 # ======================================================================================

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -3,6 +3,7 @@ import itertools
 import jax.numpy as jnp
 import pytest
 from lcm.dispatchers import (
+    allow_args,
     allow_kwargs,
     convert_kwargs_to_args,
     productmap,
@@ -270,6 +271,26 @@ def test_allow_kwargs():
         f(a=1, b=2)
 
     assert allow_kwargs(f)(a=1, b=2) == 3
+
+
+def test_allow_kwargs_with_keyword_only_args():
+    def f(a, *, b):
+        return a + b
+
+    assert allow_kwargs(f)(a=1, b=2) == 3
+
+
+# ======================================================================================
+# allow args
+# ======================================================================================
+
+
+def test_allow_args():
+    def f(a, *, b):
+        # b is keyword-only
+        return a + b
+
+    assert allow_args(f)(1, 2) == 3
 
 
 # ======================================================================================

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -1,7 +1,9 @@
+import inspect
 import itertools
 
 import jax.numpy as jnp
 import pytest
+from jax import vmap
 from lcm.dispatchers import (
     allow_args,
     allow_kwargs,
@@ -13,16 +15,28 @@ from lcm.dispatchers import (
 from numpy.testing import assert_array_almost_equal as aaae
 
 
-def f(a, b, c):
+def f(a, /, *, b, c):
+    """Tests that dispatchers can handle positional-only and keyword-only arguments.
+
+    a is positional-only, b and c are keyword-only
+    """
     return jnp.sin(a) + jnp.cos(b) + jnp.tan(c)
 
 
-def f2(b, a, c):
+def f2(b, a, /, *, c):
+    """Tests that dispatchers can handle positional-only and keyword-only arguments.
+
+    b and a are positional-only, c is keyword-only
+    """
     return jnp.sin(a) + jnp.cos(b) + jnp.tan(c)
 
 
-def g(a, b, c, d):
-    return f(a, b, c) + jnp.log(d)
+def g(a, /, b, *, c, d):
+    """Tests that dispatchers can handle positional-only and keyword-only arguments.
+
+    a is positional-only, b is positional-or-keyword, c and d are keyword-only
+    """
+    return f(a, b=b, c=c) + jnp.log(d)
 
 
 # ======================================================================================
@@ -48,7 +62,7 @@ def expected_productmap_f():
     }
 
     helper = jnp.array(list(itertools.product(*grids.values()))).T
-    return f(*helper).reshape(10, 7, 5)
+    return allow_kwargs(allow_args(f))(*helper).reshape(10, 7, 5)
 
 
 @pytest.fixture()
@@ -71,7 +85,7 @@ def expected_productmap_g():
     }
 
     helper = jnp.array(list(itertools.product(*grids.values()))).T
-    return g(*helper).reshape(10, 7, 5, 4)
+    return allow_kwargs(allow_args(g))(*helper).reshape(10, 7, 5, 4)
 
 
 @pytest.mark.parametrize(
@@ -121,7 +135,7 @@ def test_productmap_with_all_arguments_mapped_some_len_one():
 
     helper = jnp.array(list(itertools.product(*grids.values()))).T
 
-    expected = f(*helper).reshape(1, 1, 5)
+    expected = allow_kwargs(allow_args(f))(*helper).reshape(1, 1, 5)
 
     decorated = productmap(f, ["a", "b", "c"])
     calculated = decorated(*grids.values())
@@ -149,7 +163,7 @@ def test_productmap_with_some_arguments_mapped():
 
     helper = jnp.array(list(itertools.product(grids["a"], [grids["b"]], grids["c"]))).T
 
-    expected = f(*helper).reshape(10, 5)
+    expected = allow_kwargs(allow_args(f))(*helper).reshape(10, 5)
 
     decorated = productmap(f, ["a", "c"])
     calculated = decorated(*grids.values())
@@ -203,7 +217,7 @@ def expected_spacemap():
     all_grids = {**value_grid, **combination_grid}
     helper = jnp.array(list(itertools.product(*all_grids.values()))).T
 
-    return g(*helper).reshape(3, 2, 4 * 5)
+    return allow_kwargs(allow_args(g))(*helper).reshape(3, 2, 4 * 5)
 
 
 @pytest.mark.parametrize("dense_first", [True, False])
@@ -294,24 +308,16 @@ def test_allow_kwargs_incorrect_number_of_args():
         allow_kwargs(f)(a=1)
 
 
-def test_allow_kwargs_with_productmap():
-    def f(a, /, b):
-        # a is positional-only
-        return a + b
+def test_allow_kwargs_signature_change():
+    def f(a, /, b, *, c):  # noqa: ARG001
+        pass
 
-    # productmap calls allow_kwargs internally
-    decorated = productmap(f, ["a", "b"])
+    decorated = allow_args(f)
+    parameters = inspect.signature(decorated).parameters
 
-    a = jnp.arange(2)
-    b = jnp.arange(2)
-
-    with pytest.raises(TypeError):
-        # TypeError since a is positional-only
-        f(a=a, b=b)
-
-    aaae(decorated(a=a, b=b), jnp.array([[0, 1], [1, 2]]))
-    aaae(decorated(a, b=b), jnp.array([[0, 1], [1, 2]]))
-    aaae(decorated(a, b), jnp.array([[0, 1], [1, 2]]))
+    assert parameters["a"].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["b"].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["c"].kind == inspect.Parameter.KEYWORD_ONLY
 
 
 # ======================================================================================
@@ -354,32 +360,38 @@ def test_allow_args_incorrect_number_of_args():
         allow_args(f)(1)
 
 
-def test_allow_args_with_productmap():
+def test_allow_args_with_vmap():
     def f(a, *, b):
         # b is keyword-only
         return a + b
 
-    decorated_f = productmap(f, ["a", "b"])
-    decorated_f_with_allow_args = productmap(allow_args(f), ["a", "b"])
+    f_vmapped = vmap(f, in_axes=(0, 0))
+    f_allow_args_vmapped = vmap(allow_args(f), in_axes=(0, 0))
 
     a = jnp.arange(2)
     b = jnp.arange(2)
 
-    with pytest.raises(ValueError, match="vmap in_axes specification must be a tree"):
-        # ValueError since vmap is applied to a function with keyword-only argument
-        decorated_f(a=a, b=b)
+    with pytest.raises(TypeError):
+        # TypeError since b is keyword-only
+        f_vmapped(a, b)
 
-    with pytest.raises(ValueError, match="vmap in_axes specification must be a tree"):
-        # ValueError since vmap is applied to a function with keyword-only argument
-        decorated_f(a, b=b)
+    with pytest.raises(ValueError, match="vmap in_axes specification"):
+        # ValueError since vmap doesn't support keyword arguments
+        f_vmapped(a, b=b)
 
-    with pytest.raises(KeyError):
-        # KeyError since f expects b as keyword argument
-        decorated_f(a, b)
+    aaae(f_allow_args_vmapped(a, b), jnp.array([0, 2]))
 
-    aaae(decorated_f_with_allow_args(a, b), jnp.array([[0, 1], [1, 2]]))
-    aaae(decorated_f_with_allow_args(a, b=b), jnp.array([[0, 1], [1, 2]]))
-    aaae(decorated_f_with_allow_args(a=a, b=b), jnp.array([[0, 1], [1, 2]]))
+
+def test_allow_args_signature_change():
+    def f(a, /, b, *, c):  # noqa: ARG001
+        pass
+
+    decorated = allow_args(f)
+    parameters = inspect.signature(decorated).parameters
+
+    assert parameters["a"].kind == inspect.Parameter.POSITIONAL_ONLY
+    assert parameters["b"].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["c"].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
 
 
 # ======================================================================================

--- a/tests/test_dispatchers.py
+++ b/tests/test_dispatchers.py
@@ -312,7 +312,7 @@ def test_allow_kwargs_signature_change():
     def f(a, /, b, *, c):  # noqa: ARG001
         pass
 
-    decorated = allow_args(f)
+    decorated = allow_kwargs(f)
     parameters = inspect.signature(decorated).parameters
 
     assert parameters["a"].kind == inspect.Parameter.POSITIONAL_OR_KEYWORD


### PR DESCRIPTION
In this PR we implement the `allow_args` decorator and improve the `allow_kwargs` decorator.

### `allow_kwargs`

We allow for the case where the function to be wrapped has a keyword-only parameter.

### `allow_args`

We implement a decorator in line with `allow_kwargs`, which lets us call a function (that potentially has some keyword-only parameters) with positional args only. Importantly, the resulting function accepts both args and kwargs. 