### PR TITLE
Fix missing discount type assignment for high-education agents

### DIFF
--- a/src/lcm_examples/mahler_yum_2024/_model.py
+++ b/src/lcm_examples/mahler_yum_2024/_model.py
@@ -623,6 +623,7 @@ def create_inputs(
                 prod = prod.at[index].set(j - 1)
                 ht = ht.at[index].set(1 - (k - 1))
                 discount = discount.at[index].set(i - 1)
+                discount = discount.at[index + 8].set(i - 1)
                 prod = prod.at[index + 8].set(j - 1)
                 ht = ht.at[index + 8].set(1 - (k - 1))
                 ed = ed.at[index + 8].set(1)


### PR DESCRIPTION
## Summary

The type-assignment loop in `create_inputs` set `discount[index]` for indices 0–7 (low education) but never set `discount[index + 8]` for indices 8–15 (high education). All high-education agents were incorrectly assigned to the low discount factor type (default 0).

One-line fix: add `discount = discount.at[index + 8].set(i - 1)`.

Found by comparing against the original replication code (Replication_MY2024) which correctly sets discount type for all 16 type indices.

## Test plan

- [x] `prek run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)