### PR TITLE
Auto-convert pd.Series in fixed_params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ Model(
 ### Derived Categoricals
 
 When parameters are indexed by a DAG function output (not a model state/action), declare
-`derived_categoricals={"name": DiscreteGrid(...)}` on the `Regime` that uses it. For
+`derived_categoricals={"name": CategoryClass}` on the `Regime` that uses it. For
 convenience, model-level `derived_categoricals` on `Model(...)` are broadcast to all
 regimes. Functions used as derived categoricals must return **integer** types, not
 booleans — JAX cannot use booleans as array indices inside JIT. Use `jnp.int32(...)` to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,10 +222,12 @@ Model(
 
 ### Derived Categoricals
 
-When `solve()` / `simulate()` parameters are indexed by a DAG function output (not a
-model state/action), pass `derived_categoricals={"name": DiscreteGrid(...)}`. Functions
-used as derived categoricals must return **integer** types, not booleans — JAX cannot
-use booleans as array indices inside JIT. Use `jnp.int32(...)` to cast.
+When parameters are indexed by a DAG function output (not a model state/action), declare
+`derived_categoricals={"name": DiscreteGrid(...)}` on the `Regime` that uses it. For
+convenience, model-level `derived_categoricals` on `Model(...)` are broadcast to all
+regimes. Functions used as derived categoricals must return **integer** types, not
+booleans — JAX cannot use booleans as array indices inside JIT. Use `jnp.int32(...)` to
+cast.
 
 ### SimulationResult
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,9 +223,9 @@ Model(
 ### Derived Categoricals
 
 When parameters are indexed by a DAG function output (not a model state/action), declare
-`derived_categoricals={"name": CategoryClass}` on the `Regime` that uses it. For
-convenience, model-level `derived_categoricals` on `Model(...)` are broadcast to all
-regimes. Functions used as derived categoricals must return **integer** types, not
+`derived_categoricals={"name": DiscreteGrid(CategoryClass)}` on the `Regime` that uses
+it. For convenience, model-level `derived_categoricals` on `Model(...)` are broadcast to
+all regimes. Functions used as derived categoricals must return **integer** types, not
 booleans — JAX cannot use booleans as array indices inside JIT. Use `jnp.int32(...)` to
 cast.
 

--- a/docs/user_guide/pandas_interop.md
+++ b/docs/user_guide/pandas_interop.md
@@ -118,7 +118,7 @@ validate labels against. You will see an error like:
 ```
 Unrecognised indexing parameter 'employment_type'. Expected 'age' or a
 discrete grid name (['health', 'partner']). If 'employment_type' is a DAG
-function output, add derived_categoricals={"employment_type": DiscreteGrid(...)}
+function output, add derived_categoricals={"employment_type": EmploymentType}
 to the Regime or Model constructor.
 ```
 
@@ -127,7 +127,7 @@ Fix this by declaring the grid on the `Regime` that uses it:
 ```python
 working = Regime(
     # ... other fields ...
-    derived_categoricals={"employment_type": DiscreteGrid(EmploymentType)},
+    derived_categoricals={"employment_type": EmploymentType},
 )
 ```
 
@@ -137,11 +137,11 @@ own grid:
 ```python
 working = Regime(
     # ... other fields ...
-    derived_categoricals={"employment_type": DiscreteGrid(FullEmploymentType)},
+    derived_categoricals={"employment_type": FullEmploymentType},
 )
 retired = Regime(
     # ... other fields ...
-    derived_categoricals={"employment_type": DiscreteGrid(RetiredEmploymentType)},
+    derived_categoricals={"employment_type": RetiredEmploymentType},
 )
 ```
 
@@ -150,7 +150,7 @@ For convenience, model-level `derived_categoricals` are broadcast to all regimes
 ```python
 Model(
     regimes={"working": working, "retired": retired},
-    derived_categoricals={"employment_type": DiscreteGrid(EmploymentType)},
+    derived_categoricals={"employment_type": EmploymentType},
     # ... other fields ...
 )
 ```

--- a/docs/user_guide/pandas_interop.md
+++ b/docs/user_guide/pandas_interop.md
@@ -118,7 +118,7 @@ validate labels against. You will see an error like:
 ```
 Unrecognised indexing parameter 'employment_type'. Expected 'age' or a
 discrete grid name (['health', 'partner']). If 'employment_type' is a DAG
-function output, add derived_categoricals={"employment_type": EmploymentType}
+function output, add derived_categoricals={"employment_type": DiscreteGrid(EmploymentType)}
 to the Regime or Model constructor.
 ```
 
@@ -127,7 +127,7 @@ Fix this by declaring the grid on the `Regime` that uses it:
 ```python
 working = Regime(
     # ... other fields ...
-    derived_categoricals={"employment_type": EmploymentType},
+    derived_categoricals={"employment_type": DiscreteGrid(EmploymentType)},
 )
 ```
 
@@ -137,11 +137,11 @@ own grid:
 ```python
 working = Regime(
     # ... other fields ...
-    derived_categoricals={"employment_type": FullEmploymentType},
+    derived_categoricals={"employment_type": DiscreteGrid(FullEmploymentType)},
 )
 retired = Regime(
     # ... other fields ...
-    derived_categoricals={"employment_type": RetiredEmploymentType},
+    derived_categoricals={"employment_type": DiscreteGrid(RetiredEmploymentType)},
 )
 ```
 
@@ -150,7 +150,7 @@ For convenience, model-level `derived_categoricals` are broadcast to all regimes
 ```python
 Model(
     regimes={"working": working, "retired": retired},
-    derived_categoricals={"employment_type": EmploymentType},
+    derived_categoricals={"employment_type": DiscreteGrid(EmploymentType)},
     # ... other fields ...
 )
 ```

--- a/docs/user_guide/pandas_interop.md
+++ b/docs/user_guide/pandas_interop.md
@@ -118,29 +118,41 @@ validate labels against. You will see an error like:
 ```
 Unrecognised indexing parameter 'employment_type'. Expected 'age' or a
 discrete grid name (['health', 'partner']). If 'employment_type' is a DAG
-function output, pass derived_categoricals={"employment_type": DiscreteGrid(...)}
-to solve() / simulate().
+function output, add derived_categoricals={"employment_type": DiscreteGrid(...)}
+to the Regime or Model constructor.
 ```
 
-Fix this by passing the missing grid explicitly:
+Fix this by declaring the grid on the `Regime` that uses it:
 
 ```python
-model.solve(
-    params=params,
+working = Regime(
+    # ... other fields ...
     derived_categoricals={"employment_type": DiscreteGrid(EmploymentType)},
 )
 ```
 
-If the variable has different categories in different regimes, pass a per-regime
-mapping:
+If the variable has different categories in different regimes, each regime declares its
+own grid:
 
 ```python
-derived_categoricals = {
-    "employment_type": {
-        "working": DiscreteGrid(FullEmploymentType),
-        "retired": DiscreteGrid(RetiredEmploymentType),
-    },
-}
+working = Regime(
+    # ... other fields ...
+    derived_categoricals={"employment_type": DiscreteGrid(FullEmploymentType)},
+)
+retired = Regime(
+    # ... other fields ...
+    derived_categoricals={"employment_type": DiscreteGrid(RetiredEmploymentType)},
+)
+```
+
+For convenience, model-level `derived_categoricals` are broadcast to all regimes:
+
+```python
+Model(
+    regimes={"working": working, "retired": retired},
+    derived_categoricals={"employment_type": DiscreteGrid(EmploymentType)},
+    # ... other fields ...
+)
 ```
 
 ### Integer return types required

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -105,7 +105,8 @@ class Model:
             ages: Age grid for the model.
             description: Description of the model.
             regime_id_class: Dataclass mapping regime names to integer indices.
-            enable_jit: Whether to jit the functions of the internal regime.
+            enable_jit: Whether to JIT-compile the functions of the internal
+                regimes.
             fixed_params: Parameters that can be fixed at model initialization.
             derived_categoricals: Categorical grids for DAG function outputs
                 not in states/actions. Broadcast to all regimes (merged with

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -1,5 +1,6 @@
 """Collection of classes that are used by the user to define the model and grids."""
 
+import dataclasses
 from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
@@ -8,6 +9,7 @@ import pandas as pd
 from jax import Array
 
 from lcm.ages import AgeGrid
+from lcm.exceptions import InvalidValueFunctionError, ModelInitializationError
 from lcm.grids import DiscreteGrid
 from lcm.model_processing import (
     _validate_param_types,
@@ -77,7 +79,7 @@ class Model:
     """Immutable mapping of regime names to internal regime instances."""
 
     enable_jit: bool = True
-    """Whether to JIT-compile the functions of the internal regime."""
+    """Whether to JIT-compile the functions of the internal regimes."""
 
     fixed_params: UserParams
     """Parameters fixed at model initialization."""
@@ -94,8 +96,7 @@ class Model:
         regime_id_class: type,
         enable_jit: bool = True,
         fixed_params: UserParams = MappingProxyType({}),
-        derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-        | None = None,
+        derived_categoricals: Mapping[str, DiscreteGrid] = MappingProxyType({}),
     ) -> None:
         """Initialize the Model.
 
@@ -106,10 +107,10 @@ class Model:
             regime_id_class: Dataclass mapping regime names to integer indices.
             enable_jit: Whether to jit the functions of the internal regime.
             fixed_params: Parameters that can be fixed at model initialization.
-            derived_categoricals: Extra categorical mappings for derived
-                variables not in the model's state/action grids. Needed when
-                `fixed_params` contains `pd.Series` indexed by DAG function
-                outputs.
+            derived_categoricals: Categorical grids for DAG function outputs
+                not in states/actions. Broadcast to all regimes (merged with
+                each regime's own `derived_categoricals`). Raises if a regime
+                already has a conflicting entry.
 
         """
         self.description = description
@@ -130,14 +131,13 @@ class Model:
                 )
             )
         )
-        self.regimes = MappingProxyType(dict(regimes))
+        self.regimes = _merge_derived_categoricals(regimes, derived_categoricals)
         self.internal_regimes, self._params_template = build_regimes_and_template(
-            regimes=regimes,
+            regimes=self.regimes,
             ages=self.ages,
             regime_names_to_ids=self.regime_names_to_ids,
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
-            derived_categoricals=derived_categoricals,
         )
         self.enable_jit = enable_jit
         self.simulation_output_dtypes = get_simulation_output_dtypes(
@@ -168,8 +168,7 @@ class Model:
         self,
         *,
         params: UserParams,
-        derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-        | None = None,
+        max_compilation_workers: int | None = None,
         log_level: LogLevel = "progress",
         log_path: str | Path | None = None,
         log_keep_n_latest: int = 3,
@@ -187,10 +186,10 @@ class Model:
                   specification
                 Values may be `pd.Series` with labeled indices; they are
                 auto-converted to JAX arrays.
-            derived_categoricals: Extra categorical mappings (level name to
-                `DiscreteGrid`) for derived variables not in the model's
-                state/action grids. Pass per-regime mappings as
-                `{"var": {"regime_a": grid_a, ...}}`.
+            max_compilation_workers: Maximum number of threads for parallel XLA
+                compilation. Defaults to `os.cpu_count()`. Lower this on machines
+                with limited RAM, as each concurrent compilation holds an XLA HLO
+                graph in memory.
             log_level: Logging verbosity. `"off"` suppresses output, `"warning"` shows
                 NaN/Inf warnings, `"progress"` adds timing, `"debug"` adds stats and
                 requires `log_path`.
@@ -211,7 +210,6 @@ class Model:
             regimes=self.regimes,
             ages=self.ages,
             regime_names_to_ids=self.regime_names_to_ids,
-            derived_categoricals=derived_categoricals,
         )
         _validate_param_types(internal_params)
         validate_regime_transitions_all_periods(
@@ -219,12 +217,25 @@ class Model:
             internal_params=internal_params,
             ages=self.ages,
         )
-        period_to_regime_to_V_arr = solve(
-            internal_params=internal_params,
-            ages=self.ages,
-            internal_regimes=self.internal_regimes,
-            logger=get_logger(log_level=log_level),
-        )
+        try:
+            period_to_regime_to_V_arr = solve(
+                internal_params=internal_params,
+                ages=self.ages,
+                internal_regimes=self.internal_regimes,
+                logger=get_logger(log_level=log_level),
+                max_compilation_workers=max_compilation_workers,
+                enable_jit=self.enable_jit,
+            )
+        except InvalidValueFunctionError as exc:
+            if log_path is not None and exc.partial_solution is not None:
+                save_solve_snapshot(
+                    model=self,
+                    params=params,
+                    period_to_regime_to_V_arr=exc.partial_solution,  # ty: ignore[invalid-argument-type]
+                    log_path=Path(log_path),
+                    log_keep_n_latest=log_keep_n_latest,
+                )
+            raise
         if log_level == "debug" and log_path is not None:
             save_solve_snapshot(
                 model=self,
@@ -239,8 +250,6 @@ class Model:
         self,
         *,
         params: UserParams,
-        derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-        | None = None,
         initial_conditions: Mapping[str, Array],
         period_to_regime_to_V_arr: MappingProxyType[
             int, MappingProxyType[RegimeName, FloatND]
@@ -269,10 +278,6 @@ class Model:
                   specification
                 Values may be `pd.Series` with labeled indices; they are
                 auto-converted to JAX arrays.
-            derived_categoricals: Extra categorical mappings (level name to
-                `DiscreteGrid`) for derived variables not in the model's
-                state/action grids. Pass per-regime mappings as
-                `{"var": {"regime_a": grid_a, ...}}`.
             initial_conditions: Mapping of state names (plus `"regime"`) to arrays.
                 All arrays must have the same length (number of subjects). The
                 `"regime"` entry must contain integer regime codes (from
@@ -308,7 +313,6 @@ class Model:
             regimes=self.regimes,
             ages=self.ages,
             regime_names_to_ids=self.regime_names_to_ids,
-            derived_categoricals=derived_categoricals,
         )
         _validate_param_types(internal_params)
         if check_initial_conditions:
@@ -326,12 +330,24 @@ class Model:
         )
         log = get_logger(log_level=log_level)
         if period_to_regime_to_V_arr is None:
-            period_to_regime_to_V_arr = solve(
-                internal_params=internal_params,
-                ages=self.ages,
-                internal_regimes=self.internal_regimes,
-                logger=log,
-            )
+            try:
+                period_to_regime_to_V_arr = solve(
+                    internal_params=internal_params,
+                    ages=self.ages,
+                    internal_regimes=self.internal_regimes,
+                    logger=log,
+                    enable_jit=self.enable_jit,
+                )
+            except InvalidValueFunctionError as exc:
+                if log_path is not None and exc.partial_solution is not None:
+                    save_solve_snapshot(
+                        model=self,
+                        params=params,
+                        period_to_regime_to_V_arr=exc.partial_solution,  # ty: ignore[invalid-argument-type]
+                        log_path=Path(log_path),
+                        log_keep_n_latest=log_keep_n_latest,
+                    )
+                raise
         result = simulate(
             internal_params=internal_params,
             initial_conditions=initial_conditions,
@@ -356,23 +372,59 @@ class Model:
         return result
 
 
+def _merge_derived_categoricals(
+    regimes: Mapping[str, Regime],
+    derived_categoricals: Mapping[str, DiscreteGrid],
+) -> MappingProxyType[str, Regime]:
+    """Merge model-level derived_categoricals into each regime.
+
+    Args:
+        regimes: Mapping of regime names to Regime instances.
+        derived_categoricals: Model-level categorical grids to broadcast.
+
+    Returns:
+        Immutable mapping of regime names to (possibly updated) Regime instances.
+
+    Raises:
+        ModelInitializationError: If a regime already has a conflicting entry
+            (same key, different categories).
+
+    """
+    if not derived_categoricals:
+        return MappingProxyType(dict(regimes))
+    result = {}
+    for name, regime in regimes.items():
+        merged = dict(regime.derived_categoricals)
+        for var, grid in derived_categoricals.items():
+            existing = merged.get(var)
+            if existing is not None and existing.categories != grid.categories:
+                msg = (
+                    f"Model-level derived_categoricals['{var}'] conflicts "
+                    f"with regime '{name}': {grid.categories} vs "
+                    f"{existing.categories}."
+                )
+                raise ModelInitializationError(msg)
+            merged[var] = grid
+        result[name] = dataclasses.replace(
+            regime, derived_categoricals=MappingProxyType(merged)
+        )
+    return MappingProxyType(result)
+
+
 def _maybe_convert_series(
     internal_params: InternalParams,
     *,
     regimes: Mapping[str, Regime],
     ages: AgeGrid,
     regime_names_to_ids: RegimeNamesToIds,
-    derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-    | None,
 ) -> InternalParams:
     """Convert pd.Series leaves in params to JAX arrays if any are present."""
-    if derived_categoricals is not None or has_series(internal_params):
+    if has_series(internal_params):
         return convert_series_in_params(
             internal_params=internal_params,
             regimes=regimes,
             ages=ages,
             regime_names_to_ids=regime_names_to_ids,
-            derived_categoricals=derived_categoricals,
         )
     return internal_params
 

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -9,7 +9,7 @@ import pandas as pd
 from jax import Array
 
 from lcm.ages import AgeGrid
-from lcm.exceptions import InvalidValueFunctionError, ModelInitializationError
+from lcm.exceptions import ModelInitializationError
 from lcm.grids import DiscreteGrid
 from lcm.model_processing import (
     _validate_param_types,
@@ -95,7 +95,7 @@ class Model:
         regime_id_class: type,
         enable_jit: bool = True,
         fixed_params: UserParams = MappingProxyType({}),
-        derived_categoricals: Mapping[str, type | DiscreteGrid] = MappingProxyType({}),
+        derived_categoricals: Mapping[str, DiscreteGrid] = MappingProxyType({}),
     ) -> None:
         """Initialize the Model.
 
@@ -107,10 +107,9 @@ class Model:
             enable_jit: Whether to jit the functions of the internal regime.
             fixed_params: Parameters that can be fixed at model initialization.
             derived_categoricals: Categorical grids for DAG function outputs
-                not in states/actions. Values can be categorical classes or
-                `DiscreteGrid` instances. Broadcast to all regimes (merged
-                with each regime's own `derived_categoricals`). Raises if a
-                regime already has a conflicting entry.
+                not in states/actions. Broadcast to all regimes (merged with
+                each regime's own `derived_categoricals`). Raises if a regime
+                already has a conflicting entry.
 
         """
         self.description = description
@@ -213,23 +212,12 @@ class Model:
             internal_params=internal_params,
             ages=self.ages,
         )
-        try:
-            period_to_regime_to_V_arr = solve(
-                internal_params=internal_params,
-                ages=self.ages,
-                internal_regimes=self.internal_regimes,
-                logger=get_logger(log_level=log_level),
-            )
-        except InvalidValueFunctionError as exc:
-            if log_path is not None and exc.partial_solution is not None:
-                save_solve_snapshot(
-                    model=self,
-                    params=params,
-                    period_to_regime_to_V_arr=exc.partial_solution,  # ty: ignore[invalid-argument-type]
-                    log_path=Path(log_path),
-                    log_keep_n_latest=log_keep_n_latest,
-                )
-            raise
+        period_to_regime_to_V_arr = solve(
+            internal_params=internal_params,
+            ages=self.ages,
+            internal_regimes=self.internal_regimes,
+            logger=get_logger(log_level=log_level),
+        )
         if log_level == "debug" and log_path is not None:
             save_solve_snapshot(
                 model=self,
@@ -326,23 +314,12 @@ class Model:
         )
         log = get_logger(log_level=log_level)
         if period_to_regime_to_V_arr is None:
-            try:
-                period_to_regime_to_V_arr = solve(
-                    internal_params=internal_params,
-                    ages=self.ages,
-                    internal_regimes=self.internal_regimes,
-                    logger=log,
-                )
-            except InvalidValueFunctionError as exc:
-                if log_path is not None and exc.partial_solution is not None:
-                    save_solve_snapshot(
-                        model=self,
-                        params=params,
-                        period_to_regime_to_V_arr=exc.partial_solution,  # ty: ignore[invalid-argument-type]
-                        log_path=Path(log_path),
-                        log_keep_n_latest=log_keep_n_latest,
-                    )
-                raise
+            period_to_regime_to_V_arr = solve(
+                internal_params=internal_params,
+                ages=self.ages,
+                internal_regimes=self.internal_regimes,
+                logger=log,
+            )
         result = simulate(
             internal_params=internal_params,
             initial_conditions=initial_conditions,
@@ -369,14 +346,13 @@ class Model:
 
 def _merge_derived_categoricals(
     regimes: Mapping[str, Regime],
-    derived_categoricals: Mapping[str, type | DiscreteGrid],
+    derived_categoricals: Mapping[str, DiscreteGrid],
 ) -> MappingProxyType[str, Regime]:
     """Merge model-level derived_categoricals into each regime.
 
     Args:
         regimes: Mapping of regime names to Regime instances.
         derived_categoricals: Model-level categorical grids to broadcast.
-            Values can be categorical classes or `DiscreteGrid` instances.
 
     Returns:
         Immutable mapping of regime names to (possibly updated) Regime instances.
@@ -388,15 +364,10 @@ def _merge_derived_categoricals(
     """
     if not derived_categoricals:
         return MappingProxyType(dict(regimes))
-    normalized = {
-        k: v if isinstance(v, DiscreteGrid) else DiscreteGrid(v)
-        for k, v in derived_categoricals.items()
-    }
     result = {}
     for name, regime in regimes.items():
-        # After Regime.__post_init__, values are always DiscreteGrid.
-        merged: dict[str, DiscreteGrid] = dict(regime.derived_categoricals)  # ty: ignore[invalid-assignment]
-        for var, grid in normalized.items():
+        merged = dict(regime.derived_categoricals)
+        for var, grid in derived_categoricals.items():
             existing = merged.get(var)
             if existing is not None and existing.categories != grid.categories:
                 msg = (

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -126,15 +126,23 @@ class Model:
             )
         )
         self.regimes = MappingProxyType(dict(regimes))
+
+        def _convert_and_validate_fixed(
+            internal_params: InternalParams,
+        ) -> InternalParams:
+            converted = _maybe_convert_series(
+                internal_params, model=self, derived_categoricals=None
+            )
+            _validate_param_types(converted)
+            return converted
+
         self.internal_regimes, self._params_template = build_regimes_and_template(
             regimes=regimes,
             ages=self.ages,
             regime_names_to_ids=self.regime_names_to_ids,
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
-            convert_fixed_params=lambda params: _maybe_convert_series(
-                params, model=self, derived_categoricals=None
-            ),
+            convert_fixed_params=_convert_and_validate_fixed,
         )
         self.enable_jit = enable_jit
         self.simulation_output_dtypes = get_simulation_output_dtypes(

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -133,8 +133,8 @@ class Model:
         )
         self.regimes = _merge_derived_categoricals(regimes, derived_categoricals)
         self.internal_regimes, self._params_template = build_regimes_and_template(
-            regimes=self.regimes,
             ages=self.ages,
+            regimes=self.regimes,
             regime_names_to_ids=self.regime_names_to_ids,
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
@@ -332,8 +332,8 @@ class Model:
         if has_series(internal_params):
             internal_params = convert_series_in_params(
                 internal_params=internal_params,
-                regimes=self.regimes,
                 ages=self.ages,
+                regimes=self.regimes,
                 regime_names_to_ids=self.regime_names_to_ids,
             )
         _validate_param_types(internal_params)

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -132,6 +132,9 @@ class Model:
             regime_names_to_ids=self.regime_names_to_ids,
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
+            convert_fixed_params=lambda params: _maybe_convert_series(
+                params, model=self, derived_categoricals=None
+            ),
         )
         self.enable_jit = enable_jit
         self.simulation_output_dtypes = get_simulation_output_dtypes(

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -36,6 +36,7 @@ from lcm.simulation.simulate import simulate
 from lcm.solution.solve_brute import solve
 from lcm.typing import (
     FloatND,
+    InternalParams,
     ParamsTemplate,
     RegimeName,
     RegimeNamesToIds,
@@ -196,17 +197,7 @@ class Model:
 
         """
         _validate_log_args(log_level=log_level, log_path=log_path)
-        internal_params = process_params(
-            params=params, params_template=self._params_template
-        )
-        if has_series(internal_params):
-            internal_params = convert_series_in_params(
-                internal_params=internal_params,
-                regimes=self.regimes,
-                ages=self.ages,
-                regime_names_to_ids=self.regime_names_to_ids,
-            )
-        _validate_param_types(internal_params)
+        internal_params = self._process_params(params)
         validate_regime_transitions_all_periods(
             internal_regimes=self.internal_regimes,
             internal_params=internal_params,
@@ -288,17 +279,7 @@ class Model:
                 regimes=self.regimes,
                 regime_names_to_ids=self.regime_names_to_ids,
             )
-        internal_params = process_params(
-            params=params, params_template=self._params_template
-        )
-        if has_series(internal_params):
-            internal_params = convert_series_in_params(
-                internal_params=internal_params,
-                regimes=self.regimes,
-                ages=self.ages,
-                regime_names_to_ids=self.regime_names_to_ids,
-            )
-        _validate_param_types(internal_params)
+        internal_params = self._process_params(params)
         if check_initial_conditions:
             validate_initial_conditions(
                 initial_conditions=initial_conditions,
@@ -342,6 +323,21 @@ class Model:
                 log_keep_n_latest=log_keep_n_latest,
             )
         return result
+
+    def _process_params(self, params: UserParams) -> InternalParams:
+        """Broadcast, convert Series, and validate user params."""
+        internal_params = process_params(
+            params=params, params_template=self._params_template
+        )
+        if has_series(internal_params):
+            internal_params = convert_series_in_params(
+                internal_params=internal_params,
+                regimes=self.regimes,
+                ages=self.ages,
+                regime_names_to_ids=self.regime_names_to_ids,
+            )
+        _validate_param_types(internal_params)
+        return internal_params
 
 
 def _merge_derived_categoricals(

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -94,6 +94,8 @@ class Model:
         regime_id_class: type,
         enable_jit: bool = True,
         fixed_params: UserParams = MappingProxyType({}),
+        derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
+        | None = None,
     ) -> None:
         """Initialize the Model.
 
@@ -104,6 +106,10 @@ class Model:
             regime_id_class: Dataclass mapping regime names to integer indices.
             enable_jit: Whether to jit the functions of the internal regime.
             fixed_params: Parameters that can be fixed at model initialization.
+            derived_categoricals: Extra categorical mappings for derived
+                variables not in the model's state/action grids. Needed when
+                `fixed_params` contains `pd.Series` indexed by DAG function
+                outputs.
 
         """
         self.description = description
@@ -131,6 +137,7 @@ class Model:
             regime_names_to_ids=self.regime_names_to_ids,
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
+            derived_categoricals=derived_categoricals,
         )
         self.enable_jit = enable_jit
         self.simulation_output_dtypes = get_simulation_output_dtypes(

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -8,9 +8,9 @@ import pandas as pd
 from jax import Array
 
 from lcm.ages import AgeGrid
-from lcm.exceptions import InvalidParamsError
 from lcm.grids import DiscreteGrid
 from lcm.model_processing import (
+    _validate_param_types,
     build_regimes_and_template,
     validate_model_inputs,
 )
@@ -19,7 +19,6 @@ from lcm.pandas_utils import (
     has_series,
     initial_conditions_from_dataframe,
 )
-from lcm.params import MappingLeaf, SequenceLeaf
 from lcm.params.processing import (
     process_params,
 )
@@ -126,23 +125,12 @@ class Model:
             )
         )
         self.regimes = MappingProxyType(dict(regimes))
-
-        def _convert_and_validate_fixed(
-            internal_params: InternalParams,
-        ) -> InternalParams:
-            converted = _maybe_convert_series(
-                internal_params, model=self, derived_categoricals=None
-            )
-            _validate_param_types(converted)
-            return converted
-
         self.internal_regimes, self._params_template = build_regimes_and_template(
             regimes=regimes,
             ages=self.ages,
             regime_names_to_ids=self.regime_names_to_ids,
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
-            convert_fixed_params=_convert_and_validate_fixed,
         )
         self.enable_jit = enable_jit
         self.simulation_output_dtypes = get_simulation_output_dtypes(
@@ -212,7 +200,11 @@ class Model:
             params=params, params_template=self._params_template
         )
         internal_params = _maybe_convert_series(
-            internal_params, model=self, derived_categoricals=derived_categoricals
+            internal_params,
+            regimes=self.regimes,
+            ages=self.ages,
+            regime_names_to_ids=self.regime_names_to_ids,
+            derived_categoricals=derived_categoricals,
         )
         _validate_param_types(internal_params)
         validate_regime_transitions_all_periods(
@@ -296,12 +288,20 @@ class Model:
 
         """
         _validate_log_args(log_level=log_level, log_path=log_path)
-        initial_conditions = _maybe_convert_dataframe(initial_conditions, model=self)
+        initial_conditions = _maybe_convert_dataframe(
+            initial_conditions,
+            regimes=self.regimes,
+            regime_names_to_ids=self.regime_names_to_ids,
+        )
         internal_params = process_params(
             params=params, params_template=self._params_template
         )
         internal_params = _maybe_convert_series(
-            internal_params, model=self, derived_categoricals=derived_categoricals
+            internal_params,
+            regimes=self.regimes,
+            ages=self.ages,
+            regime_names_to_ids=self.regime_names_to_ids,
+            derived_categoricals=derived_categoricals,
         )
         _validate_param_types(internal_params)
         if check_initial_conditions:
@@ -352,7 +352,9 @@ class Model:
 def _maybe_convert_series(
     internal_params: InternalParams,
     *,
-    model: Model,
+    regimes: Mapping[str, Regime],
+    ages: AgeGrid,
+    regime_names_to_ids: RegimeNamesToIds,
     derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
     | None,
 ) -> InternalParams:
@@ -360,58 +362,27 @@ def _maybe_convert_series(
     if derived_categoricals is not None or has_series(internal_params):
         return convert_series_in_params(
             internal_params=internal_params,
-            model=model,
+            regimes=regimes,
+            ages=ages,
+            regime_names_to_ids=regime_names_to_ids,
             derived_categoricals=derived_categoricals,
         )
     return internal_params
 
 
-def _validate_param_types(internal_params: InternalParams) -> None:
-    """Raise if any param leaf is not a Python scalar or JAX array.
-
-    After processing, every leaf value (including inside MappingLeaf /
-    SequenceLeaf containers) must be a Python scalar (float, int, bool) or a
-    JAX array. Notably, numpy arrays and pandas Series are not accepted.
-    """
-    for regime_name, regime_params in internal_params.items():
-        for key, value in regime_params.items():
-            _check_leaf(value, f"{regime_name}__{key}")
-
-
-def _check_leaf(value: object, path: str) -> None:
-    """Check a single leaf value, recursing into MappingLeaf/SequenceLeaf."""
-    if isinstance(value, MappingLeaf):
-        for k, v in value.data.items():
-            _check_leaf(v, f"{path}.{k}")
-        return
-    if isinstance(value, SequenceLeaf):
-        for i, v in enumerate(value.data):
-            _check_leaf(v, f"{path}[{i}]")
-        return
-    if isinstance(value, (float, int, bool)):
-        return
-    if hasattr(value, "dtype") and hasattr(value, "shape"):
-        if isinstance(value, Array):
-            return
-        type_name = type(value).__module__ + "." + type(value).__name__
-        msg = (
-            f"Parameter '{path}' is a {type_name} (shape {value.shape}). "
-            f"Use jnp.array() or pass a pd.Series with a named index."
-        )
-        raise InvalidParamsError(msg)
-    type_name = type(value).__module__ + "." + type(value).__name__
-    msg = f"Parameter '{path}' has unexpected type {type_name}."
-    raise InvalidParamsError(msg)
-
-
 def _maybe_convert_dataframe(
     initial_conditions: Mapping[str, Array],
     *,
-    model: Model,
+    regimes: Mapping[str, Regime],
+    regime_names_to_ids: RegimeNamesToIds,
 ) -> Mapping[str, Array]:
     """Convert a DataFrame to initial_conditions dict if needed."""
     if isinstance(initial_conditions, pd.DataFrame):
-        return initial_conditions_from_dataframe(df=initial_conditions, model=model)
+        return initial_conditions_from_dataframe(
+            df=initial_conditions,
+            regimes=regimes,
+            regime_names_to_ids=regime_names_to_ids,
+        )
     return initial_conditions
 
 

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -36,7 +36,6 @@ from lcm.simulation.simulate import simulate
 from lcm.solution.solve_brute import solve
 from lcm.typing import (
     FloatND,
-    InternalParams,
     ParamsTemplate,
     RegimeName,
     RegimeNamesToIds,
@@ -96,7 +95,7 @@ class Model:
         regime_id_class: type,
         enable_jit: bool = True,
         fixed_params: UserParams = MappingProxyType({}),
-        derived_categoricals: Mapping[str, DiscreteGrid] = MappingProxyType({}),
+        derived_categoricals: Mapping[str, type | DiscreteGrid] = MappingProxyType({}),
     ) -> None:
         """Initialize the Model.
 
@@ -108,9 +107,10 @@ class Model:
             enable_jit: Whether to jit the functions of the internal regime.
             fixed_params: Parameters that can be fixed at model initialization.
             derived_categoricals: Categorical grids for DAG function outputs
-                not in states/actions. Broadcast to all regimes (merged with
-                each regime's own `derived_categoricals`). Raises if a regime
-                already has a conflicting entry.
+                not in states/actions. Values can be categorical classes or
+                `DiscreteGrid` instances. Broadcast to all regimes (merged
+                with each regime's own `derived_categoricals`). Raises if a
+                regime already has a conflicting entry.
 
         """
         self.description = description
@@ -168,7 +168,6 @@ class Model:
         self,
         *,
         params: UserParams,
-        max_compilation_workers: int | None = None,
         log_level: LogLevel = "progress",
         log_path: str | Path | None = None,
         log_keep_n_latest: int = 3,
@@ -186,10 +185,6 @@ class Model:
                   specification
                 Values may be `pd.Series` with labeled indices; they are
                 auto-converted to JAX arrays.
-            max_compilation_workers: Maximum number of threads for parallel XLA
-                compilation. Defaults to `os.cpu_count()`. Lower this on machines
-                with limited RAM, as each concurrent compilation holds an XLA HLO
-                graph in memory.
             log_level: Logging verbosity. `"off"` suppresses output, `"warning"` shows
                 NaN/Inf warnings, `"progress"` adds timing, `"debug"` adds stats and
                 requires `log_path`.
@@ -205,12 +200,13 @@ class Model:
         internal_params = process_params(
             params=params, params_template=self._params_template
         )
-        internal_params = _maybe_convert_series(
-            internal_params,
-            regimes=self.regimes,
-            ages=self.ages,
-            regime_names_to_ids=self.regime_names_to_ids,
-        )
+        if has_series(internal_params):
+            internal_params = convert_series_in_params(
+                internal_params=internal_params,
+                regimes=self.regimes,
+                ages=self.ages,
+                regime_names_to_ids=self.regime_names_to_ids,
+            )
         _validate_param_types(internal_params)
         validate_regime_transitions_all_periods(
             internal_regimes=self.internal_regimes,
@@ -223,8 +219,6 @@ class Model:
                 ages=self.ages,
                 internal_regimes=self.internal_regimes,
                 logger=get_logger(log_level=log_level),
-                max_compilation_workers=max_compilation_workers,
-                enable_jit=self.enable_jit,
             )
         except InvalidValueFunctionError as exc:
             if log_path is not None and exc.partial_solution is not None:
@@ -300,20 +294,22 @@ class Model:
 
         """
         _validate_log_args(log_level=log_level, log_path=log_path)
-        initial_conditions = _maybe_convert_dataframe(
-            initial_conditions,
-            regimes=self.regimes,
-            regime_names_to_ids=self.regime_names_to_ids,
-        )
+        if isinstance(initial_conditions, pd.DataFrame):
+            initial_conditions = initial_conditions_from_dataframe(
+                df=initial_conditions,
+                regimes=self.regimes,
+                regime_names_to_ids=self.regime_names_to_ids,
+            )
         internal_params = process_params(
             params=params, params_template=self._params_template
         )
-        internal_params = _maybe_convert_series(
-            internal_params,
-            regimes=self.regimes,
-            ages=self.ages,
-            regime_names_to_ids=self.regime_names_to_ids,
-        )
+        if has_series(internal_params):
+            internal_params = convert_series_in_params(
+                internal_params=internal_params,
+                regimes=self.regimes,
+                ages=self.ages,
+                regime_names_to_ids=self.regime_names_to_ids,
+            )
         _validate_param_types(internal_params)
         if check_initial_conditions:
             validate_initial_conditions(
@@ -336,7 +332,6 @@ class Model:
                     ages=self.ages,
                     internal_regimes=self.internal_regimes,
                     logger=log,
-                    enable_jit=self.enable_jit,
                 )
             except InvalidValueFunctionError as exc:
                 if log_path is not None and exc.partial_solution is not None:
@@ -374,13 +369,14 @@ class Model:
 
 def _merge_derived_categoricals(
     regimes: Mapping[str, Regime],
-    derived_categoricals: Mapping[str, DiscreteGrid],
+    derived_categoricals: Mapping[str, type | DiscreteGrid],
 ) -> MappingProxyType[str, Regime]:
     """Merge model-level derived_categoricals into each regime.
 
     Args:
         regimes: Mapping of regime names to Regime instances.
         derived_categoricals: Model-level categorical grids to broadcast.
+            Values can be categorical classes or `DiscreteGrid` instances.
 
     Returns:
         Immutable mapping of regime names to (possibly updated) Regime instances.
@@ -392,10 +388,15 @@ def _merge_derived_categoricals(
     """
     if not derived_categoricals:
         return MappingProxyType(dict(regimes))
+    normalized = {
+        k: v if isinstance(v, DiscreteGrid) else DiscreteGrid(v)
+        for k, v in derived_categoricals.items()
+    }
     result = {}
     for name, regime in regimes.items():
-        merged = dict(regime.derived_categoricals)
-        for var, grid in derived_categoricals.items():
+        # After Regime.__post_init__, values are always DiscreteGrid.
+        merged: dict[str, DiscreteGrid] = dict(regime.derived_categoricals)  # ty: ignore[invalid-assignment]
+        for var, grid in normalized.items():
             existing = merged.get(var)
             if existing is not None and existing.categories != grid.categories:
                 msg = (
@@ -409,40 +410,6 @@ def _merge_derived_categoricals(
             regime, derived_categoricals=MappingProxyType(merged)
         )
     return MappingProxyType(result)
-
-
-def _maybe_convert_series(
-    internal_params: InternalParams,
-    *,
-    regimes: Mapping[str, Regime],
-    ages: AgeGrid,
-    regime_names_to_ids: RegimeNamesToIds,
-) -> InternalParams:
-    """Convert pd.Series leaves in params to JAX arrays if any are present."""
-    if has_series(internal_params):
-        return convert_series_in_params(
-            internal_params=internal_params,
-            regimes=regimes,
-            ages=ages,
-            regime_names_to_ids=regime_names_to_ids,
-        )
-    return internal_params
-
-
-def _maybe_convert_dataframe(
-    initial_conditions: Mapping[str, Array],
-    *,
-    regimes: Mapping[str, Regime],
-    regime_names_to_ids: RegimeNamesToIds,
-) -> Mapping[str, Array]:
-    """Convert a DataFrame to initial_conditions dict if needed."""
-    if isinstance(initial_conditions, pd.DataFrame):
-        return initial_conditions_from_dataframe(
-            df=initial_conditions,
-            regimes=regimes,
-            regime_names_to_ids=regime_names_to_ids,
-        )
-    return initial_conditions
 
 
 def _validate_log_args(*, log_level: LogLevel, log_path: str | Path | None) -> None:

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -133,7 +133,7 @@ def _build_regimes_and_template_with_fixed_params(
             internal_regimes=raw_internal_regimes,
             fixed_internal=fixed_internal,
         ),
-        _remove_fixed_from_template(
+        _remove_fixed_params_from_template(
             template=raw_params_template,
             fixed_internal=fixed_internal,
         ),
@@ -274,7 +274,7 @@ def _resolve_fixed_params(
     )
 
 
-def _remove_fixed_from_template(
+def _remove_fixed_params_from_template(
     *,
     template: ParamsTemplate,
     fixed_internal: InternalParams,

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -40,8 +40,8 @@ from lcm.utils.containers import get_field_names_and_values
 
 def build_regimes_and_template(
     *,
-    regimes: Mapping[str, Regime],
     ages: AgeGrid,
+    regimes: Mapping[str, Regime],
     regime_names_to_ids: RegimeNamesToIds,
     enable_jit: bool,
     fixed_params: UserParams,
@@ -52,8 +52,8 @@ def build_regimes_and_template(
     so that each result is computed exactly once.
 
     Args:
-        regimes: Mapping of regime names to Regime instances.
         ages: Age grid for the model.
+        regimes: Mapping of regime names to Regime instances.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
         enable_jit: Whether to JIT-compile regime functions.
@@ -65,8 +65,8 @@ def build_regimes_and_template(
     """
     if not fixed_params:
         internal_regimes = process_regimes(
-            regimes=regimes,
             ages=ages,
+            regimes=regimes,
             regime_names_to_ids=regime_names_to_ids,
             enable_jit=enable_jit,
         )
@@ -74,8 +74,8 @@ def build_regimes_and_template(
     else:
         internal_regimes, params_template = (
             _build_regimes_and_template_with_fixed_params(
-                regimes=regimes,
                 ages=ages,
+                regimes=regimes,
                 regime_names_to_ids=regime_names_to_ids,
                 enable_jit=enable_jit,
                 fixed_params=fixed_params,
@@ -87,8 +87,8 @@ def build_regimes_and_template(
 
 def _build_regimes_and_template_with_fixed_params(
     *,
-    regimes: Mapping[str, Regime],
     ages: AgeGrid,
+    regimes: Mapping[str, Regime],
     regime_names_to_ids: RegimeNamesToIds,
     enable_jit: bool,
     fixed_params: UserParams,
@@ -96,8 +96,8 @@ def _build_regimes_and_template_with_fixed_params(
     """Build internal regimes and template, then partial in fixed params.
 
     Args:
-        regimes: Mapping of regime names to Regime instances.
         ages: Age grid for the model.
+        regimes: Mapping of regime names to Regime instances.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
         enable_jit: Whether to JIT-compile regime functions.
@@ -109,8 +109,8 @@ def _build_regimes_and_template_with_fixed_params(
 
     """
     internal_regimes = process_regimes(
-        regimes=regimes,
         ages=ages,
+        regimes=regimes,
         regime_names_to_ids=regime_names_to_ids,
         enable_jit=enable_jit,
     )
@@ -122,8 +122,8 @@ def _build_regimes_and_template_with_fixed_params(
     if has_series(fixed_internal):
         fixed_internal = convert_series_in_params(
             internal_params=fixed_internal,
-            regimes=regimes,
             ages=ages,
+            regimes=regimes,
             regime_names_to_ids=regime_names_to_ids,
         )
     _validate_param_types(fixed_internal)

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -41,11 +41,22 @@ def build_regimes_and_template(
     regime_names_to_ids: RegimeNamesToIds,
     enable_jit: bool,
     fixed_params: UserParams,
+    convert_fixed_params: Callable[[InternalParams], InternalParams] | None = None,
 ) -> tuple[MappingProxyType[RegimeName, InternalRegime], ParamsTemplate]:
     """Build internal regimes and params template in a single pass.
 
     Compose regime processing, template creation, and optional fixed-param partialling
     so that each result is computed exactly once.
+
+    Args:
+        regimes: Mapping of regime names to Regime instances.
+        ages: Age grid for the model.
+        regime_names_to_ids: Mapping of regime names to integer indices.
+        enable_jit: Whether to JIT-compile regime functions.
+        fixed_params: Parameters to fix at model initialization.
+        convert_fixed_params: Optional callback to convert fixed param values
+            (e.g., pd.Series to JAX arrays) after broadcasting to template shape
+            but before partialling into compiled functions.
 
     """
     internal_regimes = process_regimes(
@@ -60,6 +71,8 @@ def build_regimes_and_template(
         fixed_internal = _resolve_fixed_params(
             fixed_params=dict(fixed_params), template=params_template
         )
+        if convert_fixed_params is not None:
+            fixed_internal = convert_fixed_params(fixed_internal)
         if any(v for v in fixed_internal.values()):
             internal_regimes = _partial_fixed_params_into_regimes(
                 internal_regimes=internal_regimes, fixed_internal=fixed_internal

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -12,13 +12,17 @@ from types import MappingProxyType
 
 from dags import get_ancestors
 from dags.tree import QNAME_DELIMITER, qname_from_tree_path
+from jax import Array
 
 from lcm.ages import AgeGrid
-from lcm.exceptions import ModelInitializationError, format_messages
+from lcm.exceptions import InvalidParamsError, ModelInitializationError, format_messages
+from lcm.pandas_utils import convert_series_in_params, has_series
+from lcm.params import MappingLeaf
 from lcm.params.processing import (
     broadcast_to_template,
     create_params_template,
 )
+from lcm.params.sequence_leaf import SequenceLeaf
 from lcm.regime import Regime
 from lcm.regime_building.processing import (
     InternalRegime,
@@ -41,7 +45,6 @@ def build_regimes_and_template(
     regime_names_to_ids: RegimeNamesToIds,
     enable_jit: bool,
     fixed_params: UserParams,
-    convert_fixed_params: Callable[[InternalParams], InternalParams] | None = None,
 ) -> tuple[MappingProxyType[RegimeName, InternalRegime], ParamsTemplate]:
     """Build internal regimes and params template in a single pass.
 
@@ -54,9 +57,6 @@ def build_regimes_and_template(
         regime_names_to_ids: Mapping of regime names to integer indices.
         enable_jit: Whether to JIT-compile regime functions.
         fixed_params: Parameters to fix at model initialization.
-        convert_fixed_params: Optional callback to convert fixed param values
-            (e.g., pd.Series to JAX arrays) after broadcasting to template shape
-            but before partialling into compiled functions.
 
     Returns:
         Tuple of (internal_regimes, params_template).
@@ -74,8 +74,14 @@ def build_regimes_and_template(
         fixed_internal = _resolve_fixed_params(
             fixed_params=dict(fixed_params), template=params_template
         )
-        if convert_fixed_params is not None:
-            fixed_internal = convert_fixed_params(fixed_internal)
+        if has_series(fixed_internal):
+            fixed_internal = convert_series_in_params(
+                internal_params=fixed_internal,
+                regimes=regimes,
+                ages=ages,
+                regime_names_to_ids=regime_names_to_ids,
+            )
+        _validate_param_types(fixed_internal)
         if any(v for v in fixed_internal.values()):
             internal_regimes = _partial_fixed_params_into_regimes(
                 internal_regimes=internal_regimes, fixed_internal=fixed_internal
@@ -345,3 +351,41 @@ def _filter_kwargs_for_func(
     if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
         return kwargs
     return {k: v for k, v in kwargs.items() if k in params}
+
+
+def _validate_param_types(internal_params: InternalParams) -> None:
+    """Raise if any param leaf is not a Python scalar or JAX array.
+
+    After processing, every leaf value (including inside MappingLeaf /
+    SequenceLeaf containers) must be a Python scalar (float, int, bool) or a
+    JAX array. Notably, numpy arrays and pandas Series are not accepted.
+    """
+    for regime_name, regime_params in internal_params.items():
+        for key, value in regime_params.items():
+            _check_leaf(value, f"{regime_name}__{key}")
+
+
+def _check_leaf(value: object, path: str) -> None:
+    """Check a single leaf value, recursing into MappingLeaf/SequenceLeaf."""
+    if isinstance(value, MappingLeaf):
+        for k, v in value.data.items():
+            _check_leaf(v, f"{path}.{k}")
+        return
+    if isinstance(value, SequenceLeaf):
+        for i, v in enumerate(value.data):
+            _check_leaf(v, f"{path}[{i}]")
+        return
+    if isinstance(value, (float, int, bool)):
+        return
+    if hasattr(value, "dtype") and hasattr(value, "shape"):
+        if isinstance(value, Array):
+            return
+        type_name = type(value).__module__ + "." + type(value).__name__
+        msg = (
+            f"Parameter '{path}' is a {type_name} (shape {value.shape}). "
+            f"Use jnp.array() or pass a pd.Series with a named index."
+        )
+        raise InvalidParamsError(msg)
+    type_name = type(value).__module__ + "." + type(value).__name__
+    msg = f"Parameter '{path}' has unexpected type {type_name}."
+    raise InvalidParamsError(msg)

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -63,6 +63,51 @@ def build_regimes_and_template(
         Tuple of (internal_regimes, params_template).
 
     """
+    if not fixed_params:
+        internal_regimes = process_regimes(
+            regimes=regimes,
+            ages=ages,
+            regime_names_to_ids=regime_names_to_ids,
+            enable_jit=enable_jit,
+        )
+        params_template = create_params_template(internal_regimes)
+    else:
+        internal_regimes, params_template = (
+            _build_regimes_and_template_with_fixed_params(
+                regimes=regimes,
+                ages=ages,
+                regime_names_to_ids=regime_names_to_ids,
+                enable_jit=enable_jit,
+                fixed_params=fixed_params,
+            )
+        )
+
+    return internal_regimes, params_template
+
+
+def _build_regimes_and_template_with_fixed_params(
+    *,
+    regimes: Mapping[str, Regime],
+    ages: AgeGrid,
+    regime_names_to_ids: RegimeNamesToIds,
+    enable_jit: bool,
+    fixed_params: UserParams,
+) -> tuple[MappingProxyType[RegimeName, InternalRegime], ParamsTemplate]:
+    """Build internal regimes and template, then partial in fixed params.
+
+    Args:
+        regimes: Mapping of regime names to Regime instances.
+        ages: Age grid for the model.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
+        enable_jit: Whether to JIT-compile regime functions.
+        fixed_params: Parameters to fix at model initialization.
+
+    Returns:
+        Tuple of internal_regimes and params_template with fixed params
+        partialled in.
+
+    """
     internal_regimes = process_regimes(
         regimes=regimes,
         ages=ages,
@@ -71,43 +116,6 @@ def build_regimes_and_template(
     )
     params_template = create_params_template(internal_regimes)
 
-    if fixed_params:
-        internal_regimes, params_template = _apply_fixed_params(
-            internal_regimes=internal_regimes,
-            params_template=params_template,
-            fixed_params=fixed_params,
-            regimes=regimes,
-            ages=ages,
-            regime_names_to_ids=regime_names_to_ids,
-        )
-
-    return internal_regimes, params_template
-
-
-def _apply_fixed_params(
-    *,
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
-    params_template: ParamsTemplate,
-    fixed_params: UserParams,
-    regimes: Mapping[str, Regime],
-    ages: AgeGrid,
-    regime_names_to_ids: RegimeNamesToIds,
-) -> tuple[MappingProxyType[RegimeName, InternalRegime], ParamsTemplate]:
-    """Resolve, convert, validate, and partial fixed params.
-
-    Args:
-        internal_regimes: Immutable mapping of regime names to internal regimes.
-        params_template: Template for the model parameters.
-        fixed_params: Parameters to fix at model initialization.
-        regimes: Mapping of regime names to Regime instances.
-        ages: Age grid for the model.
-        regime_names_to_ids: Immutable mapping from regime names to integer
-            indices.
-
-    Returns:
-        Tuple of (possibly updated) internal_regimes and params_template.
-
-    """
     fixed_internal = _resolve_fixed_params(
         fixed_params=dict(fixed_params), template=params_template
     )

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -108,16 +108,16 @@ def _build_regimes_and_template_with_fixed_params(
         partialled in.
 
     """
-    internal_regimes = process_regimes(
+    raw_internal_regimes = process_regimes(
         ages=ages,
         regimes=regimes,
         regime_names_to_ids=regime_names_to_ids,
         enable_jit=enable_jit,
     )
-    params_template = create_params_template(internal_regimes)
+    raw_params_template = create_params_template(raw_internal_regimes)
 
     fixed_internal = _resolve_fixed_params(
-        fixed_params=dict(fixed_params), template=params_template
+        fixed_params=dict(fixed_params), template=raw_params_template
     )
     if has_series(fixed_internal):
         fixed_internal = convert_series_in_params(
@@ -128,16 +128,13 @@ def _build_regimes_and_template_with_fixed_params(
         )
     _validate_param_types(fixed_internal)
 
-    if not any(v for v in fixed_internal.values()):
-        return internal_regimes, params_template
-
     return (
         _partial_fixed_params_into_regimes(
-            internal_regimes=internal_regimes,
+            internal_regimes=raw_internal_regimes,
             fixed_internal=fixed_internal,
         ),
         _remove_fixed_from_template(
-            template=params_template,
+            template=raw_params_template,
             fixed_internal=fixed_internal,
         ),
     )

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -72,26 +72,67 @@ def build_regimes_and_template(
     params_template = create_params_template(internal_regimes)
 
     if fixed_params:
-        fixed_internal = _resolve_fixed_params(
-            fixed_params=dict(fixed_params), template=params_template
+        internal_regimes, params_template = _apply_fixed_params(
+            internal_regimes=internal_regimes,
+            params_template=params_template,
+            fixed_params=fixed_params,
+            regimes=regimes,
+            ages=ages,
+            regime_names_to_ids=regime_names_to_ids,
         )
-        if has_series(fixed_internal):
-            fixed_internal = convert_series_in_params(
-                internal_params=fixed_internal,
-                regimes=regimes,
-                ages=ages,
-                regime_names_to_ids=regime_names_to_ids,
-            )
-        _validate_param_types(fixed_internal)
-        if any(v for v in fixed_internal.values()):
-            internal_regimes = _partial_fixed_params_into_regimes(
-                internal_regimes=internal_regimes, fixed_internal=fixed_internal
-            )
-            params_template = _remove_fixed_from_template(
-                template=params_template, fixed_internal=fixed_internal
-            )
 
     return internal_regimes, params_template
+
+
+def _apply_fixed_params(
+    *,
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    params_template: ParamsTemplate,
+    fixed_params: UserParams,
+    regimes: Mapping[str, Regime],
+    ages: AgeGrid,
+    regime_names_to_ids: RegimeNamesToIds,
+) -> tuple[MappingProxyType[RegimeName, InternalRegime], ParamsTemplate]:
+    """Resolve, convert, validate, and partial fixed params.
+
+    Args:
+        internal_regimes: Immutable mapping of regime names to internal regimes.
+        params_template: Template for the model parameters.
+        fixed_params: Parameters to fix at model initialization.
+        regimes: Mapping of regime names to Regime instances.
+        ages: Age grid for the model.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
+
+    Returns:
+        Tuple of (possibly updated) internal_regimes and params_template.
+
+    """
+    fixed_internal = _resolve_fixed_params(
+        fixed_params=dict(fixed_params), template=params_template
+    )
+    if has_series(fixed_internal):
+        fixed_internal = convert_series_in_params(
+            internal_params=fixed_internal,
+            regimes=regimes,
+            ages=ages,
+            regime_names_to_ids=regime_names_to_ids,
+        )
+    _validate_param_types(fixed_internal)
+
+    if not any(v for v in fixed_internal.values()):
+        return internal_regimes, params_template
+
+    return (
+        _partial_fixed_params_into_regimes(
+            internal_regimes=internal_regimes,
+            fixed_internal=fixed_internal,
+        ),
+        _remove_fixed_from_template(
+            template=params_template,
+            fixed_internal=fixed_internal,
+        ),
+    )
 
 
 def validate_model_inputs(

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -16,7 +16,6 @@ from jax import Array
 
 from lcm.ages import AgeGrid
 from lcm.exceptions import InvalidParamsError, ModelInitializationError, format_messages
-from lcm.grids import DiscreteGrid
 from lcm.pandas_utils import convert_series_in_params, has_series
 from lcm.params import MappingLeaf
 from lcm.params.processing import (
@@ -46,8 +45,6 @@ def build_regimes_and_template(
     regime_names_to_ids: RegimeNamesToIds,
     enable_jit: bool,
     fixed_params: UserParams,
-    derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-    | None = None,
 ) -> tuple[MappingProxyType[RegimeName, InternalRegime], ParamsTemplate]:
     """Build internal regimes and params template in a single pass.
 
@@ -61,10 +58,6 @@ def build_regimes_and_template(
             indices.
         enable_jit: Whether to JIT-compile regime functions.
         fixed_params: Parameters to fix at model initialization.
-        derived_categoricals: Extra categorical mappings for derived
-            variables not in the model's state/action grids. Needed when
-            `fixed_params` contains `pd.Series` indexed by DAG function
-            outputs.
 
     Returns:
         Tuple of (internal_regimes, params_template).
@@ -88,7 +81,6 @@ def build_regimes_and_template(
                 regimes=regimes,
                 ages=ages,
                 regime_names_to_ids=regime_names_to_ids,
-                derived_categoricals=derived_categoricals,
             )
         _validate_param_types(fixed_internal)
         if any(v for v in fixed_internal.values()):

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -16,6 +16,7 @@ from jax import Array
 
 from lcm.ages import AgeGrid
 from lcm.exceptions import InvalidParamsError, ModelInitializationError, format_messages
+from lcm.grids import DiscreteGrid
 from lcm.pandas_utils import convert_series_in_params, has_series
 from lcm.params import MappingLeaf
 from lcm.params.processing import (
@@ -45,6 +46,8 @@ def build_regimes_and_template(
     regime_names_to_ids: RegimeNamesToIds,
     enable_jit: bool,
     fixed_params: UserParams,
+    derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
+    | None = None,
 ) -> tuple[MappingProxyType[RegimeName, InternalRegime], ParamsTemplate]:
     """Build internal regimes and params template in a single pass.
 
@@ -57,6 +60,10 @@ def build_regimes_and_template(
         regime_names_to_ids: Mapping of regime names to integer indices.
         enable_jit: Whether to JIT-compile regime functions.
         fixed_params: Parameters to fix at model initialization.
+        derived_categoricals: Extra categorical mappings for derived
+            variables not in the model's state/action grids. Needed when
+            `fixed_params` contains `pd.Series` indexed by DAG function
+            outputs.
 
     Returns:
         Tuple of (internal_regimes, params_template).
@@ -80,6 +87,7 @@ def build_regimes_and_template(
                 regimes=regimes,
                 ages=ages,
                 regime_names_to_ids=regime_names_to_ids,
+                derived_categoricals=derived_categoricals,
             )
         _validate_param_types(fixed_internal)
         if any(v for v in fixed_internal.values()):

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -58,6 +58,9 @@ def build_regimes_and_template(
             (e.g., pd.Series to JAX arrays) after broadcasting to template shape
             but before partialling into compiled functions.
 
+    Returns:
+        Tuple of (internal_regimes, params_template).
+
     """
     internal_regimes = process_regimes(
         regimes=regimes,

--- a/src/lcm/model_processing.py
+++ b/src/lcm/model_processing.py
@@ -57,7 +57,8 @@ def build_regimes_and_template(
     Args:
         regimes: Mapping of regime names to Regime instances.
         ages: Age grid for the model.
-        regime_names_to_ids: Mapping of regime names to integer indices.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
         enable_jit: Whether to JIT-compile regime functions.
         fixed_params: Parameters to fix at model initialization.
         derived_categoricals: Extra categorical mappings for derived

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -419,9 +419,7 @@ def _resolve_categoricals(
             {n: g for n, g in regime.states.items() if isinstance(g, DiscreteGrid)}
         )
         grids.update(_build_discrete_action_lookup(regime))
-        # After __post_init__, values are always DiscreteGrid.
-        dc: Mapping[str, DiscreteGrid] = regime.derived_categoricals  # ty: ignore[invalid-assignment]
-        for name, grid in dc.items():
+        for name, grid in regime.derived_categoricals.items():
             if name in grids and grids[name].categories != grid.categories:
                 msg = (
                     f"Derived categorical '{name}' conflicts with "
@@ -588,7 +586,7 @@ def _build_level_mappings_for_param(
                 f"Unrecognised indexing parameter '{param}'. Expected 'age' "
                 f"or a discrete grid name ({sorted(grids)}). If "
                 f"'{param}' is a DAG function output, add "
-                f'derived_categoricals={{"{param}": {param.title()}Class}} '
+                f'derived_categoricals={{"{param}": DiscreteGrid(...)}} '
                 f"to the Regime or Model constructor."
             )
             raise ValueError(msg)
@@ -617,12 +615,11 @@ def _build_outcome_mapping(
 
     """
     if func_name == "next_regime":
-        regime_ids = dict(regime_names_to_ids)
         return _LevelMapping(
             name="next_regime",
-            size=len(regime_ids),
-            get_code_from_label=regime_ids.__getitem__,
-            valid_labels=tuple(regime_ids),
+            size=len(regime_names_to_ids),
+            get_code_from_label=regime_names_to_ids.__getitem__,
+            valid_labels=tuple(regime_names_to_ids),
         )
 
     path = tree_path_from_qname(func_name)

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -800,25 +800,19 @@ def _validate_state_columns(
     initial_regimes: list[str],
 ) -> None:
     """Validate that DataFrame columns match model states."""
-    required, optional = _collect_state_names(
-        regimes=regimes, initial_regimes=initial_regimes
-    )
-    all_known = required | optional
+    expected = _collect_state_names(regimes=regimes, initial_regimes=initial_regimes)
 
-    unknown = state_columns - all_known
+    unknown = state_columns - expected
     if unknown:
         msg = (
             f"Unknown columns not matching any model state: {sorted(unknown)}. "
-            f"Expected states: {sorted(all_known)}."
+            f"Expected states: {sorted(expected)}."
         )
         raise ValueError(msg)
 
-    missing = required - state_columns
+    missing = expected - state_columns
     if missing:
-        msg = (
-            f"Missing required state columns: {sorted(missing)}. "
-            f"All non-shock states must be provided."
-        )
+        msg = f"Missing required state columns: {sorted(missing)}."
         raise ValueError(msg)
 
 
@@ -826,25 +820,18 @@ def _collect_state_names(
     *,
     regimes: Mapping[str, Regime],
     initial_regimes: list[str],
-) -> tuple[set[str], set[str]]:
-    """Collect required and optional state names from initial regimes.
+) -> set[str]:
+    """Collect all state names (including shock grids) from initial regimes.
 
     Returns:
-        Tuple of (required, optional). Required includes all non-shock states
-        plus age. Optional includes shock grid states (continuous, drawn fresh
-        each period but accepted in the DataFrame).
+        Set of all state names from the initial regimes, plus `'age'`
+        (always required).
 
     """
-    required: set[str] = {"age"}
-    optional: set[str] = set()
+    names: set[str] = {"age"}
     for regime_name in set(initial_regimes):
-        regime = regimes[regime_name]
-        for name, grid in regime.states.items():
-            if isinstance(grid, _ShockGrid):
-                optional.add(name)
-            else:
-                required.add(name)
-    return required, optional
+        names.update(regimes[regime_name].states.keys())
+    return names
 
 
 def _build_discrete_grid_lookup(

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -49,6 +49,7 @@ def initial_conditions_from_dataframe(
 
     Args:
         df: DataFrame with columns for states and a "regime" column.
+        regimes: Mapping of regime names to user Regime instances.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
 

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -800,19 +800,20 @@ def _validate_state_columns(
     initial_regimes: list[str],
 ) -> None:
     """Validate that DataFrame columns match model states."""
-    all_states = _collect_all_state_names(
+    required, optional = _collect_state_names(
         regimes=regimes, initial_regimes=initial_regimes
     )
+    all_known = required | optional
 
-    unknown = state_columns - all_states
+    unknown = state_columns - all_known
     if unknown:
         msg = (
             f"Unknown columns not matching any model state: {sorted(unknown)}. "
-            f"Expected states: {sorted(all_states)}."
+            f"Expected states: {sorted(all_known)}."
         )
         raise ValueError(msg)
 
-    missing = all_states - state_columns
+    missing = required - state_columns
     if missing:
         msg = (
             f"Missing required state columns: {sorted(missing)}. "
@@ -821,21 +822,29 @@ def _validate_state_columns(
         raise ValueError(msg)
 
 
-def _collect_all_state_names(
+def _collect_state_names(
     *,
     regimes: Mapping[str, Regime],
     initial_regimes: list[str],
-) -> set[str]:
-    """Collect all non-shock state names from regimes present in initial_regimes."""
-    state_names: set[str] = set()
+) -> tuple[set[str], set[str]]:
+    """Collect required and optional state names from initial regimes.
+
+    Returns:
+        Tuple of (required, optional). Required includes all non-shock states
+        plus age. Optional includes shock grid states (continuous, drawn fresh
+        each period but accepted in the DataFrame).
+
+    """
+    required: set[str] = {"age"}
+    optional: set[str] = set()
     for regime_name in set(initial_regimes):
         regime = regimes[regime_name]
         for name, grid in regime.states.items():
-            if not isinstance(grid, _ShockGrid):
-                state_names.add(name)
-    # Always include age
-    state_names.add("age")
-    return state_names
+            if isinstance(grid, _ShockGrid):
+                optional.add(name)
+            else:
+                required.add(name)
+    return required, optional
 
 
 def _build_discrete_grid_lookup(

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -166,8 +166,8 @@ def _map_discrete_labels(
 def convert_series_in_params(
     *,
     internal_params: Mapping[str, Mapping[str, object]],
-    regimes: Mapping[str, Regime],
     ages: AgeGrid,
+    regimes: Mapping[str, Regime],
     regime_names_to_ids: RegimeNamesToIds,
 ) -> InternalParams:
     """Convert pd.Series leaves in already-broadcast internal params to JAX arrays.
@@ -184,8 +184,8 @@ def convert_series_in_params(
     Args:
         internal_params: Already-broadcast params in template shape
             (`{regime: {func__param: value}}`).
-        regimes: Mapping of regime names to user Regime instances.
         ages: Age grid for the model.
+        regimes: Mapping of regime names to user Regime instances.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
 
@@ -211,8 +211,8 @@ def convert_series_in_params(
                     func=None,
                     param_name=param_name,
                     func_name=template_func_name,
-                    regimes=regimes,
                     ages=ages,
+                    regimes=regimes,
                     regime_names_to_ids=regime_names_to_ids,
                     regime_name=regime_name,
                 )
@@ -231,8 +231,8 @@ def convert_series_in_params(
                 func=func,
                 param_name=param_name,
                 func_name=resolved_func_name,
-                regimes=regimes,
                 ages=ages,
+                regimes=regimes,
                 regime_names_to_ids=regime_names_to_ids,
                 regime_name=regime_name,
             )
@@ -249,8 +249,8 @@ def _convert_param_value(
     func: Callable | None,
     param_name: str,
     func_name: str,
-    regimes: Mapping[str, Regime],
     ages: AgeGrid,
+    regimes: Mapping[str, Regime],
     regime_names_to_ids: RegimeNamesToIds,
     regime_name: str | None,
 ) -> object:
@@ -262,8 +262,8 @@ def _convert_param_value(
             grid params — triggers scalar passthrough).
         param_name: Parameter name in the function.
         func_name: Function name (for `next_*` outcome axis detection).
-        regimes: Mapping of regime names to user Regime instances.
         ages: Age grid for the model.
+        regimes: Mapping of regime names to user Regime instances.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
         regime_name: Regime name for action grid lookup.
@@ -280,8 +280,8 @@ def _convert_param_value(
             func=func,
             param_name=param_name,
             func_name=func_name,
-            regimes=regimes,
             ages=ages,
+            regimes=regimes,
             regime_names_to_ids=regime_names_to_ids,
             regime_name=regime_name,
         )
@@ -292,8 +292,8 @@ def _convert_param_value(
             func=func,
             param_name=param_name,
             func_name=func_name,
-            regimes=regimes,
             ages=ages,
+            regimes=regimes,
             regime_names_to_ids=regime_names_to_ids,
             regime_name=regime_name,
         )
@@ -310,8 +310,8 @@ def array_from_series(
     func: Callable | None,
     param_name: str,
     func_name: str,
-    regimes: Mapping[str, Regime],
     ages: AgeGrid,
+    regimes: Mapping[str, Regime],
     regime_names_to_ids: RegimeNamesToIds,
     regime_name: str | None = None,
 ) -> Array:
@@ -335,8 +335,8 @@ def array_from_series(
             runtime grid/shock params (triggers scalar passthrough).
         param_name: The array parameter name in `func`.
         func_name: Function name (for `next_*` outcome axis detection).
-        regimes: Mapping of regime names to user Regime instances.
         ages: Age grid for the model.
+        regimes: Mapping of regime names to user Regime instances.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
         regime_name: Regime for action grid lookup.

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -419,7 +419,9 @@ def _resolve_categoricals(
             {n: g for n, g in regime.states.items() if isinstance(g, DiscreteGrid)}
         )
         grids.update(_build_discrete_action_lookup(regime))
-        for name, grid in regime.derived_categoricals.items():
+        # After __post_init__, values are always DiscreteGrid.
+        dc: Mapping[str, DiscreteGrid] = regime.derived_categoricals  # ty: ignore[invalid-assignment]
+        for name, grid in dc.items():
             if name in grids and grids[name].categories != grid.categories:
                 msg = (
                     f"Derived categorical '{name}' conflicts with "
@@ -586,7 +588,7 @@ def _build_level_mappings_for_param(
                 f"Unrecognised indexing parameter '{param}'. Expected 'age' "
                 f"or a discrete grid name ({sorted(grids)}). If "
                 f"'{param}' is a DAG function output, add "
-                f'derived_categoricals={{"{param}": DiscreteGrid(...)}} '
+                f'derived_categoricals={{"{param}": {param.title()}Class}} '
                 f"to the Regime or Model constructor."
             )
             raise ValueError(msg)

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -339,7 +339,7 @@ def array_from_series(
         regimes: Mapping of regime names to user Regime instances.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
-        regime_name: Regime for action grid lookup.
+        regime_name: Regime for grid and derived categorical lookup.
 
     Returns:
         JAX array with axes corresponding to the indexing parameters in
@@ -430,6 +430,16 @@ def _resolve_categoricals(
             grids[name] = grid
     else:
         grids.update(_build_discrete_grid_lookup(regimes))
+        for regime in regimes.values():
+            for name, grid in regime.derived_categoricals.items():
+                if name in grids and grids[name].categories != grid.categories:
+                    msg = (
+                        f"Derived categorical '{name}' conflicts with "
+                        f"model grid: {grid.categories} vs "
+                        f"{grids[name].categories}."
+                    )
+                    raise ValueError(msg)
+                grids[name] = grid
     return grids
 
 

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -169,8 +169,6 @@ def convert_series_in_params(
     regimes: Mapping[str, Regime],
     ages: AgeGrid,
     regime_names_to_ids: RegimeNamesToIds,
-    derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-    | None = None,
 ) -> InternalParams:
     """Convert pd.Series leaves in already-broadcast internal params to JAX arrays.
 
@@ -180,6 +178,9 @@ def convert_series_in_params(
     traversed and any Series inside are converted. Other values (scalars,
     existing arrays) pass through unchanged.
 
+    Each regime's `derived_categoricals` field is used to resolve index
+    levels that correspond to DAG function outputs (not states/actions).
+
     Args:
         internal_params: Already-broadcast params in template shape
             (`{regime: {func__param: value}}`).
@@ -187,9 +188,6 @@ def convert_series_in_params(
         ages: Age grid for the model.
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
-        derived_categoricals: Extra categorical mappings (level name to
-            grid) for derived variables not in the model's state/action
-            grids.
 
     Returns:
         Immutable mapping with the same structure, Series replaced by JAX
@@ -217,7 +215,6 @@ def convert_series_in_params(
                     ages=ages,
                     regime_names_to_ids=regime_names_to_ids,
                     regime_name=regime_name,
-                    derived_categoricals=derived_categoricals,
                 )
                 continue
 
@@ -238,7 +235,6 @@ def convert_series_in_params(
                 ages=ages,
                 regime_names_to_ids=regime_names_to_ids,
                 regime_name=regime_name,
-                derived_categoricals=derived_categoricals,
             )
         result[regime_name] = converted_regime
     return cast(
@@ -257,8 +253,6 @@ def _convert_param_value(
     ages: AgeGrid,
     regime_names_to_ids: RegimeNamesToIds,
     regime_name: str | None,
-    derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-    | None = None,
 ) -> object:
     """Convert a single param value, dispatching on type.
 
@@ -273,8 +267,6 @@ def _convert_param_value(
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
         regime_name: Regime name for action grid lookup.
-        derived_categoricals: Extra categorical mappings (level name to
-            grid).
 
     Returns:
         Converted value: JAX array for Series, MappingLeaf with converted
@@ -292,7 +284,6 @@ def _convert_param_value(
             ages=ages,
             regime_names_to_ids=regime_names_to_ids,
             regime_name=regime_name,
-            derived_categoricals=derived_categoricals,
         )
 
     if isinstance(value, pd.Series):
@@ -305,7 +296,6 @@ def _convert_param_value(
             ages=ages,
             regime_names_to_ids=regime_names_to_ids,
             regime_name=regime_name,
-            derived_categoricals=derived_categoricals,
         )
     if isinstance(value, MappingLeaf):
         return MappingLeaf({k: _recurse(v) for k, v in value.data.items()})
@@ -324,8 +314,6 @@ def array_from_series(
     ages: AgeGrid,
     regime_names_to_ids: RegimeNamesToIds,
     regime_name: str | None = None,
-    derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-    | None = None,
 ) -> Array:
     """Convert a pandas Series to a JAX array.
 
@@ -338,6 +326,9 @@ def array_from_series(
     Missing grid points are filled with NaN. Extra ages outside the model's
     `AgeGrid` are silently dropped.
 
+    Derived categoricals are read from `regimes[regime_name].derived_categoricals`
+    when `regime_name` is not None.
+
     Args:
         sr: Labeled pandas Series.
         func: The function that uses this array parameter. `None` for
@@ -349,9 +340,6 @@ def array_from_series(
         regime_names_to_ids: Immutable mapping from regime names to integer
             indices.
         regime_name: Regime for action grid lookup.
-        derived_categoricals: Extra categorical mappings (level name to
-            grid) for derived variables not in the model's state/action
-            grids.
 
     Returns:
         JAX array with axes corresponding to the indexing parameters in
@@ -372,7 +360,6 @@ def array_from_series(
     grids = _resolve_categoricals(
         regimes=regimes,
         regime_name=regime_name,
-        derived_categoricals=derived_categoricals,
     )
 
     # Replace internal "period" with user-facing "age"
@@ -407,99 +394,43 @@ def _resolve_categoricals(
     *,
     regimes: Mapping[str, Regime],
     regime_name: str | None,
-    derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
-    | None,
 ) -> dict[str, DiscreteGrid]:
-    """Build combined categorical lookup from model grids and explicit overrides.
+    """Build combined categorical lookup from model grids and regime overrides.
 
-    Derived categoricals can be provided at two levels:
-
-    - Model-level: `{"var": grid}` — applies to all regimes.
-    - Regime-level: `{"var": {"regime_a": grid_a, "regime_b": grid_b}}` —
-      the grid for `regime_name` is selected.
+    Collect discrete state and action grids, then merge in the regime's
+    `derived_categoricals` (grids for DAG function outputs).
 
     Args:
         regimes: Mapping of regime names to user Regime instances.
-        regime_name: Regime for action grid discovery and regime-level
-            categorical resolution.
-        derived_categoricals: Explicit categorical mappings. Values are
-            either a `DiscreteGrid` (model-level) or a `Mapping` from
-            regime names to `DiscreteGrid` (regime-level).
+        regime_name: Regime for grid discovery. When `None`, grids from
+            all regimes are merged.
 
     Returns:
         Dict mapping variable names to `DiscreteGrid` instances.
 
     Raises:
-        ValueError: If a key in `derived_categoricals` already exists in
-            the model grids with different categories.
+        ValueError: If a derived categorical conflicts with a model grid.
 
     """
     grids: dict[str, DiscreteGrid] = {}
     if regime_name is not None:
-        # Use only this regime's grids (avoids cross-regime inconsistencies
-        # like health having different categories pre-65 vs post-65).
         regime = regimes[regime_name]
         grids.update(
             {n: g for n, g in regime.states.items() if isinstance(g, DiscreteGrid)}
         )
         grids.update(_build_discrete_action_lookup(regime))
+        for name, grid in regime.derived_categoricals.items():
+            if name in grids and grids[name].categories != grid.categories:
+                msg = (
+                    f"Derived categorical '{name}' conflicts with "
+                    f"model grid: {grid.categories} vs "
+                    f"{grids[name].categories}."
+                )
+                raise ValueError(msg)
+            grids[name] = grid
     else:
         grids.update(_build_discrete_grid_lookup(regimes))
-    if derived_categoricals is not None:
-        for name, entry in derived_categoricals.items():
-            grid = _resolve_categorical_entry(
-                name=name, entry=entry, regime_name=regime_name
-            )
-            if grid is None:
-                continue
-            if name in grids:
-                if grids[name].categories != grid.categories:
-                    msg = (
-                        f"Explicit categorical '{name}' conflicts with "
-                        f"model grid: {grid.categories} vs "
-                        f"{grids[name].categories}."
-                    )
-                    raise ValueError(msg)
-            else:
-                grids[name] = grid
     return grids
-
-
-def _resolve_categorical_entry(
-    *,
-    name: str,
-    entry: DiscreteGrid | Mapping[str, DiscreteGrid],
-    regime_name: str | None,
-) -> DiscreteGrid | None:
-    """Resolve a single derived_categoricals entry to a grid.
-
-    Args:
-        name: Variable name.
-        entry: Either a `DiscreteGrid` (model-level) or a `Mapping` from
-            regime names to `DiscreteGrid` (regime-level).
-        regime_name: Current regime name for regime-level resolution.
-
-    Returns:
-        The resolved `DiscreteGrid`, or `None` if the regime-level entry
-        doesn't have a grid for the current regime.
-
-    """
-    if isinstance(entry, DiscreteGrid):
-        return entry
-    if isinstance(entry, Mapping):
-        if regime_name is None:
-            msg = (
-                f"Regime-level categorical '{name}' requires a resolved "
-                f"regime_name, but regime_name is None. Use a fully "
-                f"qualified 3-part param_path."
-            )
-            raise ValueError(msg)
-        return entry.get(regime_name)
-    msg = (
-        f"Categorical '{name}' must be a DiscreteGrid or a Mapping "
-        f"from regime names to DiscreteGrid. Got {type(entry).__name__}."
-    )
-    raise TypeError(msg)
 
 
 def _resolve_per_target_template_key(
@@ -654,9 +585,9 @@ def _build_level_mappings_for_param(
             msg = (
                 f"Unrecognised indexing parameter '{param}'. Expected 'age' "
                 f"or a discrete grid name ({sorted(grids)}). If "
-                f"'{param}' is a DAG function output, pass "
+                f"'{param}' is a DAG function output, add "
                 f'derived_categoricals={{"{param}": DiscreteGrid(...)}} '
-                f"to solve() / simulate()."
+                f"to the Regime or Model constructor."
             )
             raise ValueError(msg)
     return tuple(mappings)

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -415,10 +415,10 @@ def _resolve_categoricals(
     grids: dict[str, DiscreteGrid] = {}
     if regime_name is not None:
         regime = regimes[regime_name]
-        grids.update(
-            {n: g for n, g in regime.states.items() if isinstance(g, DiscreteGrid)}
-        )
-        grids.update(_build_discrete_action_lookup(regime))
+        for grids_mapping in (regime.states, regime.actions):
+            grids.update(
+                {n: g for n, g in grids_mapping.items() if isinstance(g, DiscreteGrid)}
+            )
         for name, grid in regime.derived_categoricals.items():
             if name in grids and grids[name].categories != grid.categories:
                 msg = (
@@ -792,48 +792,32 @@ def _collect_state_names(
 def _build_discrete_grid_lookup(
     regimes: Mapping[str, Regime],
 ) -> dict[str, DiscreteGrid]:
-    """Collect all DiscreteGrid instances across regimes, verifying consistency.
+    """Collect all DiscreteGrid instances from states and actions across regimes.
 
     Args:
         regimes: Mapping of regime names to Regime instances.
 
     Returns:
-        dict mapping state name to DiscreteGrid.
+        Dict mapping variable name to DiscreteGrid.
 
     Raises:
-        ValueError: If two regimes define the same state with different categories.
+        ValueError: If two regimes define the same variable with different categories.
 
     """
     lookup: dict[str, DiscreteGrid] = {}
     for regime_name, regime in regimes.items():
-        for state_name, grid in regime.states.items():
-            if isinstance(grid, DiscreteGrid):
-                if state_name in lookup:
-                    if lookup[state_name].categories != grid.categories:
-                        msg = (
-                            f"Inconsistent DiscreteGrid for state '{state_name}': "
-                            f"regime '{regime_name}' has categories "
-                            f"{grid.categories}, but a previous regime has "
-                            f"{lookup[state_name].categories}."
-                        )
-                        raise ValueError(msg)
-                else:
-                    lookup[state_name] = grid
+        for grids_mapping in (regime.states, regime.actions):
+            for var_name, grid in grids_mapping.items():
+                if isinstance(grid, DiscreteGrid):
+                    if var_name in lookup:
+                        if lookup[var_name].categories != grid.categories:
+                            msg = (
+                                f"Inconsistent DiscreteGrid for '{var_name}': "
+                                f"regime '{regime_name}' has categories "
+                                f"{grid.categories}, but a previous regime has "
+                                f"{lookup[var_name].categories}."
+                            )
+                            raise ValueError(msg)
+                    else:
+                        lookup[var_name] = grid
     return lookup
-
-
-def _build_discrete_action_lookup(regime: Regime) -> dict[str, DiscreteGrid]:
-    """Collect DiscreteGrid instances from a regime's actions.
-
-    Args:
-        regime: The Regime instance.
-
-    Returns:
-        dict mapping action name to DiscreteGrid.
-
-    """
-    return {
-        name: grid
-        for name, grid in regime.actions.items()
-        if isinstance(grid, DiscreteGrid)
-    }

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import jax.numpy as jnp
 import numpy as np
@@ -14,14 +14,10 @@ from jax import Array
 from lcm.ages import AgeGrid
 from lcm.grids import DiscreteGrid, IrregSpacedGrid
 from lcm.params import MappingLeaf
-
-if TYPE_CHECKING:
-    from lcm.model import Model  # avoid circular import: pandas_utils ↔ model
-
 from lcm.params.sequence_leaf import SequenceLeaf
 from lcm.regime import Regime
 from lcm.shocks import _ShockGrid
-from lcm.typing import InternalParams
+from lcm.typing import InternalParams, RegimeNamesToIds
 from lcm.utils.error_handling import (
     _get_func_indexing_params,
 )
@@ -46,18 +42,20 @@ def has_series(params: Mapping) -> bool:
 def initial_conditions_from_dataframe(
     *,
     df: pd.DataFrame,
-    model: Model,
+    regimes: Mapping[str, Regime],
+    regime_names_to_ids: RegimeNamesToIds,
 ) -> dict[str, Array]:
     """Convert a DataFrame of initial conditions to LCM initial conditions format.
 
     Args:
         df: DataFrame with columns for states and a "regime" column.
-        model: The LCM Model instance.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
 
     Returns:
         Dict mapping state names (plus `"regime"`) to JAX arrays. The
         `"regime"` entry contains integer codes derived from the `"regime"`
-        column via `model.regime_names_to_ids`.
+        column via `regime_names_to_ids`.
 
     Raises:
         ValueError: If the DataFrame is empty, the "regime" column is missing,
@@ -74,7 +72,7 @@ def initial_conditions_from_dataframe(
         raise ValueError(msg)
 
     # Validate regime names
-    valid_regimes = set(model.regime_names_to_ids.keys())
+    valid_regimes = set(regime_names_to_ids.keys())
     invalid = set(df["regime"]) - valid_regimes
     if invalid:
         msg = (
@@ -86,7 +84,7 @@ def initial_conditions_from_dataframe(
     state_columns = {col for col in df.columns if col != "regime"}
     _validate_state_columns(
         state_columns=state_columns,
-        regimes=model.regimes,
+        regimes=regimes,
         initial_regimes=df["regime"].tolist(),
     )
 
@@ -101,7 +99,7 @@ def initial_conditions_from_dataframe(
 
     # Process per regime group (vectorised .map() within each group)
     for regime_name, group in df.groupby("regime"):
-        regime = model.regimes[str(regime_name)]
+        regime = regimes[str(regime_name)]
         idx = group.index
         discrete_grids = {
             name: grid
@@ -134,7 +132,7 @@ def initial_conditions_from_dataframe(
         for col, arr in result_arrays.items()
     }
     initial_conditions["regime"] = jnp.array(
-        df["regime"].map(dict(model.regime_names_to_ids)).to_numpy()
+        df["regime"].map(dict(regime_names_to_ids)).to_numpy()
     )
 
     return initial_conditions
@@ -167,7 +165,9 @@ def _map_discrete_labels(
 def convert_series_in_params(
     *,
     internal_params: Mapping[str, Mapping[str, object]],
-    model: Model,
+    regimes: Mapping[str, Regime],
+    ages: AgeGrid,
+    regime_names_to_ids: RegimeNamesToIds,
     derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
     | None = None,
 ) -> InternalParams:
@@ -182,7 +182,10 @@ def convert_series_in_params(
     Args:
         internal_params: Already-broadcast params in template shape
             (`{regime: {func__param: value}}`).
-        model: The LCM Model instance.
+        regimes: Mapping of regime names to user Regime instances.
+        ages: Age grid for the model.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
         derived_categoricals: Extra categorical mappings (level name to
             grid) for derived variables not in the model's state/action
             grids.
@@ -194,7 +197,7 @@ def convert_series_in_params(
     """
     result: dict[str, dict[str, object]] = {}
     for regime_name, regime_params in internal_params.items():
-        regime = model.regimes[regime_name]
+        regime = regimes[regime_name]
         all_funcs = regime.get_all_functions()
         converted_regime: dict[str, object] = {}
         for func_param, value in regime_params.items():
@@ -209,7 +212,9 @@ def convert_series_in_params(
                     func=None,
                     param_name=param_name,
                     func_name=template_func_name,
-                    model=model,
+                    regimes=regimes,
+                    ages=ages,
+                    regime_names_to_ids=regime_names_to_ids,
                     regime_name=regime_name,
                     derived_categoricals=derived_categoricals,
                 )
@@ -228,7 +233,9 @@ def convert_series_in_params(
                 func=func,
                 param_name=param_name,
                 func_name=resolved_func_name,
-                model=model,
+                regimes=regimes,
+                ages=ages,
+                regime_names_to_ids=regime_names_to_ids,
                 regime_name=regime_name,
                 derived_categoricals=derived_categoricals,
             )
@@ -245,7 +252,9 @@ def _convert_param_value(
     func: Callable | None,
     param_name: str,
     func_name: str,
-    model: Model,
+    regimes: Mapping[str, Regime],
+    ages: AgeGrid,
+    regime_names_to_ids: RegimeNamesToIds,
     regime_name: str | None,
     derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
     | None = None,
@@ -258,7 +267,10 @@ def _convert_param_value(
             grid params — triggers scalar passthrough).
         param_name: Parameter name in the function.
         func_name: Function name (for `next_*` outcome axis detection).
-        model: The LCM Model instance.
+        regimes: Mapping of regime names to user Regime instances.
+        ages: Age grid for the model.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
         regime_name: Regime name for action grid lookup.
         derived_categoricals: Extra categorical mappings (level name to
             grid).
@@ -275,7 +287,9 @@ def _convert_param_value(
             func=func,
             param_name=param_name,
             func_name=func_name,
-            model=model,
+            regimes=regimes,
+            ages=ages,
+            regime_names_to_ids=regime_names_to_ids,
             regime_name=regime_name,
             derived_categoricals=derived_categoricals,
         )
@@ -286,7 +300,9 @@ def _convert_param_value(
             func=func,
             param_name=param_name,
             func_name=func_name,
-            model=model,
+            regimes=regimes,
+            ages=ages,
+            regime_names_to_ids=regime_names_to_ids,
             regime_name=regime_name,
             derived_categoricals=derived_categoricals,
         )
@@ -303,7 +319,9 @@ def array_from_series(
     func: Callable | None,
     param_name: str,
     func_name: str,
-    model: Model,
+    regimes: Mapping[str, Regime],
+    ages: AgeGrid,
+    regime_names_to_ids: RegimeNamesToIds,
     regime_name: str | None = None,
     derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
     | None = None,
@@ -325,7 +343,10 @@ def array_from_series(
             runtime grid/shock params (triggers scalar passthrough).
         param_name: The array parameter name in `func`.
         func_name: Function name (for `next_*` outcome axis detection).
-        model: The LCM Model instance.
+        regimes: Mapping of regime names to user Regime instances.
+        ages: Age grid for the model.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
         regime_name: Regime for action grid lookup.
         derived_categoricals: Extra categorical mappings (level name to
             grid) for derived variables not in the model's state/action
@@ -348,7 +369,7 @@ def array_from_series(
         return jnp.array(sr.to_numpy(), dtype=float)
 
     grids = _resolve_categoricals(
-        model=model,
+        regimes=regimes,
         regime_name=regime_name,
         derived_categoricals=derived_categoricals,
     )
@@ -357,7 +378,7 @@ def array_from_series(
     display_params = ["age" if p == "period" else p for p in indexing_params]
 
     level_mappings = _build_level_mappings_for_param(
-        indexing_params=display_params, grids=grids, ages=model.ages
+        indexing_params=display_params, grids=grids, ages=ages
     )
 
     # Append outcome axis for transition probability arrays (next_* functions
@@ -368,20 +389,22 @@ def array_from_series(
         ]
         if next_levels:
             outcome_mapping = _build_outcome_mapping(
-                func_name=func_name, grids=grids, model=model
+                func_name=func_name,
+                grids=grids,
+                regime_names_to_ids=regime_names_to_ids,
             )
             level_mappings = (*level_mappings, outcome_mapping)
 
     if "age" in display_params:
         _fail_if_period_level(sr)
-        sr = _filter_to_grid_ages(series=sr, ages=model.ages)
+        sr = _filter_to_grid_ages(series=sr, ages=ages)
 
     return _scatter_series(series=sr, level_mappings=level_mappings)
 
 
 def _resolve_categoricals(
     *,
-    model: Model,
+    regimes: Mapping[str, Regime],
     regime_name: str | None,
     derived_categoricals: Mapping[str, DiscreteGrid | Mapping[str, DiscreteGrid]]
     | None,
@@ -395,7 +418,7 @@ def _resolve_categoricals(
       the grid for `regime_name` is selected.
 
     Args:
-        model: The LCM Model instance.
+        regimes: Mapping of regime names to user Regime instances.
         regime_name: Regime for action grid discovery and regime-level
             categorical resolution.
         derived_categoricals: Explicit categorical mappings. Values are
@@ -414,13 +437,13 @@ def _resolve_categoricals(
     if regime_name is not None:
         # Use only this regime's grids (avoids cross-regime inconsistencies
         # like health having different categories pre-65 vs post-65).
-        regime = model.regimes[regime_name]
+        regime = regimes[regime_name]
         grids.update(
             {n: g for n, g in regime.states.items() if isinstance(g, DiscreteGrid)}
         )
         grids.update(_build_discrete_action_lookup(regime))
     else:
-        grids.update(_build_discrete_grid_lookup(model.regimes))
+        grids.update(_build_discrete_grid_lookup(regimes))
     if derived_categoricals is not None:
         for name, entry in derived_categoricals.items():
             grid = _resolve_categorical_entry(
@@ -642,24 +665,25 @@ def _build_outcome_mapping(
     *,
     func_name: str,
     grids: dict[str, DiscreteGrid],
-    model: Model,
+    regime_names_to_ids: RegimeNamesToIds,
 ) -> _LevelMapping:
     """Build a `_LevelMapping` for the outcome axis of a `next_*` function.
 
     For state transitions (e.g. `"next_partner"`), look up the state grid.
-    For regime transitions (`"next_regime"`), use `model.regime_names_to_ids`.
+    For regime transitions (`"next_regime"`), use `regime_names_to_ids`.
 
     Args:
         func_name: Function name starting with `"next_"`.
         grids: Categorical grid lookup.
-        model: The LCM Model instance.
+        regime_names_to_ids: Immutable mapping from regime names to integer
+            indices.
 
     Returns:
         `_LevelMapping` for the outcome (last) axis.
 
     """
     if func_name == "next_regime":
-        regime_ids = dict(model.regime_names_to_ids)
+        regime_ids = dict(regime_names_to_ids)
         return _LevelMapping(
             name="next_regime",
             size=len(regime_ids),

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -74,10 +74,10 @@ def initial_conditions_from_dataframe(
 
     # Validate regime names
     valid_regimes = set(regime_names_to_ids.keys())
-    invalid = set(df["regime"]) - valid_regimes
-    if invalid:
+    invalid_regimes = set(df["regime"]) - valid_regimes
+    if invalid_regimes:
         msg = (
-            f"Invalid regime names in 'regime' column: {sorted(invalid)}. "
+            f"Invalid regime names in 'regime' column: {sorted(invalid_regimes)}. "
             f"Valid regimes: {sorted(valid_regimes)}."
         )
         raise ValueError(msg)

--- a/src/lcm/regime.py
+++ b/src/lcm/regime.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 from typing import Any, Literal, TypeAliasType, cast, overload
 
 from lcm.exceptions import RegimeInitializationError
-from lcm.grids import Grid
+from lcm.grids import DiscreteGrid, Grid
 from lcm.interfaces import SolveSimulateFunctionPair
 from lcm.typing import (
     ActiveFunction,
@@ -156,6 +156,11 @@ class Regime:
     )
     """Mapping of constraint names to constraint functions."""
 
+    derived_categoricals: Mapping[str, DiscreteGrid] = field(
+        default_factory=lambda: MappingProxyType({})
+    )
+    """Categorical grids for DAG function outputs not in states/actions."""
+
     description: str = ""
     """Description of the regime."""
 
@@ -191,6 +196,7 @@ class Regime:
         make_immutable("state_transitions")
         make_immutable("actions")
         make_immutable("constraints")
+        make_immutable("derived_categoricals")
 
     def get_all_functions(
         self,

--- a/src/lcm/regime.py
+++ b/src/lcm/regime.py
@@ -156,15 +156,10 @@ class Regime:
     )
     """Mapping of constraint names to constraint functions."""
 
-    derived_categoricals: Mapping[str, type | DiscreteGrid] = field(
+    derived_categoricals: Mapping[str, DiscreteGrid] = field(
         default_factory=lambda: MappingProxyType({})
     )
-    """Categorical grids for DAG function outputs not in states/actions.
-
-    Values can be categorical classes (created with `@categorical`) or
-    `DiscreteGrid` instances. Raw classes are wrapped in `DiscreteGrid`
-    automatically.
-    """
+    """Categorical grids for DAG function outputs not in states/actions."""
 
     description: str = ""
     """Description of the regime."""
@@ -201,16 +196,7 @@ class Regime:
         make_immutable("state_transitions")
         make_immutable("actions")
         make_immutable("constraints")
-        object.__setattr__(
-            self,
-            "derived_categoricals",
-            MappingProxyType(
-                {
-                    k: v if isinstance(v, DiscreteGrid) else DiscreteGrid(v)
-                    for k, v in self.derived_categoricals.items()
-                }
-            ),
-        )
+        make_immutable("derived_categoricals")
 
     def get_all_functions(
         self,

--- a/src/lcm/regime.py
+++ b/src/lcm/regime.py
@@ -156,10 +156,15 @@ class Regime:
     )
     """Mapping of constraint names to constraint functions."""
 
-    derived_categoricals: Mapping[str, DiscreteGrid] = field(
+    derived_categoricals: Mapping[str, type | DiscreteGrid] = field(
         default_factory=lambda: MappingProxyType({})
     )
-    """Categorical grids for DAG function outputs not in states/actions."""
+    """Categorical grids for DAG function outputs not in states/actions.
+
+    Values can be categorical classes (created with `@categorical`) or
+    `DiscreteGrid` instances. Raw classes are wrapped in `DiscreteGrid`
+    automatically.
+    """
 
     description: str = ""
     """Description of the regime."""
@@ -196,7 +201,16 @@ class Regime:
         make_immutable("state_transitions")
         make_immutable("actions")
         make_immutable("constraints")
-        make_immutable("derived_categoricals")
+        object.__setattr__(
+            self,
+            "derived_categoricals",
+            MappingProxyType(
+                {
+                    k: v if isinstance(v, DiscreteGrid) else DiscreteGrid(v)
+                    for k, v in self.derived_categoricals.items()
+                }
+            ),
+        )
 
     def get_all_functions(
         self,

--- a/src/lcm_examples/mahler_yum_2024/_model.py
+++ b/src/lcm_examples/mahler_yum_2024/_model.py
@@ -623,6 +623,7 @@ def create_inputs(
                 prod = prod.at[index].set(j - 1)
                 ht = ht.at[index].set(1 - (k - 1))
                 discount = discount.at[index].set(i - 1)
+                discount = discount.at[index + 8].set(i - 1)
                 prod = prod.at[index + 8].set(j - 1)
                 ht = ht.at[index + 8].set(1 - (k - 1))
                 ed = ed.at[index + 8].set(1)

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -1785,3 +1785,27 @@ def test_resolve_categoricals_conflict_raises() -> None:
             regimes={"working_life": conflicting_regime},
             regime_name="working_life",
         )
+
+
+def test_resolve_categoricals_includes_derived_when_no_regime_name() -> None:
+    """derived_categoricals are included even when regime_name is None."""
+    from lcm.pandas_utils import _resolve_categoricals  # noqa: PLC0415
+
+    model = get_stochastic_model(3)
+
+    @categorical(ordered=False)
+    class ExtraVar:
+        a: int
+        b: int
+
+    updated_regimes = {
+        name: dataclasses.replace(
+            r, derived_categoricals={"extra": DiscreteGrid(ExtraVar)}
+        )
+        for name, r in model.regimes.items()
+    }
+    grids = _resolve_categoricals(
+        regimes=updated_regimes,
+        regime_name=None,
+    )
+    assert "extra" in grids

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -289,8 +289,8 @@ def test_shock_state_columns_accepted():
     assert "regime" in conditions
 
 
-def test_shock_state_columns_optional():
-    """DataFrame without shock columns is accepted (shocks are optional)."""
+def test_shock_state_columns_required():
+    """DataFrame without shock columns raises (shocks are required)."""
     model = get_shock_model(n_periods=4, distribution_type="uniform")
     df = pd.DataFrame(
         {
@@ -300,9 +300,8 @@ def test_shock_state_columns_optional():
             "age": [0.0, 0.0],
         }
     )
-    conditions = initial_conditions_from_dataframe(df=df, model=model)
-    assert "income" not in conditions
-    assert jnp.allclose(conditions["wealth"], jnp.array([2.0, 4.0]))
+    with pytest.raises(ValueError, match=r"Missing required state columns.*income"):
+        initial_conditions_from_dataframe(df=df, model=model)
 
 
 def test_round_trip_with_discrete_model():

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -32,6 +32,7 @@ from tests.test_models.basic_discrete import (
     get_model as get_basic_model,
 )
 from tests.test_models.regime_markov import get_model as get_regime_markov_model
+from tests.test_models.shock_grids import get_model as get_shock_model
 from tests.test_models.stochastic import get_model as get_stochastic_model
 
 
@@ -268,6 +269,40 @@ def test_missing_state_column_raises():
     )
     with pytest.raises(ValueError, match="Missing required"):
         initial_conditions_from_dataframe(df=df, model=model)
+
+
+def test_shock_state_columns_accepted():
+    """Shock grid columns are accepted as continuous float columns."""
+    model = get_shock_model(n_periods=4, distribution_type="uniform")
+    df = pd.DataFrame(
+        {
+            "regime": ["alive", "alive"],
+            "wealth": [2.0, 4.0],
+            "health": ["bad", "good"],
+            "income": [0.3, 0.7],
+            "age": [0.0, 0.0],
+        }
+    )
+    conditions = initial_conditions_from_dataframe(df=df, model=model)
+    assert jnp.allclose(conditions["income"], jnp.array([0.3, 0.7]))
+    assert jnp.allclose(conditions["wealth"], jnp.array([2.0, 4.0]))
+    assert "regime" in conditions
+
+
+def test_shock_state_columns_optional():
+    """DataFrame without shock columns is accepted (shocks are optional)."""
+    model = get_shock_model(n_periods=4, distribution_type="uniform")
+    df = pd.DataFrame(
+        {
+            "regime": ["alive", "alive"],
+            "wealth": [2.0, 4.0],
+            "health": ["bad", "good"],
+            "age": [0.0, 0.0],
+        }
+    )
+    conditions = initial_conditions_from_dataframe(df=df, model=model)
+    assert "income" not in conditions
+    assert jnp.allclose(conditions["wealth"], jnp.array([2.0, 4.0]))
 
 
 def test_round_trip_with_discrete_model():

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -135,7 +135,11 @@ def test_continuous_states_and_age():
             "age": [25.0, 35.0],
         }
     )
-    conditions = initial_conditions_from_dataframe(df=df, model=model)
+    conditions = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     assert jnp.array_equal(
         conditions["regime"],
         jnp.array([BasicRegimeId.working_life, BasicRegimeId.working_life]),
@@ -154,7 +158,11 @@ def test_categorical_string_labels():
             "age": [25.0, 25.0],
         }
     )
-    conditions = initial_conditions_from_dataframe(df=df, model=model)
+    conditions = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     assert jnp.array_equal(
         conditions["regime"],
         jnp.array([BasicRegimeId.working_life, BasicRegimeId.retirement]),
@@ -173,7 +181,11 @@ def test_categorical_pd_categorical_column():
             "age": [25.0, 25.0],
         }
     )
-    conditions = initial_conditions_from_dataframe(df=df, model=model)
+    conditions = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     assert jnp.array_equal(conditions["health"], jnp.array([Health.good, Health.bad]))
 
 
@@ -187,7 +199,11 @@ def test_multi_regime():
             "age": [25.0, 25.0, 25.0],
         }
     )
-    conditions = initial_conditions_from_dataframe(df=df, model=model)
+    conditions = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     assert jnp.array_equal(
         conditions["regime"],
         jnp.array(
@@ -205,7 +221,11 @@ def test_missing_regime_column_raises():
     model = get_basic_model()
     df = pd.DataFrame({"wealth": [10.0]})
     with pytest.raises(ValueError, match="'regime' column"):
-        initial_conditions_from_dataframe(df=df, model=model)
+        initial_conditions_from_dataframe(
+            df=df,
+            regimes=model.regimes,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
 
 def test_invalid_regime_name_raises():
@@ -217,7 +237,11 @@ def test_invalid_regime_name_raises():
         }
     )
     with pytest.raises(ValueError, match="Invalid regime names"):
-        initial_conditions_from_dataframe(df=df, model=model)
+        initial_conditions_from_dataframe(
+            df=df,
+            regimes=model.regimes,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
 
 def test_invalid_category_label_raises():
@@ -231,7 +255,11 @@ def test_invalid_category_label_raises():
         }
     )
     with pytest.raises(ValueError, match="Invalid labels"):
-        initial_conditions_from_dataframe(df=df, model=model)
+        initial_conditions_from_dataframe(
+            df=df,
+            regimes=model.regimes,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
 
 def test_empty_dataframe_raises():
@@ -240,7 +268,11 @@ def test_empty_dataframe_raises():
         {"regime": pd.Series([], dtype=str), "wealth": pd.Series([], dtype=float)}
     )
     with pytest.raises(ValueError, match="empty"):
-        initial_conditions_from_dataframe(df=df, model=model)
+        initial_conditions_from_dataframe(
+            df=df,
+            regimes=model.regimes,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
 
 def test_unknown_column_raises():
@@ -255,7 +287,11 @@ def test_unknown_column_raises():
         }
     )
     with pytest.raises(ValueError, match="Unknown columns"):
-        initial_conditions_from_dataframe(df=df, model=model)
+        initial_conditions_from_dataframe(
+            df=df,
+            regimes=model.regimes,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
 
 def test_missing_state_column_raises():
@@ -268,7 +304,11 @@ def test_missing_state_column_raises():
         }
     )
     with pytest.raises(ValueError, match="Missing required"):
-        initial_conditions_from_dataframe(df=df, model=model)
+        initial_conditions_from_dataframe(
+            df=df,
+            regimes=model.regimes,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
 
 def test_shock_state_columns_accepted():
@@ -283,7 +323,11 @@ def test_shock_state_columns_accepted():
             "age": [0.0, 0.0],
         }
     )
-    conditions = initial_conditions_from_dataframe(df=df, model=model)
+    conditions = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     assert jnp.allclose(conditions["income"], jnp.array([0.3, 0.7]))
     assert jnp.allclose(conditions["wealth"], jnp.array([2.0, 4.0]))
     assert "regime" in conditions
@@ -301,7 +345,11 @@ def test_shock_state_columns_required():
         }
     )
     with pytest.raises(ValueError, match=r"Missing required state columns.*income"):
-        initial_conditions_from_dataframe(df=df, model=model)
+        initial_conditions_from_dataframe(
+            df=df,
+            regimes=model.regimes,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
 
 def test_round_trip_with_discrete_model():
@@ -337,7 +385,11 @@ def test_round_trip_with_discrete_model():
             "age": [50.0, 50.0],
         }
     )
-    df_conditions = initial_conditions_from_dataframe(df=df, model=model)
+    df_conditions = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     result_df = model.simulate(
         params=params,
         initial_conditions=df_conditions,
@@ -423,7 +475,11 @@ def test_initial_conditions_heterogeneous_health_grids() -> None:
             "age": [50.0, 50.0, 70.0, 70.0],
         }
     )
-    result = initial_conditions_from_dataframe(df=df, model=model)
+    result = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
 
     # pre65: disabled=0, good=2; post65: bad=0, good=1
     assert jnp.array_equal(result["health"], jnp.array([0, 2, 0, 1]))
@@ -450,7 +506,12 @@ def test_convert_series_heterogeneous_grids() -> None:
     internal = broadcast_to_template(
         params={"bonus": sr}, template=model._params_template, required=False
     )
-    convert_series_in_params(internal_params=internal, model=model)
+    convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
 
 
 def test_convert_series_next_function_no_outcome_axis() -> None:
@@ -491,7 +552,12 @@ def test_convert_series_next_function_no_outcome_axis() -> None:
     internal = broadcast_to_template(
         params={"rate": sr}, template=m._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=m)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=m.regimes,
+        ages=m.ages,
+        regime_names_to_ids=m.regime_names_to_ids,
+    )
     assert result is not None
 
 
@@ -506,7 +572,11 @@ def test_heterogeneous_health_solve_simulate() -> None:
             "age": [50.0, 50.0, 70.0, 70.0],
         }
     )
-    ic = initial_conditions_from_dataframe(df=df, model=model)
+    ic = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     result = model.simulate(
         params={"bonus": 0.0, "discount_factor": 0.95},
         initial_conditions=ic,
@@ -539,7 +609,11 @@ def test_heterogeneous_health_simulate_use_labels_false() -> None:
             "age": [50.0, 70.0],
         }
     )
-    ic = initial_conditions_from_dataframe(df=df, model=model)
+    ic = initial_conditions_from_dataframe(
+        df=df,
+        regimes=model.regimes,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     result = model.simulate(
         params={"bonus": 0.0, "discount_factor": 0.95},
         initial_conditions=ic,
@@ -598,7 +672,9 @@ def test_array_from_series_transition_basic_round_trip():
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     np.testing.assert_allclose(result, arr, atol=1e-7)
@@ -615,7 +691,9 @@ def test_array_from_series_transition_categorical_labels():
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     # age=40, work, single->partnered
@@ -637,7 +715,9 @@ def test_array_from_series_transition_reordered_levels():
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     np.testing.assert_allclose(result, arr, atol=1e-7)
@@ -659,7 +739,9 @@ def test_array_from_series_transition_wrong_level_names_raises():
             func=func,
             param_name="probs_array",
             func_name="next_partner",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="working_life",
         )
 
@@ -679,7 +761,9 @@ def test_array_from_series_transition_invalid_label_raises():
             func=func,
             param_name="probs_array",
             func_name="next_partner",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="working_life",
         )
 
@@ -699,7 +783,9 @@ def test_array_from_series_transition_period_level_raises():
             func=func,
             param_name="probs_array",
             func_name="next_partner",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="working_life",
         )
 
@@ -719,7 +805,9 @@ def test_array_from_series_transition_duplicate_level_names_raises():
             func=func,
             param_name="probs_array",
             func_name="next_partner",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="working_life",
         )
 
@@ -739,7 +827,9 @@ def test_array_from_series_transition_invalid_age_dropped():
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     # All ages are invalid, so all positions should be NaN
@@ -764,7 +854,9 @@ def test_array_from_series_transition_sparse_input_fills_nan():
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     # age=40 (period 0), work (0), single (0) → provided
@@ -858,7 +950,9 @@ def test_array_from_series_regime_transition_basic_round_trip():
         func=func,
         param_name="probs_array",
         func_name="next_regime",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="alive",
     )
     np.testing.assert_allclose(result, arr, atol=1e-7)
@@ -876,7 +970,9 @@ def test_array_from_series_regime_transition_reordered_levels():
         func=func,
         param_name="probs_array",
         func_name="next_regime",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="alive",
     )
     np.testing.assert_allclose(result, arr, atol=1e-7)
@@ -895,7 +991,9 @@ def test_array_from_series_regime_transition_wrong_level_names_raises():
             func=func,
             param_name="probs_array",
             func_name="next_regime",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="alive",
         )
 
@@ -914,7 +1012,9 @@ def test_array_from_series_regime_transition_invalid_label_raises():
             func=func,
             param_name="probs_array",
             func_name="next_regime",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="alive",
         )
 
@@ -976,7 +1076,9 @@ def test_array_from_series_fully_qualified() -> None:
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     assert result.shape == (3, 2, 2, 2)
@@ -996,7 +1098,9 @@ def test_array_from_series_scalar_param() -> None:
         func=func,
         param_name="wage",
         func_name="labor_income",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     np.testing.assert_allclose(result, jnp.array([10.0]))
@@ -1030,7 +1134,9 @@ def test_array_from_series_extra_ages_dropped() -> None:
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     assert result.shape == (3, 2, 2, 2)
@@ -1061,7 +1167,9 @@ def test_array_from_series_missing_ages_filled_with_nan() -> None:
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     assert result.shape == (3, 2, 2, 2)
@@ -1084,7 +1192,9 @@ def test_array_from_series_reordered_levels() -> None:
         func=func,
         param_name="probs_array",
         func_name="next_partner",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     assert result.shape == (3, 2, 2, 2)
@@ -1106,7 +1216,9 @@ def test_array_from_series_invalid_label_raises() -> None:
             func=func,
             param_name="probs_array",
             func_name="next_partner",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="working_life",
         )
 
@@ -1126,7 +1238,9 @@ def test_array_from_series_wrong_level_names_raises() -> None:
             func=func,
             param_name="probs_array",
             func_name="next_partner",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="working_life",
         )
 
@@ -1147,7 +1261,9 @@ def test_array_from_series_integer_labels_rejected() -> None:
             func=func,
             param_name="probs_array",
             func_name="next_partner",
-            model=model,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
             regime_name="working_life",
         )
 
@@ -1163,7 +1279,9 @@ def test_array_from_series_scalar_param_explicit_lookup() -> None:
         func=func,
         param_name="wage",
         func_name="labor_income",
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         regime_name="working_life",
     )
     np.testing.assert_allclose(result, jnp.array([10.0]))
@@ -1181,7 +1299,12 @@ def test_convert_series_function_level_series() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     arr = result["working_life"]["next_partner__probs_array"]
     assert arr.shape == (3, 2, 2, 2)  # ty: ignore[unresolved-attribute]
     assert float(arr[0, 0, 0, 0]) == pytest.approx(1.0)  # ty: ignore[not-subscriptable]
@@ -1194,7 +1317,12 @@ def test_convert_series_model_level_scalar_passthrough() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     # Model-level param is broadcast to all regimes/functions that need it
     assert result["working_life"]["H__discount_factor"] == 0.95
     assert result["retirement"]["H__discount_factor"] == 0.95
@@ -1212,7 +1340,12 @@ def test_convert_series_regime_level_series() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     arr = result["working_life"]["next_partner__probs_array"]
     assert arr.shape == (3, 2, 2, 2)  # ty: ignore[unresolved-attribute]
 
@@ -1233,7 +1366,12 @@ def test_convert_series_mixed_dict() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     assert result["working_life"]["H__discount_factor"] == 0.95
     assert result["working_life"]["utility__disutility_of_work"] == 0.5
     assert result["working_life"]["next_partner__probs_array"].shape == (3, 2, 2, 2)  # ty: ignore[unresolved-attribute]
@@ -1258,7 +1396,12 @@ def test_convert_series_mapping_leaf() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     converted_leaf = result["working_life"]["next_partner__probs_array"]
     assert isinstance(converted_leaf, MappingLeaf)
     arr = converted_leaf.data["sub_key"]
@@ -1281,7 +1424,12 @@ def test_convert_series_nested_mapping_leaf() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     converted = result["working_life"]["next_partner__probs_array"]
     assert isinstance(converted, MappingLeaf)
     inner_converted = converted.data["inner_leaf"]
@@ -1347,12 +1495,19 @@ def test_convert_series_with_derived_categoricals() -> None:
         params=params, template=model._params_template, required=False
     )
     with pytest.raises(ValueError, match="Unrecognised indexing parameter"):
-        convert_series_in_params(internal_params=internal, model=model)
+        convert_series_in_params(
+            internal_params=internal,
+            regimes=model.regimes,
+            ages=model.ages,
+            regime_names_to_ids=model.regime_names_to_ids,
+        )
 
     # With derived_categoricals providing the labor_supply grid, it succeeds
     result = convert_series_in_params(
         internal_params=internal,
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         derived_categoricals={"labor_supply": labor_grid},
     )
     arr = result["retirement"]["next_partner__probs_array"]
@@ -1429,7 +1584,12 @@ def test_convert_series_per_target_transition() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     arr = result["working"]["to_working_next_health__probs_array"]
     assert arr.shape == (3, 2, 2)  # ty: ignore[unresolved-attribute]
 
@@ -1443,7 +1603,9 @@ def test_build_outcome_mapping_qualified_func_name() -> None:
 
     grids = _build_discrete_grid_lookup(model.regimes)
     result = _build_outcome_mapping(
-        func_name="next_health__working", grids=grids, model=model
+        func_name="next_health__working",
+        grids=grids,
+        regime_names_to_ids=model.regime_names_to_ids,
     )
     assert result.size == 2
     assert result.name == "next_health"
@@ -1520,7 +1682,9 @@ def test_convert_series_structured_derived_categoricals() -> None:
     )
     result_both = convert_series_in_params(
         internal_params=internal,
-        model=model,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
         derived_categoricals={
             "derived": {
                 "regime_a": DiscreteGrid(_ChoiceA),
@@ -1564,7 +1728,12 @@ def test_convert_series_runtime_grid_param() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     np.testing.assert_allclose(result["alive"]["wealth__points"], sr.to_numpy())
 
 
@@ -1579,7 +1748,12 @@ def test_convert_series_sequence_leaf_traversal() -> None:
     internal = broadcast_to_template(
         params=params, template=model._params_template, required=False
     )
-    result = convert_series_in_params(internal_params=internal, model=model)
+    result = convert_series_in_params(
+        internal_params=internal,
+        regimes=model.regimes,
+        ages=model.ages,
+        regime_names_to_ids=model.regime_names_to_ids,
+    )
     converted = result["working_life"]["labor_income__wage"]
     assert isinstance(converted, SequenceLeaf)
     assert not isinstance(converted.data[0], pd.Series)
@@ -1600,7 +1774,7 @@ def test_resolve_categoricals_conflict_raises() -> None:
     conflicting = {"partner": DiscreteGrid(WrongPartner)}
     with pytest.raises(ValueError, match="conflicts with model grid"):
         _resolve_categoricals(
-            model=model,
+            regimes=model.regimes,
             regime_name="working_life",
             derived_categoricals=conflicting,
         )

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -1,5 +1,7 @@
 """Tests for lcm.pandas_utils and categorical.to_categorical_dtype."""
 
+import dataclasses
+
 import jax.numpy as jnp
 import numpy as np
 import pandas as pd
@@ -1502,13 +1504,20 @@ def test_convert_series_with_derived_categoricals() -> None:
             regime_names_to_ids=model.regime_names_to_ids,
         )
 
-    # With derived_categoricals providing the labor_supply grid, it succeeds
+    # With derived_categoricals on the regime, it succeeds
+    updated_regimes = {
+        name: (
+            dataclasses.replace(r, derived_categoricals={"labor_supply": labor_grid})
+            if name == "retirement"
+            else r
+        )
+        for name, r in model.regimes.items()
+    }
     result = convert_series_in_params(
         internal_params=internal,
-        regimes=model.regimes,
+        regimes=updated_regimes,
         ages=model.ages,
         regime_names_to_ids=model.regime_names_to_ids,
-        derived_categoricals={"labor_supply": labor_grid},
     )
     arr = result["retirement"]["next_partner__probs_array"]
     assert arr.shape == (3, 2, 2, 2)  # ty: ignore[unresolved-attribute]
@@ -1656,11 +1665,13 @@ def test_convert_series_structured_derived_categoricals() -> None:
         states={"wealth": LinSpacedGrid(start=0, stop=10, n_points=5)},
         state_transitions={"wealth": _next_wealth_sc},
         functions={"utility": func_a, "derived": _derived_a},
+        derived_categoricals={"derived": DiscreteGrid(_ChoiceA)},
     )
     regime_b = Regime(
         transition=None,
         states={"wealth": LinSpacedGrid(start=0, stop=10, n_points=5)},
         functions={"utility": func_b, "derived": _derived_b},
+        derived_categoricals={"derived": DiscreteGrid(_ChoiceB)},
     )
     model = Model(
         regimes={"regime_a": regime_a, "regime_b": regime_b},
@@ -1669,7 +1680,7 @@ def test_convert_series_structured_derived_categoricals() -> None:
     )
 
     # "derived" has 2 outcomes in regime_a (_ChoiceA: x,y) and 3 in
-    # regime_b (_ChoiceB: x,y,z). Need per-regime categoricals.
+    # regime_b (_ChoiceB: x,y,z). Each regime declares its own grid.
     sr_a = pd.Series([1.0, 2.0], index=pd.Index(["x", "y"], name="derived"))
     sr_b = pd.Series([1.0, 2.0, 3.0], index=pd.Index(["x", "y", "z"], name="derived"))
 
@@ -1685,12 +1696,6 @@ def test_convert_series_structured_derived_categoricals() -> None:
         regimes=model.regimes,
         ages=model.ages,
         regime_names_to_ids=model.regime_names_to_ids,
-        derived_categoricals={
-            "derived": {
-                "regime_a": DiscreteGrid(_ChoiceA),
-                "regime_b": DiscreteGrid(_ChoiceB),
-            },
-        },
     )
     assert result_both["regime_a"]["utility__rates"].shape == (2,)  # ty: ignore[unresolved-attribute]
     assert result_both["regime_b"]["utility__rates"].shape == (3,)  # ty: ignore[unresolved-attribute]
@@ -1771,10 +1776,12 @@ def test_resolve_categoricals_conflict_raises() -> None:
         x: int
         y: int
 
-    conflicting = {"partner": DiscreteGrid(WrongPartner)}
+    conflicting_regime = dataclasses.replace(
+        model.regimes["working_life"],
+        derived_categoricals={"partner": DiscreteGrid(WrongPartner)},
+    )
     with pytest.raises(ValueError, match="conflicts with model grid"):
         _resolve_categoricals(
-            regimes=model.regimes,
+            regimes={"working_life": conflicting_regime},
             regime_name="working_life",
-            derived_categoricals=conflicting,
         )

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -4,8 +4,8 @@ import jax.numpy as jnp
 import pandas as pd
 from numpy.testing import assert_array_almost_equal as aaae
 
-from lcm import AgeGrid, LinSpacedGrid, Model, Regime, categorical
-from lcm.typing import ContinuousAction, ContinuousState, FloatND, UserParams
+from lcm import AgeGrid, DiscreteGrid, LinSpacedGrid, Model, Regime, categorical
+from lcm.typing import ContinuousAction, ContinuousState, FloatND, ScalarInt, UserParams
 from tests.test_models.regime_markov import Health
 from tests.test_models.regime_markov import RegimeId as MarkovRegimeId
 from tests.test_models.regime_markov import alive as markov_alive
@@ -261,6 +261,65 @@ def test_mixed_series_and_scalar_fixed_params():
     result = model.simulate(
         params={},
         initial_conditions=_MARKOV_INITIAL_CONDITIONS,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )
+    df = result.to_dataframe()
+    assert len(df) > 0
+
+
+@categorical(ordered=False)
+class _WealthGroup:
+    low: int
+    high: int
+
+
+def _wealth_group(wealth: ContinuousState) -> ScalarInt:
+    return jnp.int32(wealth > 5.0)
+
+
+def _utility_with_group(
+    consumption: ContinuousAction,
+    wealth_group: ScalarInt,
+    group_bonus: FloatND,
+) -> FloatND:
+    return jnp.log(consumption + 1) + group_bonus[wealth_group]
+
+
+def test_series_fixed_param_with_derived_categoricals():
+    """Fixed pd.Series indexed by derived categorical needs derived_categoricals."""
+    group_bonus = pd.Series(
+        [0.0, 1.0],
+        index=pd.Index(["low", "high"], name="wealth_group"),
+    )
+    alive = Regime(
+        functions={"utility": _utility_with_group, "wealth_group": _wealth_group},
+        states={"wealth": LinSpacedGrid(start=1, stop=10, n_points=5)},
+        state_transitions={"wealth": lambda wealth: wealth},
+        actions={"consumption": LinSpacedGrid(start=0.1, stop=5, n_points=5)},
+        constraints={"borrowing_constraint": _borrowing_constraint},
+        transition=_next_regime,
+        active=lambda age: age < 2,
+    )
+    dead = Regime(
+        transition=None,
+        functions={"utility": lambda: 0.0},
+        active=lambda age: age >= 2,
+    )
+    model = Model(
+        regimes={"alive": alive, "dead": dead},
+        ages=AgeGrid(start=0, stop=2, step="Y"),
+        regime_id_class=RegimeId,
+        fixed_params={"group_bonus": group_bonus},
+        derived_categoricals={"wealth_group": DiscreteGrid(_WealthGroup)},
+    )
+    result = model.simulate(
+        params={"discount_factor": 0.95},
+        initial_conditions={
+            "wealth": jnp.array([3.0, 8.0]),
+            "age": jnp.array([0.0, 0.0]),
+            "regime": jnp.array([RegimeId.alive] * 2),
+        },
         period_to_regime_to_V_arr=None,
         log_level="off",
     )

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -245,7 +245,7 @@ def test_series_fixed_param_parity_with_runtime_param():
 
     df_runtime = result_runtime.to_dataframe()
     df_fixed = result_fixed.to_dataframe()
-    aaae(df_runtime["wealth"].values, df_fixed["wealth"].values)
+    aaae(df_runtime["wealth"].to_numpy(), df_fixed["wealth"].to_numpy())
 
 
 def test_mixed_series_and_scalar_fixed_params():

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -1,10 +1,23 @@
 """Tests for static params (fixed_params partialled at model initialization)."""
 
 import jax.numpy as jnp
+import pandas as pd
 from numpy.testing import assert_array_almost_equal as aaae
 
 from lcm import AgeGrid, LinSpacedGrid, Model, Regime, categorical
 from lcm.typing import ContinuousAction, ContinuousState, FloatND
+from tests.test_models.regime_markov import (
+    Health,
+)
+from tests.test_models.regime_markov import (
+    RegimeId as MarkovRegimeId,
+)
+from tests.test_models.regime_markov import (
+    alive as markov_alive,
+)
+from tests.test_models.regime_markov import (
+    dead as markov_dead,
+)
 
 
 @categorical(ordered=False)
@@ -160,3 +173,114 @@ def test_all_params_fixed():
     # Solve with empty params
     period_to_regime_to_V_arr = model.solve(params={}, log_level="off")
     assert len(period_to_regime_to_V_arr) > 0
+
+
+# ---------------------------------------------------------------------------
+# Series conversion for fixed_params (using regime_markov test model)
+# ---------------------------------------------------------------------------
+
+_AGES = (60.0, 61.0, 62.0)
+
+_PROBS_ARRAY = jnp.array(
+    [
+        [[0.95, 0.05], [0.98, 0.02]],  # age 60 → 61 (alive active)
+        [[0.0, 1.0], [0.0, 1.0]],  # age 61 → 62 (alive inactive, must die)
+        [[0.0, 1.0], [0.0, 1.0]],  # age 62 (terminal)
+    ]
+)
+
+_PROBS_SERIES = pd.Series(
+    [0.95, 0.05, 0.98, 0.02, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+    index=pd.MultiIndex.from_product(
+        [_AGES, ["bad", "good"], ["alive", "dead"]],
+        names=["age", "health", "next_regime"],
+    ),
+)
+
+_MARKOV_INITIAL_CONDITIONS = {
+    "wealth": jnp.array([50.0, 80.0]),
+    "health": jnp.array([Health.bad, Health.good]),
+    "age": jnp.array([60.0, 60.0]),
+    "regime": jnp.array([MarkovRegimeId.alive] * 2),
+}
+
+
+def _make_markov_model(*, fixed_params=None):
+    """Create regime_markov model with optional fixed_params."""
+    return Model(
+        regimes={"alive": markov_alive, "dead": markov_dead},
+        ages=AgeGrid(start=60, stop=62, step="Y"),
+        regime_id_class=MarkovRegimeId,
+        fixed_params=fixed_params or {},
+    )
+
+
+def test_series_as_runtime_param_works():
+    """Baseline: pd.Series works as a runtime param (not fixed)."""
+    model = _make_markov_model()
+    result = model.simulate(
+        params={"discount_factor": 0.95, "probs_array": _PROBS_SERIES},
+        initial_conditions=_MARKOV_INITIAL_CONDITIONS,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )
+    df = result.to_dataframe()
+    assert len(df) > 0
+
+
+def test_series_as_fixed_param():
+    """pd.Series in fixed_params should be auto-converted like runtime params."""
+    model = _make_markov_model(
+        fixed_params={"probs_array": _PROBS_SERIES},
+    )
+    result = model.simulate(
+        params={"discount_factor": 0.95},
+        initial_conditions=_MARKOV_INITIAL_CONDITIONS,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )
+    df = result.to_dataframe()
+    assert len(df) > 0
+
+
+def test_series_fixed_param_parity_with_runtime_param():
+    """Same Series value as fixed_param vs runtime param produces identical results."""
+    model_runtime = _make_markov_model()
+    result_runtime = model_runtime.simulate(
+        params={"discount_factor": 0.95, "probs_array": _PROBS_SERIES},
+        initial_conditions=_MARKOV_INITIAL_CONDITIONS,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )
+
+    model_fixed = _make_markov_model(
+        fixed_params={"probs_array": _PROBS_SERIES},
+    )
+    result_fixed = model_fixed.simulate(
+        params={"discount_factor": 0.95},
+        initial_conditions=_MARKOV_INITIAL_CONDITIONS,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )
+
+    df_runtime = result_runtime.to_dataframe()
+    df_fixed = result_fixed.to_dataframe()
+    aaae(df_runtime["wealth"].values, df_fixed["wealth"].values)
+
+
+def test_mixed_series_and_scalar_fixed_params():
+    """Mixed: some fixed_params are Series, others are scalars."""
+    model = _make_markov_model(
+        fixed_params={
+            "probs_array": _PROBS_SERIES,
+            "discount_factor": 0.95,
+        },
+    )
+    result = model.simulate(
+        params={},
+        initial_conditions=_MARKOV_INITIAL_CONDITIONS,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )
+    df = result.to_dataframe()
+    assert len(df) > 0

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -2,6 +2,7 @@
 
 import jax.numpy as jnp
 import pandas as pd
+import pytest
 from numpy.testing import assert_array_almost_equal as aaae
 
 from lcm import AgeGrid, DiscreteGrid, LinSpacedGrid, Model, Regime, categorical
@@ -386,7 +387,6 @@ def test_model_broadcast_matching_regime_entry():
 
 def test_model_broadcast_conflict_raises():
     """Model-level entry conflicting with regime entry raises."""
-    import pytest  # noqa: PLC0415
 
     @categorical(ordered=False)
     class _OtherGroup:

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -300,7 +300,7 @@ def test_series_fixed_param_with_derived_categoricals():
         constraints={"borrowing_constraint": _borrowing_constraint},
         transition=_next_regime,
         active=lambda age: age < 2,
-        derived_categoricals={"wealth_group": _WealthGroup},
+        derived_categoricals={"wealth_group": DiscreteGrid(_WealthGroup)},
     )
     dead = Regime(
         transition=None,
@@ -347,7 +347,7 @@ def test_model_broadcast_merges_into_regimes():
         regimes={"alive": alive, "dead": dead},
         ages=AgeGrid(start=0, stop=2, step="Y"),
         regime_id_class=RegimeId,
-        derived_categoricals={"wealth_group": _WealthGroup},
+        derived_categoricals={"wealth_group": DiscreteGrid(_WealthGroup)},
     )
     assert isinstance(
         model.regimes["alive"].derived_categoricals["wealth_group"], DiscreteGrid

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -5,19 +5,11 @@ import pandas as pd
 from numpy.testing import assert_array_almost_equal as aaae
 
 from lcm import AgeGrid, LinSpacedGrid, Model, Regime, categorical
-from lcm.typing import ContinuousAction, ContinuousState, FloatND
-from tests.test_models.regime_markov import (
-    Health,
-)
-from tests.test_models.regime_markov import (
-    RegimeId as MarkovRegimeId,
-)
-from tests.test_models.regime_markov import (
-    alive as markov_alive,
-)
-from tests.test_models.regime_markov import (
-    dead as markov_dead,
-)
+from lcm.typing import ContinuousAction, ContinuousState, FloatND, UserParams
+from tests.test_models.regime_markov import Health
+from tests.test_models.regime_markov import RegimeId as MarkovRegimeId
+from tests.test_models.regime_markov import alive as markov_alive
+from tests.test_models.regime_markov import dead as markov_dead
 
 
 @categorical(ordered=False)
@@ -175,19 +167,7 @@ def test_all_params_fixed():
     assert len(period_to_regime_to_V_arr) > 0
 
 
-# ---------------------------------------------------------------------------
-# Series conversion for fixed_params (using regime_markov test model)
-# ---------------------------------------------------------------------------
-
 _AGES = (60.0, 61.0, 62.0)
-
-_PROBS_ARRAY = jnp.array(
-    [
-        [[0.95, 0.05], [0.98, 0.02]],  # age 60 → 61 (alive active)
-        [[0.0, 1.0], [0.0, 1.0]],  # age 61 → 62 (alive inactive, must die)
-        [[0.0, 1.0], [0.0, 1.0]],  # age 62 (terminal)
-    ]
-)
 
 _PROBS_SERIES = pd.Series(
     [0.95, 0.05, 0.98, 0.02, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
@@ -205,7 +185,7 @@ _MARKOV_INITIAL_CONDITIONS = {
 }
 
 
-def _make_markov_model(*, fixed_params=None):
+def _make_markov_model(*, fixed_params: UserParams | None = None) -> Model:
     """Create regime_markov model with optional fixed_params."""
     return Model(
         regimes={"alive": markov_alive, "dead": markov_dead},

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -300,7 +300,7 @@ def test_series_fixed_param_with_derived_categoricals():
         constraints={"borrowing_constraint": _borrowing_constraint},
         transition=_next_regime,
         active=lambda age: age < 2,
-        derived_categoricals={"wealth_group": DiscreteGrid(_WealthGroup)},
+        derived_categoricals={"wealth_group": _WealthGroup},
     )
     dead = Regime(
         transition=None,
@@ -328,8 +328,7 @@ def test_series_fixed_param_with_derived_categoricals():
 
 
 def test_model_broadcast_merges_into_regimes():
-    """Model-level derived_categoricals broadcast to all regimes."""
-    wg_grid = DiscreteGrid(_WealthGroup)
+    """Model-level derived_categoricals broadcast to all regimes (raw class)."""
     alive = Regime(
         functions={"utility": _utility_with_group, "wealth_group": _wealth_group},
         states={"wealth": LinSpacedGrid(start=1, stop=10, n_points=5)},
@@ -348,10 +347,14 @@ def test_model_broadcast_merges_into_regimes():
         regimes={"alive": alive, "dead": dead},
         ages=AgeGrid(start=0, stop=2, step="Y"),
         regime_id_class=RegimeId,
-        derived_categoricals={"wealth_group": wg_grid},
+        derived_categoricals={"wealth_group": _WealthGroup},
     )
-    assert model.regimes["alive"].derived_categoricals["wealth_group"] is wg_grid
-    assert model.regimes["dead"].derived_categoricals["wealth_group"] is wg_grid
+    assert isinstance(
+        model.regimes["alive"].derived_categoricals["wealth_group"], DiscreteGrid
+    )
+    assert isinstance(
+        model.regimes["dead"].derived_categoricals["wealth_group"], DiscreteGrid
+    )
 
 
 def test_model_broadcast_matching_regime_entry():

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -300,6 +300,7 @@ def test_series_fixed_param_with_derived_categoricals():
         constraints={"borrowing_constraint": _borrowing_constraint},
         transition=_next_regime,
         active=lambda age: age < 2,
+        derived_categoricals={"wealth_group": DiscreteGrid(_WealthGroup)},
     )
     dead = Regime(
         transition=None,
@@ -311,7 +312,6 @@ def test_series_fixed_param_with_derived_categoricals():
         ages=AgeGrid(start=0, stop=2, step="Y"),
         regime_id_class=RegimeId,
         fixed_params={"group_bonus": group_bonus},
-        derived_categoricals={"wealth_group": DiscreteGrid(_WealthGroup)},
     )
     result = model.simulate(
         params={"discount_factor": 0.95},
@@ -325,3 +325,134 @@ def test_series_fixed_param_with_derived_categoricals():
     )
     df = result.to_dataframe()
     assert len(df) > 0
+
+
+def test_model_broadcast_merges_into_regimes():
+    """Model-level derived_categoricals broadcast to all regimes."""
+    wg_grid = DiscreteGrid(_WealthGroup)
+    alive = Regime(
+        functions={"utility": _utility_with_group, "wealth_group": _wealth_group},
+        states={"wealth": LinSpacedGrid(start=1, stop=10, n_points=5)},
+        state_transitions={"wealth": lambda wealth: wealth},
+        actions={"consumption": LinSpacedGrid(start=0.1, stop=5, n_points=5)},
+        constraints={"borrowing_constraint": _borrowing_constraint},
+        transition=_next_regime,
+        active=lambda age: age < 2,
+    )
+    dead = Regime(
+        transition=None,
+        functions={"utility": lambda: 0.0},
+        active=lambda age: age >= 2,
+    )
+    model = Model(
+        regimes={"alive": alive, "dead": dead},
+        ages=AgeGrid(start=0, stop=2, step="Y"),
+        regime_id_class=RegimeId,
+        derived_categoricals={"wealth_group": wg_grid},
+    )
+    assert model.regimes["alive"].derived_categoricals["wealth_group"] is wg_grid
+    assert model.regimes["dead"].derived_categoricals["wealth_group"] is wg_grid
+
+
+def test_model_broadcast_matching_regime_entry():
+    """Model-level entry matching a regime entry does not conflict."""
+    wg_grid = DiscreteGrid(_WealthGroup)
+    alive = Regime(
+        functions={"utility": _utility_with_group, "wealth_group": _wealth_group},
+        states={"wealth": LinSpacedGrid(start=1, stop=10, n_points=5)},
+        state_transitions={"wealth": lambda wealth: wealth},
+        actions={"consumption": LinSpacedGrid(start=0.1, stop=5, n_points=5)},
+        constraints={"borrowing_constraint": _borrowing_constraint},
+        transition=_next_regime,
+        active=lambda age: age < 2,
+        derived_categoricals={"wealth_group": wg_grid},
+    )
+    dead = Regime(
+        transition=None,
+        functions={"utility": lambda: 0.0},
+        active=lambda age: age >= 2,
+    )
+    model = Model(
+        regimes={"alive": alive, "dead": dead},
+        ages=AgeGrid(start=0, stop=2, step="Y"),
+        regime_id_class=RegimeId,
+        derived_categoricals={"wealth_group": wg_grid},
+    )
+    assert model.regimes["alive"].derived_categoricals["wealth_group"] is wg_grid
+
+
+def test_model_broadcast_conflict_raises():
+    """Model-level entry conflicting with regime entry raises."""
+    import pytest  # noqa: PLC0415
+
+    @categorical(ordered=False)
+    class _OtherGroup:
+        a: int
+        b: int
+        c: int
+
+    alive = Regime(
+        functions={"utility": _utility_with_group, "wealth_group": _wealth_group},
+        states={"wealth": LinSpacedGrid(start=1, stop=10, n_points=5)},
+        state_transitions={"wealth": lambda wealth: wealth},
+        actions={"consumption": LinSpacedGrid(start=0.1, stop=5, n_points=5)},
+        constraints={"borrowing_constraint": _borrowing_constraint},
+        transition=_next_regime,
+        active=lambda age: age < 2,
+        derived_categoricals={"wealth_group": DiscreteGrid(_OtherGroup)},
+    )
+    dead = Regime(
+        transition=None,
+        functions={"utility": lambda: 0.0},
+        active=lambda age: age >= 2,
+    )
+    with pytest.raises(Exception, match="conflicts"):
+        Model(
+            regimes={"alive": alive, "dead": dead},
+            ages=AgeGrid(start=0, stop=2, step="Y"),
+            regime_id_class=RegimeId,
+            derived_categoricals={"wealth_group": DiscreteGrid(_WealthGroup)},
+        )
+
+
+def test_different_regime_derived_categoricals_with_model_broadcast():
+    """Different per-regime grids coexist with a model-level broadcast."""
+
+    @categorical(ordered=False)
+    class _GroupA:
+        x: int
+        y: int
+
+    @categorical(ordered=False)
+    class _GroupB:
+        p: int
+        q: int
+
+    @categorical(ordered=False)
+    class _Shared:
+        lo: int
+        hi: int
+
+    alive = Regime(
+        functions={"utility": lambda: 0.0},
+        transition=_next_regime,
+        active=lambda age: age < 2,
+        derived_categoricals={"group_a": DiscreteGrid(_GroupA)},
+    )
+    dead = Regime(
+        transition=None,
+        functions={"utility": lambda: 0.0},
+        active=lambda age: age >= 2,
+        derived_categoricals={"group_b": DiscreteGrid(_GroupB)},
+    )
+    model = Model(
+        regimes={"alive": alive, "dead": dead},
+        ages=AgeGrid(start=0, stop=2, step="Y"),
+        regime_id_class=RegimeId,
+        derived_categoricals={"shared": DiscreteGrid(_Shared)},
+    )
+    assert "group_a" in model.regimes["alive"].derived_categoricals
+    assert "shared" in model.regimes["alive"].derived_categoricals
+    assert "group_a" not in model.regimes["dead"].derived_categoricals
+    assert "group_b" in model.regimes["dead"].derived_categoricals
+    assert "shared" in model.regimes["dead"].derived_categoricals

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -231,6 +231,7 @@ def test_series_fixed_param_parity_with_runtime_param():
         initial_conditions=_MARKOV_INITIAL_CONDITIONS,
         period_to_regime_to_V_arr=None,
         log_level="off",
+        seed=0,
     )
 
     model_fixed = _make_markov_model(
@@ -241,6 +242,7 @@ def test_series_fixed_param_parity_with_runtime_param():
         initial_conditions=_MARKOV_INITIAL_CONDITIONS,
         period_to_regime_to_V_arr=None,
         log_level="off",
+        seed=0,
     )
 
     df_runtime = result_runtime.to_dataframe()


### PR DESCRIPTION
## Summary

- `fixed_params` now auto-converts `pd.Series` to JAX arrays, matching the behavior of runtime `params`
- Removes `Model` dependency from `pandas_utils.py` and eliminates the callback pattern -- `model_processing.py` calls `convert_series_in_params` and `_validate_param_types` directly with decomposed parameters (`regimes`, `ages`, `regime_names_to_ids`)
- Previously, passing a `pd.Series` in `fixed_params` caused `TypeError: ... is not a valid JAX type` during tracing

## Test plan

- [x] New test: Series as fixed_param solves and simulates
- [x] New test: parity between Series as fixed_param vs runtime param (identical results)
- [x] New test: mixed Series + scalar fixed_params
- [x] New test: Series fixed_param indexed by derived categorical with `derived_categoricals` on `Model.__init__`
- [x] Full test suite (824 passed)

Generated with [Claude Code](https://claude.ai/code)