### PR TITLE
Support heterogeneous state sets in initial conditions

### DIFF
--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -93,9 +93,9 @@ def initial_conditions_from_dataframe(
     n_subjects = len(df)
     state_cols = [col for col in df.columns if col != "regime"]
 
-    # Pre-allocate result arrays
+    # Pre-allocate result arrays (NaN default surfaces bugs for missing states)
     result_arrays: dict[str, np.ndarray] = {
-        col: np.empty(n_subjects, dtype=float) for col in state_cols
+        col: np.full(n_subjects, np.nan) for col in state_cols
     }
     discrete_state_names: set[str] = set()
 
@@ -110,7 +110,16 @@ def initial_conditions_from_dataframe(
         }
         discrete_state_names |= discrete_grids.keys()
 
+        regime_state_names = {
+            name
+            for name, grid in regime.states.items()
+            if not isinstance(grid, _ShockGrid)
+        } | {"age"}
+
         for col in state_cols:
+            if col not in regime_state_names:
+                continue
+
             values = group[col]
             if hasattr(values, "cat"):
                 values = values.astype(str)

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -144,7 +144,10 @@ def validate_initial_conditions(
 
     # Validate discrete state values
     _validate_discrete_state_values(
-        initial_states=initial_states, internal_regimes=internal_regimes
+        initial_states=initial_states,
+        internal_regimes=internal_regimes,
+        regime_id_arr=regime_arr,
+        regime_names_to_ids=regime_names_to_ids,
     )
 
     # Validate feasibility
@@ -415,35 +418,53 @@ def _validate_discrete_state_values(
     *,
     initial_states: Mapping[str, Array],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    regime_id_arr: Array,
+    regime_names_to_ids: Mapping[str, int],
 ) -> None:
     """Validate that discrete state values are valid codes.
+
+    Only check subjects in regimes that actually have the state.
 
     Args:
         initial_states: Mapping of state names to arrays.
         internal_regimes: Immutable mapping of regime names to internal regime
             instances.
+        regime_id_arr: Array of regime IDs for each subject.
+        regime_names_to_ids: Mapping from regime names to integer IDs.
 
     Raises:
         InvalidInitialConditionsError: If any discrete state contains invalid codes.
 
     """
-    discrete_valid_codes: dict[str, set[int]] = {}
-    for internal_regime in internal_regimes.values():
+    # Build per-state: valid codes + regime IDs that have this state
+    discrete_info: dict[str, tuple[set[int], set[int]]] = {}
+    for regime_name, internal_regime in internal_regimes.items():
+        regime_id = regime_names_to_ids[regime_name]
         for state_name in internal_regime.variable_info.query(
             "is_state and is_discrete"
         ).index:
             grid = internal_regime.grids[state_name]
             if isinstance(grid, DiscreteGrid):
-                existing = discrete_valid_codes.get(state_name, set())
-                discrete_valid_codes[state_name] = existing | set(grid.codes)
+                codes, regime_ids = discrete_info.get(state_name, (set(), set()))
+                discrete_info[state_name] = (
+                    codes | set(grid.codes),
+                    regime_ids | {regime_id},
+                )
 
-    for state_name, valid_codes in discrete_valid_codes.items():
+    for state_name, (valid_codes, regime_ids) in discrete_info.items():
         if state_name not in initial_states:
             continue
         values = initial_states[state_name]
-        invalid_mask = jnp.isin(values, jnp.array(sorted(valid_codes)), invert=True)
+        # Only validate subjects in regimes that have this state
+        in_relevant_regime = jnp.isin(regime_id_arr, jnp.array(sorted(regime_ids)))
+        relevant_values = values[in_relevant_regime]
+        if relevant_values.size == 0:
+            continue
+        invalid_mask = jnp.isin(
+            relevant_values, jnp.array(sorted(valid_codes)), invert=True
+        )
         if jnp.any(invalid_mask):
-            invalid_vals = sorted({int(v) for v in values[invalid_mask]})
+            invalid_vals = sorted({int(v) for v in relevant_values[invalid_mask]})
             raise InvalidInitialConditionsError(
                 f"Invalid values {invalid_vals} for discrete state "
                 f"'{state_name}'. Valid codes are: {sorted(valid_codes)}"

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -407,6 +407,73 @@ def test_initial_conditions_heterogeneous_health_grids() -> None:
     )
 
 
+def test_initial_conditions_heterogeneous_state_sets() -> None:
+    """Handle regimes where a state only exists in some regimes."""
+
+    @categorical(ordered=False)
+    class _Rid:
+        with_status: int
+        without_status: int
+        dead: int
+
+    @categorical(ordered=False)
+    class _Status:
+        low: int
+        high: int
+
+    def _next_regime() -> int:
+        return _Rid.dead
+
+    def _utility_with_status(wealth: float, status: int) -> float:
+        return wealth + status
+
+    def _utility_without_status(wealth: float) -> float:
+        return wealth
+
+    with_status = Regime(
+        transition=_next_regime,
+        states={
+            "wealth": LinSpacedGrid(start=0, stop=100, n_points=5),
+            "status": DiscreteGrid(_Status),
+        },
+        state_transitions={"wealth": None, "status": None},
+        functions={"utility": _utility_with_status},
+    )
+    without_status = Regime(
+        transition=_next_regime,
+        states={"wealth": LinSpacedGrid(start=0, stop=100, n_points=5)},
+        state_transitions={"wealth": None},
+        functions={"utility": _utility_without_status},
+    )
+    dead = Regime(transition=None, functions={"utility": lambda: 0.0})
+
+    model = Model(
+        regimes={
+            "with_status": with_status,
+            "without_status": without_status,
+            "dead": dead,
+        },
+        ages=AgeGrid(start=50, stop=52, step="Y"),
+        regime_id_class=_Rid,
+    )
+
+    df = pd.DataFrame(
+        {
+            "regime": ["with_status", "with_status", "without_status"],
+            "wealth": [10.0, 20.0, 30.0],
+            "status": ["low", "high", pd.NA],
+            "age": [50.0, 51.0, 50.0],
+        }
+    )
+    result = initial_conditions_from_dataframe(df=df, model=model)
+
+    # status: low=0, high=1 for with_status regime
+    assert result["status"][0] == 0
+    assert result["status"][1] == 1
+    # without_status regime: value is unused (NaN→int32 gives a sentinel)
+    assert jnp.allclose(result["wealth"], jnp.array([10.0, 20.0, 30.0]))
+
+
 def test_convert_series_heterogeneous_grids() -> None:
     """convert_series_in_params handles per-regime grid lookup."""
     model = _get_heterogeneous_health_model()


### PR DESCRIPTION
## Summary

- `initial_conditions_from_dataframe`: skip columns that aren't states of the current regime instead of trying to convert them (fails on NA/string). Pre-allocate with NaN so unused slots surface bugs.
- `_validate_discrete_state_values`: only check codes for subjects in regimes that actually have the state (NaN→int32 sentinel was falsely rejected).

Motivated by aca-model where `claimed_ss` and `lagged_labor_supply` only exist in some regimes.

## Test plan

- [x] New test `test_initial_conditions_heterogeneous_state_sets` — model with a discrete state in one regime but not another
- [x] Existing tests pass (88 in test_pandas_utils, 20 in test_initial_conditions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)