### PR TITLE
More sensible tracking of GPU peak memory usage in benchmarks

### DIFF
--- a/benchmarks/_gpu_mem.py
+++ b/benchmarks/_gpu_mem.py
@@ -1,0 +1,107 @@
+"""Measure GPU peak memory for a benchmark in an isolated subprocess.
+
+ASV runs all benchmarks in one process, so ``peak_bytes_in_use`` accumulates
+across runs and warm-up calls.  This module spawns a fresh Python process that
+builds the model, runs it once cold (compilation + execution), and reports the
+true peak.
+
+The ``GpuPeakMem`` base class provides a ready-made ASV benchmark with a no-op
+``setup`` so the parent process does not touch the GPU before spawning the
+subprocess.  Subclass it and set ``bench_module`` / ``bench_class``::
+
+    class MahlerYumGpuPeakMem(GpuPeakMem):
+        bench_module = "benchmarks.bench_mahler_yum"
+        bench_class = "MahlerYum"
+
+The subprocess calls ``setup_for_gpu_measurement()`` (model + params only, no
+warm-up) followed by ``time_execution()`` (cold = compile + run), then prints
+``peak_bytes_in_use``.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Project root: the directory containing the benchmarks/ package.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def measure_gpu_peak(bench_module: str, bench_class: str) -> int:
+    """Run a benchmark in a subprocess and return peak GPU bytes.
+
+    Args:
+        bench_module: Dotted module path (e.g. ``"benchmarks.bench_mahler_yum"``).
+        bench_class: Class name within the module (e.g. ``"MahlerYum"``).
+
+    Returns:
+        Peak GPU memory in bytes (including compilation).
+
+    """
+    # Remove MEM_FRACTION so the subprocess can use all available GPU memory.
+    # The parent ASV process may limit itself (e.g. 0.3), but the subprocess
+    # needs full access since it runs in isolation.
+    env = {k: v for k, v in os.environ.items() if k != "XLA_PYTHON_CLIENT_MEM_FRACTION"}
+    env["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+    result = subprocess.run(
+        [sys.executable, "-m", "benchmarks._gpu_mem", bench_module, bench_class],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_PROJECT_ROOT,
+        env=env,
+    )
+    if result.returncode != 0:
+        msg = (
+            f"GPU memory subprocess failed (exit {result.returncode}).\n"
+            f"stdout: {result.stdout!r}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        raise RuntimeError(msg)
+    return int(result.stdout.strip())
+
+
+def _track_gpu_peak_mem(self):
+    return measure_gpu_peak(self.bench_module, self.bench_class)
+
+
+_track_gpu_peak_mem.unit = "bytes"
+
+
+class GpuPeakMem:
+    """ASV benchmark base class for GPU peak memory measurement.
+
+    Subclasses only need to set ``bench_module`` and ``bench_class``.  The
+    ``setup`` is intentionally a no-op so the parent ASV process does not
+    allocate GPU memory before the subprocess runs.
+
+    The ``track_gpu_peak_mem`` method is injected into subclasses (not the base)
+    so that ASV does not discover the base class as a runnable benchmark.
+    """
+
+    bench_module: str
+    bench_class: str
+    timeout = 1200
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.track_gpu_peak_mem = _track_gpu_peak_mem
+
+    def setup(self):
+        pass
+
+
+if __name__ == "__main__":
+    import importlib
+
+    module = importlib.import_module(sys.argv[1])
+    cls = getattr(module, sys.argv[2])
+
+    instance = cls()
+    instance.setup_for_gpu_measurement()
+    instance.time_execution()
+
+    import jax
+
+    stats = jax.local_devices()[0].memory_stats()
+    print(stats["peak_bytes_in_use"])

--- a/benchmarks/bench_mahler_yum.py
+++ b/benchmarks/bench_mahler_yum.py
@@ -3,13 +3,7 @@
 import gc
 import time
 
-
-def _get_gpu_peak_bytes():
-    import jax
-
-    stats = jax.local_devices()[0].memory_stats()
-    return stats["peak_bytes_in_use"]
-
+from benchmarks import _gpu_mem
 
 _N_SUBJECTS = 100
 
@@ -17,7 +11,7 @@ _N_SUBJECTS = 100
 class MahlerYum:
     timeout = 1200
 
-    def setup(self):
+    def _build(self):
         import jax.numpy as jnp
 
         from lcm_examples.mahler_yum_2024 import (
@@ -50,6 +44,9 @@ class MahlerYum:
                 dtype=jnp.int32,
             ),
         }
+
+    def setup(self):
+        self._build()
         start = time.perf_counter()
         self.model.simulate(
             params=self.model_params,
@@ -59,6 +56,9 @@ class MahlerYum:
             check_initial_conditions=False,
         )
         self._compile_time = time.perf_counter() - start
+
+    def setup_for_gpu_measurement(self):
+        self._build()
 
     def time_execution(self):
         self.model.simulate(
@@ -84,12 +84,12 @@ class MahlerYum:
         jax.clear_caches()
         gc.collect()
 
-    def track_gpu_peak_mem(self):
-        return _get_gpu_peak_bytes()
-
-    track_gpu_peak_mem.unit = "bytes"
-
     def track_compilation_time(self):
         return self._compile_time
 
     track_compilation_time.unit = "seconds"
+
+
+class MahlerYumGpuPeakMem(_gpu_mem.GpuPeakMem):
+    bench_module = "benchmarks.bench_mahler_yum"
+    bench_class = "MahlerYum"

--- a/benchmarks/bench_mortality.py
+++ b/benchmarks/bench_mortality.py
@@ -3,13 +3,7 @@
 import gc
 import time
 
-
-def _get_gpu_peak_bytes():
-    import jax
-
-    stats = jax.local_devices()[0].memory_stats()
-    return stats["peak_bytes_in_use"]
-
+from benchmarks import _gpu_mem
 
 _N_SUBJECTS = 100_000
 
@@ -17,7 +11,7 @@ _N_SUBJECTS = 100_000
 class Mortality:
     timeout = 600
 
-    def setup(self):
+    def _build(self):
         import jax.numpy as jnp
 
         from lcm_examples import mortality
@@ -29,6 +23,9 @@ class Mortality:
             "wealth": jnp.full(_N_SUBJECTS, 100.0),
             "regime": jnp.zeros(_N_SUBJECTS, dtype=jnp.int32),
         }
+
+    def setup(self):
+        self._build()
         start = time.perf_counter()
         self.model.simulate(
             params=self.model_params,
@@ -38,6 +35,9 @@ class Mortality:
             check_initial_conditions=False,
         )
         self._compile_time = time.perf_counter() - start
+
+    def setup_for_gpu_measurement(self):
+        self._build()
 
     def time_execution(self):
         self.model.simulate(
@@ -63,12 +63,12 @@ class Mortality:
         jax.clear_caches()
         gc.collect()
 
-    def track_gpu_peak_mem(self):
-        return _get_gpu_peak_bytes()
-
-    track_gpu_peak_mem.unit = "bytes"
-
     def track_compilation_time(self):
         return self._compile_time
 
     track_compilation_time.unit = "seconds"
+
+
+class MortalityGpuPeakMem(_gpu_mem.GpuPeakMem):
+    bench_module = "benchmarks.bench_mortality"
+    bench_class = "Mortality"

--- a/benchmarks/bench_precautionary_savings.py
+++ b/benchmarks/bench_precautionary_savings.py
@@ -3,6 +3,8 @@
 import gc
 import time
 
+from benchmarks import _gpu_mem
+
 _N_SUBJECTS = 1_000
 
 
@@ -35,13 +37,6 @@ def _make_initial_conditions(n_subjects):
     }
 
 
-def _get_gpu_peak_bytes():
-    import jax
-
-    stats = jax.local_devices()[0].memory_stats()
-    return stats["peak_bytes_in_use"]
-
-
 def _clear_gpu_memory():
     import jax
 
@@ -52,14 +47,20 @@ def _clear_gpu_memory():
 class PrecautionarySavingsSolve:
     timeout = 600
 
-    def setup(self):
+    def _build(self):
         self.model, self.model_params = _make_model(
             wealth_n_points=500,
             consumption_n_points=500,
         )
+
+    def setup(self):
+        self._build()
         start = time.perf_counter()
         self.model.solve(params=self.model_params, log_level="off")
         self._compile_time = time.perf_counter() - start
+
+    def setup_for_gpu_measurement(self):
+        self._build()
 
     def time_execution(self):
         self.model.solve(params=self.model_params, log_level="off")
@@ -70,26 +71,29 @@ class PrecautionarySavingsSolve:
     def teardown(self):
         _clear_gpu_memory()
 
-    def track_gpu_peak_mem(self):
-        return _get_gpu_peak_bytes()
-
-    track_gpu_peak_mem.unit = "bytes"
-
     def track_compilation_time(self):
         return self._compile_time
 
     track_compilation_time.unit = "seconds"
+
+
+class PrecautionarySavingsSolveGpuPeakMem(_gpu_mem.GpuPeakMem):
+    bench_module = "benchmarks.bench_precautionary_savings"
+    bench_class = "PrecautionarySavingsSolve"
 
 
 class PrecautionarySavingsSimulate:
     timeout = 600
 
-    def setup(self):
+    def _build(self):
         self.model, self.model_params = _make_model()
         self.period_to_regime_to_V_arr = self.model.solve(
             params=self.model_params, log_level="off"
         )
         self.initial_conditions = _make_initial_conditions(1_000_000)
+
+    def setup(self):
+        self._build()
         start = time.perf_counter()
         self.model.simulate(
             params=self.model_params,
@@ -99,6 +103,9 @@ class PrecautionarySavingsSimulate:
             check_initial_conditions=False,
         )
         self._compile_time = time.perf_counter() - start
+
+    def setup_for_gpu_measurement(self):
+        self._build()
 
     def time_execution(self):
         self.model.simulate(
@@ -121,26 +128,29 @@ class PrecautionarySavingsSimulate:
     def teardown(self):
         _clear_gpu_memory()
 
-    def track_gpu_peak_mem(self):
-        return _get_gpu_peak_bytes()
-
-    track_gpu_peak_mem.unit = "bytes"
-
     def track_compilation_time(self):
         return self._compile_time
 
     track_compilation_time.unit = "seconds"
+
+
+class PrecautionarySavingsSimulateGpuPeakMem(_gpu_mem.GpuPeakMem):
+    bench_module = "benchmarks.bench_precautionary_savings"
+    bench_class = "PrecautionarySavingsSimulate"
 
 
 class PrecautionarySavingsSimulateWithSolve:
     timeout = 600
 
-    def setup(self):
+    def _build(self):
         self.model, self.model_params = _make_model(
             wealth_n_points=200,
             consumption_n_points=200,
         )
         self.initial_conditions = _make_initial_conditions(500_000)
+
+    def setup(self):
+        self._build()
         start = time.perf_counter()
         self.model.simulate(
             params=self.model_params,
@@ -150,6 +160,9 @@ class PrecautionarySavingsSimulateWithSolve:
             check_initial_conditions=False,
         )
         self._compile_time = time.perf_counter() - start
+
+    def setup_for_gpu_measurement(self):
+        self._build()
 
     def time_execution(self):
         self.model.simulate(
@@ -172,27 +185,30 @@ class PrecautionarySavingsSimulateWithSolve:
     def teardown(self):
         _clear_gpu_memory()
 
-    def track_gpu_peak_mem(self):
-        return _get_gpu_peak_bytes()
-
-    track_gpu_peak_mem.unit = "bytes"
-
     def track_compilation_time(self):
         return self._compile_time
 
     track_compilation_time.unit = "seconds"
 
 
+class PrecautionarySavingsSimulateWithSolveGpuPeakMem(_gpu_mem.GpuPeakMem):
+    bench_module = "benchmarks.bench_precautionary_savings"
+    bench_class = "PrecautionarySavingsSimulateWithSolve"
+
+
 class PrecautionarySavingsSimulateWithSolveIrreg:
     timeout = 600
 
-    def setup(self):
+    def _build(self):
         self.model, self.model_params = _make_model(
             wealth_grid_type="irreg",
             wealth_n_points=200,
             consumption_n_points=200,
         )
         self.initial_conditions = _make_initial_conditions(500_000)
+
+    def setup(self):
+        self._build()
         start = time.perf_counter()
         self.model.simulate(
             params=self.model_params,
@@ -202,6 +218,9 @@ class PrecautionarySavingsSimulateWithSolveIrreg:
             check_initial_conditions=False,
         )
         self._compile_time = time.perf_counter() - start
+
+    def setup_for_gpu_measurement(self):
+        self._build()
 
     def time_execution(self):
         self.model.simulate(
@@ -224,12 +243,12 @@ class PrecautionarySavingsSimulateWithSolveIrreg:
     def teardown(self):
         _clear_gpu_memory()
 
-    def track_gpu_peak_mem(self):
-        return _get_gpu_peak_bytes()
-
-    track_gpu_peak_mem.unit = "bytes"
-
     def track_compilation_time(self):
         return self._compile_time
 
     track_compilation_time.unit = "seconds"
+
+
+class PrecautionarySavingsSimulateWithSolveIrregGpuPeakMem(_gpu_mem.GpuPeakMem):
+    bench_module = "benchmarks.bench_precautionary_savings"
+    bench_class = "PrecautionarySavingsSimulateWithSolveIrreg"

--- a/benchmarks/pr_comment.py
+++ b/benchmarks/pr_comment.py
@@ -78,7 +78,7 @@ _DATA_ROW_RE = re.compile(
     r"^\|\s*[-+~x]?\s*"  # | change_indicator
     r"\|\s*(\S+)\s*"  # | before_value
     r"\|\s*(\S+)\s*"  # | after_value
-    r"\|\s*~?([\d.]+)\s*"  # | ratio (strip ~ prefix)
+    r"\|\s*~?([\w/.]+)\s*"  # | ratio (numeric or n/a)
     r"\|\s*(.+?)\s*\|$"  # | benchmark_name |
 )
 _BENCH_NAME_RE = re.compile(r"(?:\w+\.)*(\w+)\.(\w+)(?:\(([^)]*)\))?$")
@@ -91,7 +91,7 @@ class _BenchmarkRow(NamedTuple):
     params: str
     before_value: str
     after_value: str
-    ratio: float
+    ratio: float | None
 
 
 def post_pr_comment() -> None:
@@ -108,7 +108,9 @@ def post_pr_comment() -> None:
 
     comparison_md = _try_comparison(machine_dir, head_sha_full)
     processed = (
-        _postprocess_comparison(comparison_md) if comparison_md is not None else None
+        _postprocess_comparison(comparison_md, head_result_file)
+        if comparison_md is not None
+        else None
     )
 
     if processed is not None:
@@ -147,10 +149,6 @@ def _try_comparison(
         )
         return None
 
-    head_file = _find_result_file(machine_dir, head_sha_full[:8])
-    if head_file is not None:
-        _backfill_base_results(base_file, head_file)
-
     try:
         result = subprocess.run(
             [
@@ -171,53 +169,6 @@ def _try_comparison(
         return None
 
 
-def _backfill_base_results(
-    base_file: Path,
-    head_file: Path,
-) -> None:
-    """Sync the base result file so ``asv compare`` finds matching benchmarks.
-
-    Copies HEAD entries into the base when the benchmark is missing or its
-    parameter set has changed (e.g. after adding/removing param values).
-    Since both runs use the same ``existing:python`` environment, the
-    values are comparable.
-
-    """
-    base_data: dict[str, Any] = json.loads(base_file.read_text(encoding="utf-8"))
-    head_data: dict[str, Any] = json.loads(head_file.read_text(encoding="utf-8"))
-
-    base_results = base_data.setdefault("results", {})
-    head_results = head_data.get("results", {})
-
-    updates = {
-        key: head_val
-        for key, head_val in head_results.items()
-        if _needs_backfill(base_results.get(key), head_val)
-    }
-
-    if not updates:
-        return
-
-    base_results.update(updates)
-    base_file.write_text(json.dumps(base_data, indent=4), encoding="utf-8")
-
-
-def _needs_backfill(
-    base_val: list[Any] | None,
-    head_val: Any,
-) -> bool:
-    """Return True when a base entry is missing or has different params."""
-    if base_val is None:
-        return True
-    return (
-        isinstance(head_val, list)
-        and len(head_val) > 1
-        and isinstance(base_val, list)
-        and len(base_val) > 1
-        and head_val[1] != base_val[1]
-    )
-
-
 def _format_comparison_comment(
     head_sha: str,
     processed_md: str,
@@ -235,15 +186,15 @@ def _format_comparison_comment(
     )
 
 
-def _postprocess_comparison(raw: str) -> str | None:
+def _postprocess_comparison(raw: str, head_result_file: Path) -> str | None:
     """Parse ASV compare output and reformat as a grouped benchmark table.
 
-    Return ``None`` when no rows with numeric ratios are found (e.g. all
-    benchmarks were renamed between base and HEAD, producing only ``n/a``
-    ratios).
+    Benchmarks present in HEAD but missing from the baseline appear with
+    empty before/ratio columns.  Return ``None`` when no rows are found.
 
     """
     rows, hashes = _parse_comparison_rows(raw)
+    rows.extend(_find_head_only_rows(rows, head_result_file))
 
     if not rows:
         return None
@@ -289,6 +240,11 @@ def _parse_comparison_rows(
         if class_name not in _CLASS_DISPLAY and method_name not in _METHOD_DISPLAY:
             continue
 
+        try:
+            ratio = float(ratio_str)
+        except ValueError:
+            ratio = None
+
         rows.append(
             _BenchmarkRow(
                 class_name=class_name,
@@ -296,11 +252,33 @@ def _parse_comparison_rows(
                 params=params or "",
                 before_value=before_val,
                 after_value=after_val,
-                ratio=float(ratio_str),
+                ratio=ratio,
             )
         )
 
     return rows, hashes
+
+
+def _find_head_only_rows(
+    comparison_rows: list[_BenchmarkRow],
+    head_result_file: Path,
+) -> list[_BenchmarkRow]:
+    """Return rows for benchmarks present in HEAD but missing from the comparison."""
+    seen = {(r.class_name, r.method_name, r.params) for r in comparison_rows}
+    head_entries = _parse_raw_entries(head_result_file)
+    return [
+        _BenchmarkRow(
+            class_name=class_name,
+            method_name=method_name,
+            params=params,
+            before_value="",
+            after_value=value,
+            ratio=None,
+        )
+        for class_name, method_name, params, value in head_entries
+        if (class_name, method_name, params) not in seen
+        and (class_name in _CLASS_DISPLAY or method_name in _METHOD_DISPLAY)
+    ]
 
 
 def _build_grouped_table(rows: list[_BenchmarkRow]) -> str:
@@ -334,11 +312,18 @@ def _build_grouped_table(rows: list[_BenchmarkRow]) -> str:
         for i, row in enumerate(groups[(display_name, params)]):
             bench_col = label if i == 0 else ""
             stat_col = _METHOD_DISPLAY.get(row.method_name, row.method_name)
-            alert = "\u274c" if row.ratio > _ALERT_RATIO else ""
+            if row.ratio is not None:
+                before_col = row.before_value
+                ratio_col = f"{row.ratio:.2f}"
+                alert = "\u274c" if row.ratio > _ALERT_RATIO else ""
+            else:
+                before_col = ""
+                ratio_col = ""
+                alert = ""
             lines.append(
                 f"| {bench_col} | {stat_col} "
-                f"| {row.before_value} | {row.after_value} "
-                f"| {row.ratio:.2f} | {alert} |"
+                f"| {before_col} | {row.after_value} "
+                f"| {ratio_col} | {alert} |"
             )
 
     return "\n".join(lines)

--- a/benchmarks/pr_comment.py
+++ b/benchmarks/pr_comment.py
@@ -28,13 +28,23 @@ _RESULTS_DIR = Path(".asv/results")
 
 _CLASS_DISPLAY = {
     "MahlerYum": "Mahler-Yum",
+    "MahlerYumGpuPeakMem": "Mahler-Yum",
     "Mortality": "Mortality",
+    "MortalityGpuPeakMem": "Mortality",
     "PrecautionarySavingsSolve": "Precautionary Savings - Solve",
-    "PrecautionarySavingsSimulate": ("Precautionary Savings - Simulate"),
+    "PrecautionarySavingsSolveGpuPeakMem": "Precautionary Savings - Solve",
+    "PrecautionarySavingsSimulate": "Precautionary Savings - Simulate",
+    "PrecautionarySavingsSimulateGpuPeakMem": "Precautionary Savings - Simulate",
     "PrecautionarySavingsSimulateWithSolve": (
         "Precautionary Savings - Solve & Simulate"
     ),
+    "PrecautionarySavingsSimulateWithSolveGpuPeakMem": (
+        "Precautionary Savings - Solve & Simulate"
+    ),
     "PrecautionarySavingsSimulateWithSolveIrreg": (
+        "Precautionary Savings - Solve & Simulate (irreg)"
+    ),
+    "PrecautionarySavingsSimulateWithSolveIrregGpuPeakMem": (
         "Precautionary Savings - Solve & Simulate (irreg)"
     ),
 }
@@ -58,7 +68,9 @@ _METHOD_SORT = {
     )
 }
 
-_CLASS_SORT = {name: i for i, name in enumerate(_CLASS_DISPLAY)}
+_DISPLAY_SORT = {
+    display: i for i, display in enumerate(dict.fromkeys(_CLASS_DISPLAY.values()))
+}
 
 _ALERT_RATIO = 1.10
 
@@ -295,7 +307,7 @@ def _build_grouped_table(rows: list[_BenchmarkRow]) -> str:
     """Build a grouped markdown table from parsed benchmark rows."""
     groups: dict[tuple[str, str], list[_BenchmarkRow]] = {}
     for row in rows:
-        key = (row.class_name, row.params)
+        key = (_CLASS_DISPLAY.get(row.class_name, row.class_name), row.params)
         groups.setdefault(key, []).append(row)
 
     for group_rows in groups.values():
@@ -306,7 +318,7 @@ def _build_grouped_table(rows: list[_BenchmarkRow]) -> str:
     sorted_keys = sorted(
         groups,
         key=lambda k: (
-            _CLASS_SORT.get(k[0], len(_CLASS_SORT)),
+            _DISPLAY_SORT.get(k[0], len(_DISPLAY_SORT)),
             k[1],
         ),
     )
@@ -316,13 +328,11 @@ def _build_grouped_table(rows: list[_BenchmarkRow]) -> str:
         "|---|---|---|---|---|---|",
     ]
 
-    for class_name, params in sorted_keys:
-        display_name = _CLASS_DISPLAY.get(class_name, class_name)
-        if params:
-            display_name = f"{display_name} ({params})"
+    for display_name, params in sorted_keys:
+        label = f"{display_name} ({params})" if params else display_name
 
-        for i, row in enumerate(groups[(class_name, params)]):
-            bench_col = display_name if i == 0 else ""
+        for i, row in enumerate(groups[(display_name, params)]):
+            bench_col = label if i == 0 else ""
             stat_col = _METHOD_DISPLAY.get(row.method_name, row.method_name)
             alert = "\u274c" if row.ratio > _ALERT_RATIO else ""
             lines.append(
@@ -343,7 +353,8 @@ def _format_raw_results(result_file: Path, head_sha: str) -> str:
 
     groups: dict[tuple[str, str], list[tuple[str, str]]] = {}
     for class_name, method_name, params, value in entries:
-        groups.setdefault((class_name, params), []).append((method_name, value))
+        display = _CLASS_DISPLAY.get(class_name, class_name)
+        groups.setdefault((display, params), []).append((method_name, value))
 
     for group in groups.values():
         group.sort(key=lambda x: _METHOD_SORT.get(x[0], len(_METHOD_SORT)))
@@ -351,7 +362,7 @@ def _format_raw_results(result_file: Path, head_sha: str) -> str:
     sorted_keys = sorted(
         groups,
         key=lambda k: (
-            _CLASS_SORT.get(k[0], len(_CLASS_SORT)),
+            _DISPLAY_SORT.get(k[0], len(_DISPLAY_SORT)),
             k[1],
         ),
     )
@@ -361,13 +372,11 @@ def _format_raw_results(result_file: Path, head_sha: str) -> str:
         "|---|---|---|",
     ]
 
-    for class_name, params in sorted_keys:
-        display_name = _CLASS_DISPLAY.get(class_name, class_name)
-        if params:
-            display_name = f"{display_name} ({params})"
+    for display_name, params in sorted_keys:
+        label = f"{display_name} ({params})" if params else display_name
 
-        for i, (method_name, value) in enumerate(groups[(class_name, params)]):
-            bench_col = display_name if i == 0 else ""
+        for i, (method_name, value) in enumerate(groups[(display_name, params)]):
+            bench_col = label if i == 0 else ""
             stat_col = _METHOD_DISPLAY.get(method_name, method_name)
             lines.append(f"| {bench_col} | {stat_col} | {value} |")
 

--- a/docs/explanations/dispatchers.ipynb
+++ b/docs/explanations/dispatchers.ipynb
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f_product = productmap(func=f, variables=(\"x\", \"y\"))\n",
+    "f_product = productmap(func=f, variables=(\"x\", \"y\"), batch_sizes={\"x\": 0, \"y\": 0})\n",
     "\n",
     "x = jnp.array([1.0, 2.0, 3.0, 4.0])\n",
     "y = jnp.array([10.0, 20.0, 30.0])\n",

--- a/docs/explanations/function_representation.ipynb
+++ b/docs/explanations/function_representation.ipynb
@@ -190,7 +190,10 @@
    "source": [
     "from lcm.utils.dispatchers import productmap\n",
     "\n",
-    "u_and_f_mapped = productmap(func=u_and_f, variables=(\"wealth\", \"consumption\"))\n",
+    "_variables = (\"wealth\", \"consumption\")\n",
+    "u_and_f_mapped = productmap(\n",
+    "    func=u_and_f, variables=_variables, batch_sizes=dict.fromkeys(_variables, 0)\n",
+    ")\n",
     "grid_arrays = {name: g.to_jax() for name, g in internal_regime.grids.items()}\n",
     "u, f = u_and_f_mapped(**grid_arrays, utility__risk_aversion=1.5)\n",
     "\n",
@@ -244,7 +247,18 @@
    "id": "12",
    "metadata": {},
    "outputs": [],
-   "source": "from lcm.regime_building.V import create_v_interpolation_info, get_V_interpolator\n\nv_interpolation_info = create_v_interpolation_info(retirement_regime)\n\nscalar_value_function = get_V_interpolator(\n    v_interpolation_info=v_interpolation_info,\n    state_prefix=\"next_\",\n    V_arr_name=\"V_arr\",\n)\nscalar_value_function.__signature__"
+   "source": [
+    "from lcm.regime_building.V import create_v_interpolation_info, get_V_interpolator\n",
+    "\n",
+    "v_interpolation_info = create_v_interpolation_info(retirement_regime)\n",
+    "\n",
+    "scalar_value_function = get_V_interpolator(\n",
+    "    v_interpolation_info=v_interpolation_info,\n",
+    "    state_prefix=\"next_\",\n",
+    "    V_arr_name=\"V_arr\",\n",
+    ")\n",
+    "scalar_value_function.__signature__"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -261,7 +275,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "value_function = productmap(func=scalar_value_function, variables=(\"next_wealth\",))"
+    "value_function = productmap(\n",
+    "    func=scalar_value_function,\n",
+    "    variables=(\"next_wealth\",),\n",
+    "    batch_sizes={\"next_wealth\": 0},\n",
+    ")"
    ]
   },
   {
@@ -506,7 +524,13 @@
    "id": "28",
    "metadata": {},
    "outputs": [],
-   "source": "space_info = create_v_interpolation_info(retirement_regime)\n\nfuncs = {}\n\nprint(f\"Discrete states: {space_info.discrete_states}\")"
+   "source": [
+    "space_info = create_v_interpolation_info(retirement_regime)\n",
+    "\n",
+    "funcs = {}\n",
+    "\n",
+    "print(f\"Discrete states: {space_info.discrete_states}\")"
+   ]
   },
   {
    "cell_type": "code",

--- a/pixi.lock
+++ b/pixi.lock
@@ -13360,8 +13360,8 @@ packages:
   timestamp: 1774796815820
 - pypi: ./
   name: pylcm
-  version: 0.0.2.dev118+g16b453689.d20260407
-  sha256: 75388ad4e330df78a1b6b31e600993094fde7a808c6449fe5e0806c80a7e4a11
+  version: 0.0.2.dev111+g49ea7046e.d20260408
+  sha256: 321e08797e47c3bb480f85e6cadf287696a7160e95b42f5ad17293f187eaaaac
   requires_dist:
   - cloudpickle>=3.1.2
   - dags>=0.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,8 +150,8 @@ asv-compare = "asv compare"
 asv-preview = "asv preview"
 asv-pr-comment = "python benchmarks/pr_comment.py"
 asv-publish = "python benchmarks/publish.py"
-asv-quick = { cmd = "asv run --quick --set-commit-hash=$(git rev-parse HEAD)", env = { XLA_PYTHON_CLIENT_PREALLOCATE = "false", XLA_PYTHON_CLIENT_MEM_FRACTION = "0.3" } }
-asv-run = { cmd = 'git status --porcelain --ignore-submodules | grep -q . && echo "Refusing to benchmark: worktree is dirty. Commit first." && exit 1; asv run --set-commit-hash=$(git rev-parse HEAD)', env = { XLA_PYTHON_CLIENT_PREALLOCATE = "false", XLA_PYTHON_CLIENT_MEM_FRACTION = "0.3" } }
+asv-quick = { cmd = "asv run --quick --set-commit-hash=$(git rev-parse HEAD)", env = { XLA_PYTHON_CLIENT_MEM_FRACTION = "0.3" } }
+asv-run = { cmd = 'git status --porcelain --ignore-submodules | grep -q . && echo "Refusing to benchmark: worktree is dirty. Commit first." && exit 1; asv run --set-commit-hash=$(git rev-parse HEAD)', env = { XLA_PYTHON_CLIENT_MEM_FRACTION = "0.3" } }
 asv-run-and-pr-comment = { depends-on = [ "asv-run", "asv-pr-comment" ] }
 asv-run-and-publish-main = { depends-on = [ "asv-run", "asv-publish" ] }
 [tool.pixi.workspace]

--- a/src/lcm/__init__.py
+++ b/src/lcm/__init__.py
@@ -1,5 +1,12 @@
 import contextlib
+import os
 from types import MappingProxyType
+
+# Use on-demand GPU memory allocation instead of JAX's default of pre-allocating
+# 75% of GPU memory. This plays nicely with other GPU processes, makes nvidia-smi
+# reflect actual usage, and enables meaningful GPU memory benchmarks. Users can
+# override by setting XLA_PYTHON_CLIENT_PREALLOCATE=true before importing lcm.
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
 
 import jax
 


### PR DESCRIPTION
- Fix `track_gpu_peak_mem` benchmarks to actually measure GPU peak memory in isolation.
  The previous implementation read `peak_bytes_in_use` from the parent ASV process after
  `setup()` had already run, which returned the cumulative high-water mark of the ASV
  process rather than the peak of a single benchmark run. Since ASV reuses one process
  for all benchmarks, this number grew monotonically and mixed memory from unrelated
  benchmarks.
- The new implementation spawns an isolated subprocess per measurement via
  `benchmarks/_gpu_mem.py`. The subprocess builds the model from scratch, runs it once
  cold (compilation + execution), and reports the true peak. A `GpuPeakMem` base class
  provides dedicated ASV benchmark classes with no-op setup so the parent process never
  touches the GPU.
- Use on-demand GPU memory allocation instead of JAX's default of pre-allocating
  75% of GPU memory. This plays nicely with other GPU processes, makes nvidia-smi
  reflect actual usage, and enables meaningful GPU memory benchmarks. Users can
  override by setting XLA_PYTHON_CLIENT_PREALLOCATE=true before importing lcm.
- Fix `productmap` calls in `function_representation.ipynb` and `dispatchers.ipynb` that broke
  after `batch_sizes` became required (#280).