### PR TITLE
Fix period bug in additional target computation

### DIFF
--- a/src/lcm/simulate.py
+++ b/src/lcm/simulate.py
@@ -346,16 +346,21 @@ def _process_simulated_data(results):
     Returns:
         dict: Dict with processed simulation results. The keys are the variable names
             and the values are the flattened arrays, with dimension (n_periods *
-            n_initial_states, ).
+            n_initial_states, ). Additionally, the _period variable is added.
 
     """
+    n_periods = len(results)
+    n_initial_states = len(results[0]["value"])
+
     list_of_dicts = [
         {"value": d["value"], **d["choices"], **d["states"]} for d in results
     ]
     dict_of_lists = {
         key: [d[key] for d in list_of_dicts] for key in list(list_of_dicts[0])
     }
-    return {key: jnp.concatenate(values) for key, values in dict_of_lists.items()}
+    out = {key: jnp.concatenate(values) for key, values in dict_of_lists.items()}
+    out["_period"] = jnp.repeat(jnp.arange(n_periods), n_initial_states)
+    return out
 
 
 # ======================================================================================

--- a/tests/test_entry_point.py
+++ b/tests/test_entry_point.py
@@ -59,6 +59,7 @@ def test_get_lcm_function_with_simulation_target_simple(user_model):
         initial_states={
             "wealth": jnp.array([0.0, 10.0, 50.0]),
         },
+        additional_targets=["age"] if "age" in user_model["functions"] else None,
     )
 
 

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -145,6 +145,7 @@ def test_simulate_using_get_lcm_function(phelps_deaton_model_solution, n_periods
     )
 
     assert {
+        "_period",
         "value",
         "retirement",
         "consumption",


### PR DESCRIPTION
Fixes a bug that prevented the usage of the `_period` argument in the computation of additional targets for the simulation result.