### PR TITLE
Use regime_id_cls for regime_name_to_id mapping

### DIFF
--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -173,6 +173,7 @@ class Model:
             initial_states=initial_states,
             initial_regimes=initial_regimes,
             internal_regimes=self.internal_regimes,
+            regime_id_cls=self.regime_id_cls,
             logger=logger,
             V_arr_dict=V_arr_dict,
             additional_targets=additional_targets,

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -34,6 +34,7 @@ def simulate(
     initial_states: dict[RegimeName, dict[str, Array]],
     initial_regimes: list[RegimeName],
     internal_regimes: dict[RegimeName, InternalRegime],
+    regime_id_cls: type,
     logger: logging.Logger,
     V_arr_dict: dict[int, dict[RegimeName, FloatND]],
     *,
@@ -47,6 +48,7 @@ def simulate(
         initial_states: List of initial states to start from. Typically from the
             observed dataset.
         internal_regimes: Dict of internal regime instances.
+        regime_id_cls: Dataclass mapping regime names to integer indices.
         initial_regimes: List containing the names of the regimes the subjects start in.
         logger: Logger that logs to stdout.
         V_arr_dict: Dict of value function arrays of length n_periods.
@@ -66,7 +68,7 @@ def simulate(
 
     # Preparations
     # ----------------------------------------------------------------------------------
-    regime_name_to_id = get_regime_name_to_id_mapping(internal_regimes)
+    regime_name_to_id = get_regime_name_to_id_mapping(regime_id_cls)
 
     # The following variables are updated during the forward simulation
     states = flatten_regime_namespace(initial_states)

--- a/src/lcm/simulation/util.py
+++ b/src/lcm/simulation/util.py
@@ -1,3 +1,5 @@
+from dataclasses import fields
+
 import jax
 from jax import Array, vmap
 from jax import numpy as jnp
@@ -10,13 +12,17 @@ from lcm.typing import Bool1D, Int1D, ParamsDict, RegimeName
 from lcm.utils import flatten_regime_namespace
 
 
-def get_regime_name_to_id_mapping(
-    internal_regimes: dict[RegimeName, InternalRegime],
-) -> dict[RegimeName, int]:
-    return {
-        internal_regime.name: _id
-        for _id, internal_regime in enumerate(internal_regimes.values())
-    }
+def get_regime_name_to_id_mapping(regime_id_cls: type) -> dict[RegimeName, int]:
+    """Get mapping from regime names to integer IDs from regime_id_cls.
+
+    Args:
+        regime_id_cls: Dataclass mapping regime names to integer indices.
+
+    Returns:
+        Dict mapping regime names to their integer IDs.
+
+    """
+    return {field.name: int(field.default) for field in fields(regime_id_cls)}  # type: ignore[arg-type]
 
 
 def create_regime_state_action_space(

--- a/tests/simulation/test_simulate.py
+++ b/tests/simulation/test_simulate.py
@@ -34,15 +34,17 @@ def simulate_inputs():
             "consumption": _orig_regime.actions["consumption"].replace(stop=100),  # type: ignore[attr-defined]
         }
     )
+    regime_id_cls = create_default_regime_id_cls(regime.name)
     internal_regimes = process_regimes(
         [regime],
         n_periods=1,
-        regime_id_cls=create_default_regime_id_cls(regime.name),
+        regime_id_cls=regime_id_cls,
         enable_jit=True,
     )
 
     return {
         "internal_regimes": internal_regimes,
+        "regime_id_cls": regime_id_cls,
     }
 
 


### PR DESCRIPTION
### Summary

Use the `regime_id_cls` dataclass to derive the regime name to ID mapping in simulation, instead of enumerating over `internal_regimes` dictionary (which relies on dict ordering).

### Changes

- Update `get_regime_name_to_id_mapping()` to accept `regime_id_cls` instead of `internal_regimes`
- Pass `regime_id_cls` to the `simulate()` function from `Model.simulate()`
- Update test fixture to include `regime_id_cls`

This ensures consistency with the explicit regime ID mapping defined in the `RegimeID` class.