### PR TITLE
Add period as special argument

### DIFF
--- a/src/lcm/create_params.py
+++ b/src/lcm/create_params.py
@@ -106,12 +106,16 @@ def _create_shock_params(model, variable_info, grids):
             variables=dependencies,
             variable_info=variable_info,
             msg_suffix=(
-                f"The function next_{var} can only depend on discrete state variables."
+                f"The function next_{var} can only depend on discrete state variables "
+                f"or '_period'."
             ),
         )
 
         # get dimensions of variables that influence the stochastic variable
-        dimensions = [len(grids[dep]) for dep in dependencies]
+        dimensions = [
+            len(grids[dep]) if dep != "_period" else model["n_periods"]
+            for dep in dependencies
+        ]
         # add dimension of stochastic variable to last axis
         dimensions = (*dimensions, len(grids[var]))
 
@@ -127,7 +131,7 @@ def _create_standard_params():
 def _check_variables_are_all_discrete_states(variables, variable_info, msg_suffix):
     discrete_state_vars = variable_info.query("is_state and is_discrete").index.tolist()
     for var in variables:
-        if var not in discrete_state_vars:
+        if var not in discrete_state_vars and var != "_period":
             raise ValueError(
                 f"Variable {var} is not a discrete state variable. {msg_suffix}",
             )

--- a/src/lcm/create_params.py
+++ b/src/lcm/create_params.py
@@ -21,10 +21,7 @@ def create_params(user_model, variable_info, grids):
         dict: A dictionary of model parameters.
 
     """
-    params = {
-        **_create_standard_params(),
-        **_create_function_params(user_model),
-    }
+    params = _create_standard_params() | _create_function_params(user_model)
 
     if variable_info["is_stochastic"].any():
         params["shocks"] = _create_shock_params(
@@ -38,6 +35,9 @@ def create_params(user_model, variable_info, grids):
 
 def _create_function_params(model):
     """Get function parameters from a model specification.
+
+    The argument '_period' is handled separately. It is not treated as a parameter, but
+    as the period of the model. Functions like 'age' can depend on it.
 
     Args:
         model (dict): A model specification. Has keys
@@ -63,7 +63,7 @@ def _create_function_params(model):
     for name, func in model["functions"].items():
         arguments = set(inspect.signature(func).parameters)
         params = sorted(arguments.difference(variables))
-        out[name] = {p: np.nan for p in params}
+        out[name] = {p: np.nan for p in params if p != "_period"}
     return out
 
 

--- a/src/lcm/entry_point.py
+++ b/src/lcm/entry_point.py
@@ -121,6 +121,7 @@ def get_lcm_function(model, targets="solve", interpolation_options=None):
             space_info=space_infos[period],
             data_name="vf_arr",
             interpolation_options=interpolation_options,
+            period=period,
             is_last_period=is_last_period,
         )
         compute_ccv = create_compute_conditional_continuation_value(

--- a/src/lcm/example_models.py
+++ b/src/lcm/example_models.py
@@ -51,8 +51,12 @@ def consumption_constraint(consumption, wealth):
     return consumption <= wealth
 
 
-def age(period):
-    return period + 18
+def wage(age):
+    return 1 + 0.1 * age
+
+
+def age(_period):
+    return _period + 18
 
 
 def mandatory_retirement_filter(retirement, age):
@@ -69,6 +73,8 @@ PHELPS_DEATON = {
         "next_wealth": next_wealth,
         "consumption_constraint": consumption_constraint,
         "working": working,
+        "wage": wage,
+        "age": age,
     },
     "choices": {
         "retirement": {"options": [0, 1]},

--- a/src/lcm/example_models_stochastic.py
+++ b/src/lcm/example_models_stochastic.py
@@ -21,7 +21,7 @@ def next_health(health, partner):  # noqa: ARG001
 
 
 @lcm.mark.stochastic
-def next_partner(partner):  # noqa: ARG001
+def next_partner(_period):
     pass
 
 
@@ -68,6 +68,6 @@ PARAMS = {
     "consumption_constraint": {},
     "shocks": {
         "health": jnp.array([[[0.5, 0.5], [0.5, 0.5]], [[0.5, 0.5], [0.5, 0.5]]]),
-        "partner": jnp.array([[0.5, 0.5], [0.5, 0.5]]),
+        "partner": jnp.array([[1.0, 0], [0.0, 1]]),
     },
 }

--- a/src/lcm/get_model.py
+++ b/src/lcm/get_model.py
@@ -32,8 +32,18 @@ def get_model(model: str):
 # Models
 # ======================================================================================
 
+# Remove age and wage functions from Phelps-Deaton model, as they are not used in the
+# original paper.
+PHELPS_DEATON_WITHOUT_AGE = PHELPS_DEATON.copy()
+PHELPS_DEATON_WITHOUT_AGE["functions"] = {
+    name: func
+    for name, func in PHELPS_DEATON_WITHOUT_AGE["functions"].items()
+    if name not in ["age", "wage"]
+}
+
+
 PHELPS_DEATON_FIVE_PERIODS = {
-    **PHELPS_DEATON,
+    **PHELPS_DEATON_WITHOUT_AGE,
     "choices": {
         "retirement": {"options": [0, 1]},
         "consumption": {

--- a/src/lcm/model_functions.py
+++ b/src/lcm/model_functions.py
@@ -107,7 +107,7 @@ def get_utility_and_feasibility_function(
                 _period=period,
                 params=kwargs["params"],
             )
-            weights = next_weights(**states, params=kwargs["params"])
+            weights = next_weights(**states, _period=period, params=kwargs["params"])
 
             value_function = productmap(
                 scalar_value_function,

--- a/src/lcm/model_functions.py
+++ b/src/lcm/model_functions.py
@@ -19,6 +19,7 @@ def get_utility_and_feasibility_function(
     space_info,
     data_name,
     interpolation_options,
+    period,
     is_last_period,
 ):
     # ==================================================================================
@@ -65,7 +66,7 @@ def get_utility_and_feasibility_function(
     # Create the utility and feasability function
     # ==================================================================================
 
-    arg_names = {"vf_arr"} | get_union_of_arguments(relevant_functions)
+    arg_names = {"vf_arr"} | get_union_of_arguments(relevant_functions) - {"_period"}
     arg_names = [arg for arg in arg_names if "next_" not in arg]
 
     if is_last_period:
@@ -77,7 +78,12 @@ def get_utility_and_feasibility_function(
             states = {k: v for k, v in kwargs.items() if k in state_variables}
             choices = {k: v for k, v in kwargs.items() if k in choice_variables}
 
-            return current_u_and_f(**states, **choices, params=kwargs["params"])
+            return current_u_and_f(
+                **states,
+                **choices,
+                _period=period,
+                params=kwargs["params"],
+            )
 
     else:
 
@@ -88,9 +94,19 @@ def get_utility_and_feasibility_function(
             states = {k: v for k, v in kwargs.items() if k in state_variables}
             choices = {k: v for k, v in kwargs.items() if k in choice_variables}
 
-            u, f = current_u_and_f(**states, **choices, params=kwargs["params"])
+            u, f = current_u_and_f(
+                **states,
+                **choices,
+                _period=period,
+                params=kwargs["params"],
+            )
 
-            _next_state = next_state(**states, **choices, params=kwargs["params"])
+            _next_state = next_state(
+                **states,
+                **choices,
+                _period=period,
+                params=kwargs["params"],
+            )
             weights = next_weights(**states, params=kwargs["params"])
 
             value_function = productmap(
@@ -158,6 +174,7 @@ def get_current_u_and_f(model):
     return concatenate_functions(
         functions=functions,
         targets=["utility", "feasibility"],
+        enforce_signature=False,
     )
 
 

--- a/src/lcm/process_model.py
+++ b/src/lcm/process_model.py
@@ -395,16 +395,19 @@ def _get_stochastic_weight_function(raw_func, name, variable_info, grids):
 
     # Assert that stochastic next function only depends on state variables
     for arg in function_parameters:
-        if not variable_info.loc[arg, "is_state"]:
+        if arg != "_period" and not variable_info.loc[arg, "is_state"]:
             raise ValueError(
-                f"Stochastic variables can only depend on state variables, but {name} "
-                f"depends on {arg}.",
+                f"Stochastic variables can only depend on state variables and '_period'"
+                f" but {name} depends on {arg}.",
             )
 
     label_translators = {
         var: get_label_translator(labels=grids[var], in_name=var)
         for var in function_parameters
+        if var != "_period"
     }
+    if "_period" in function_parameters:
+        label_translators["_period"] = lambda _period: _period
 
     new_kwargs = [*function_parameters, "params"]
 

--- a/src/lcm/random_choice.py
+++ b/src/lcm/random_choice.py
@@ -7,7 +7,7 @@ def random_choice(key, probs, labels):
     """Draw multiple random choices.
 
     Args:
-        key (jax.random.PRNGKey): Random keys. One for each simulation unit.
+        key (jax.random.PRNGKey): Random key.
         probs (jax.numpy.array): 2d array of probabilities. Second dimension must be
             the same length as the first dimension of labels.
         labels (jax.numpy.array): 1d array of labels.

--- a/src/lcm/simulate.py
+++ b/src/lcm/simulate.py
@@ -191,7 +191,13 @@ def simulate(
             ids=model.function_info.query("is_stochastic_next").index,
         )
 
-        states = next_state(**states, **choices, params=params, keys=sim_keys)
+        states = next_state(
+            **states,
+            **choices,
+            _period=period,
+            params=params,
+            keys=sim_keys,
+        )
 
         # 'next_' prefix is added by the next_state function, but needs to be removed
         # because in the next period, next states are current states.

--- a/src/lcm/simulate.py
+++ b/src/lcm/simulate.py
@@ -75,6 +75,7 @@ def simulate(
     # Preparations
     # ==================================================================================
     n_periods = len(vf_arr_list)
+    n_initial_states = len(next(iter(initial_states.values())))
 
     _discrete_policy_calculator = get_discrete_policy_calculator(
         variable_info=model.variable_info,
@@ -194,7 +195,7 @@ def simulate(
         states = next_state(
             **states,
             **choices,
-            _period=period,
+            _period=jnp.repeat(period, n_initial_states),
             params=params,
             keys=sim_keys,
         )

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -148,6 +148,7 @@ def test_create_compute_conditional_continuation_value():
         space_info=space_info,
         data_name="vf_arr",
         interpolation_options={},
+        period=model.n_periods - 1,
         is_last_period=True,
     )
 
@@ -195,6 +196,7 @@ def test_create_compute_conditional_continuation_policy():
         space_info=space_info,
         data_name="vf_arr",
         interpolation_options={},
+        period=model.n_periods - 1,
         is_last_period=True,
     )
 

--- a/tests/test_model_functions.py
+++ b/tests/test_model_functions.py
@@ -64,6 +64,7 @@ def test_get_utility_and_feasibility_function():
         space_info=space_info,
         data_name="vf_arr",
         interpolation_options={},
+        period=model.n_periods - 1,
         is_last_period=True,
     )
 

--- a/tests/test_next_state.py
+++ b/tests/test_next_state.py
@@ -20,14 +20,13 @@ def test_get_next_state_function_with_solve_target():
         "utility": {"delta": 1.0},
         "next_wealth": {
             "interest_rate": 0.05,
-            "wage": 1.0,
         },
     }
 
     choice = {"retirement": 1, "consumption": 10}
     state = {"wealth": 20}
 
-    got = got_func(**choice, **state, params=params)
+    got = got_func(**choice, **state, _period=1, params=params)
     assert got == {"next_wealth": 1.05 * (20 - 10)}
 
 

--- a/tests/test_process_model.py
+++ b/tests/test_process_model.py
@@ -200,12 +200,12 @@ def test_process_phelps_deaton():
     # Functions
     assert (
         model.function_info["is_next"].to_numpy()
-        == np.array([False, True, False, False])
+        == np.array([False, True, False, False, False, False])
     ).all()
 
     assert (
         model.function_info["is_constraint"].to_numpy()
-        == np.array([False, False, True, False])
+        == np.array([False, False, True, False, False, False])
     ).all()
 
     assert ~model.function_info.loc["utility"].to_numpy().any()

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -48,20 +48,21 @@ def simulate_inputs():
         jit_filter=False,
     )
 
-    u_and_f = get_utility_and_feasibility_function(
-        model=model,
-        space_info=space_info,
-        data_name="vf_arr",
-        interpolation_options={},
-        is_last_period=True,
-    )
-
-    compute_ccv_policy_functions = model.n_periods * [
-        create_compute_conditional_continuation_policy(
+    compute_ccv_policy_functions = []
+    for period in range(model.n_periods):
+        u_and_f = get_utility_and_feasibility_function(
+            model=model,
+            space_info=space_info,
+            data_name="vf_arr",
+            interpolation_options={},
+            period=period,
+            is_last_period=True,
+        )
+        compute_ccv = create_compute_conditional_continuation_policy(
             utility_and_feasibility=u_and_f,
             continuous_choice_variables=["consumption"],
-        ),
-    ]
+        )
+        compute_ccv_policy_functions.append(compute_ccv)
 
     return {
         "state_indexers": [{}],
@@ -80,7 +81,6 @@ def test_simulate_using_raw_inputs(simulate_inputs):
         "utility": {"delta": 1.0},
         "next_wealth": {
             "interest_rate": 0.05,
-            "wage": 1.0,
         },
     }
 
@@ -104,6 +104,12 @@ def test_simulate_using_raw_inputs(simulate_inputs):
 def phelps_deaton_model_solution():
     def _model_solution(n_periods):
         model = {**PHELPS_DEATON, "n_periods": n_periods}
+        model["functions"] = {
+            # remove dependency on age, so that wage becomes a parameter
+            name: func
+            for name, func in model["functions"].items()
+            if name not in ["age", "wage"]
+        }
         solve_model, _ = get_lcm_function(model=model)
 
         params = {
@@ -176,7 +182,6 @@ def test_effect_of_beta_on_last_period():
         "utility": {"delta": 1.0},
         "next_wealth": {
             "interest_rate": 0.05,
-            "wage": 1.0,
         },
     }
 
@@ -231,7 +236,6 @@ def test_effect_of_delta():
         "utility": {"delta": None},
         "next_wealth": {
             "interest_rate": 0.05,
-            "wage": 1.0,
         },
     }
 

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -15,7 +15,7 @@ from lcm.example_models_stochastic import MODEL, PARAMS
 def test_get_lcm_function_with_simulate_target():
     simulate_model, _ = get_lcm_function(model=MODEL, targets="solve_and_simulate")
 
-    simulate_model(
+    res = simulate_model(
         PARAMS,
         initial_states={
             "health": jnp.array([1, 1, 0, 0]),
@@ -23,6 +23,22 @@ def test_get_lcm_function_with_simulate_target():
             "wealth": jnp.array([10.0, 50.0, 30, 80.0]),
         },
     )
+
+    expected_partner = [
+        0,
+        0,
+        1,
+        0,  # period 0
+        0,
+        0,
+        0,
+        0,  # period 1
+        1,
+        1,
+        1,
+        1,  # period 2
+    ]
+    assert jnp.array_equal(res["partner"].values, expected_partner)
 
 
 # ======================================================================================


### PR DESCRIPTION
In this PR, we add a special argument `_period`, that can be used in the user-defined functions. It represents the current period in the model. This can be useful, for example, to model age:

```python
def age(_period):
   return _period + 18
```

---

@ChristianZimpelmann Before we merge, could you check that the simulated results using this feature make sense in one of your models? Ideally, we would also have another small test for the lcm test suite. I've only tested that nothing breaks, not that the feature does what it should.

> **Comment:**
>
> I know that the testing situation in LCM is horrible, as there are way too many slightly different "PHELPS_DEATON" models floating around. But there is little time to fix this now. I've opened an issue regarding this: #46.