### PR TITLE
Fix AOT deduplication for fixed_params models

### DIFF
--- a/src/lcm/solution/solve_brute.py
+++ b/src/lcm/solution/solve_brute.py
@@ -1,7 +1,8 @@
+import functools
 import logging
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Hashable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from types import MappingProxyType
 
@@ -196,10 +197,10 @@ def _compile_all_functions(
     if not enable_jit:
         return all_functions
 
-    # Deduplicate by object identity.
-    unique: dict[int, tuple[Callable, RegimeName, int]] = {}
+    # Deduplicate by identity (or by underlying function for partials).
+    unique: dict[Hashable, tuple[Callable, RegimeName, int]] = {}
     for (name, period), func in all_functions.items():
-        func_id = id(func)
+        func_id = _func_dedup_key(func)
         if func_id not in unique:
             unique[func_id] = (func, name, period)
 
@@ -215,8 +216,8 @@ def _compile_all_functions(
 
     # Phase 1: Lower all unique functions (sequential — tracing is not
     # thread-safe and must happen on the main thread).
-    lowered: dict[int, jax.stages.Lowered] = {}
-    labels: dict[int, str] = {}
+    lowered: dict[Hashable, jax.stages.Lowered] = {}
+    labels: dict[Hashable, str] = {}
     for i, (func_id, (func, name, period)) in enumerate(unique.items(), 1):
         state_action_space = internal_regimes[name].state_action_space(
             regime_params=internal_params[name],
@@ -239,13 +240,13 @@ def _compile_all_functions(
         logger.info("  lowered in %s", format_duration(seconds=elapsed))
 
     # Phase 2: Compile all lowered programs in parallel (XLA releases the GIL).
-    compiled: dict[int, jax.stages.Compiled] = {}
+    compiled: dict[Hashable, jax.stages.Compiled] = {}
 
     def _compile_and_log(
-        func_id: int,
+        func_id: Hashable,
         low: jax.stages.Lowered,
         label: str,
-    ) -> tuple[int, jax.stages.Compiled]:
+    ) -> tuple[Hashable, jax.stages.Compiled]:
         logger.info("  compiling %s ...", label)
         start = time.monotonic()
         result = low.compile()
@@ -263,7 +264,19 @@ def _compile_all_functions(
             compiled[func_id] = comp
 
     # Map back to (regime, period) keys.
-    return {key: compiled[id(func)] for key, func in all_functions.items()}
+    return {key: compiled[_func_dedup_key(func)] for key, func in all_functions.items()}
+
+
+def _func_dedup_key(func: Callable) -> Hashable:
+    """Return a hashable deduplication key for a callable.
+
+    For `functools.partial` objects wrapping shared JIT functions, deduplicate
+    by the underlying function's identity and the keyword argument names.
+    For plain callables, use object identity.
+    """
+    if isinstance(func, functools.partial):
+        return (id(func.func), tuple(sorted(func.keywords)))
+    return id(func)
 
 
 def _get_regime_V_shapes(

--- a/tests/test_static_params.py
+++ b/tests/test_static_params.py
@@ -1,7 +1,10 @@
 """Tests for static params (fixed_params partialled at model initialization)."""
 
+import logging
+
 import jax.numpy as jnp
 import pandas as pd
+import pytest
 from numpy.testing import assert_array_almost_equal as aaae
 
 from lcm import AgeGrid, LinSpacedGrid, Model, Regime, categorical
@@ -134,6 +137,47 @@ def test_simulate_with_fixed_params():
     df_fixed = result_fixed.to_dataframe()
     aaae(df_full["wealth"].values, df_fixed["wealth"].values)
     aaae(df_full["consumption"].values, df_fixed["consumption"].values)
+
+
+def test_solve_fixed_params_aot_parity():
+    """Solve with fixed_params produces identical V arrays via AOT compilation."""
+    params_full: UserParams = {"discount_factor": 0.95, "interest_rate": 0.05}
+
+    model_runtime = _make_model()
+    result_runtime = model_runtime.solve(params=params_full, log_level="off")
+
+    model_fixed = _make_model(extra_fixed_params={"interest_rate": 0.05})
+    result_fixed = model_fixed.solve(params={"discount_factor": 0.95}, log_level="off")
+
+    for period in result_runtime:
+        for regime_name in result_runtime[period]:
+            aaae(
+                result_runtime[period][regime_name],
+                result_fixed[period][regime_name],
+            )
+
+
+def test_aot_dedup_with_fixed_params(caplog: pytest.LogCaptureFixture) -> None:
+    """AOT compilation deduplicates partial objects wrapping the same JIT function."""
+    # Without fixed_params, count the unique functions as baseline.
+    model_baseline = _make_model()
+    with caplog.at_level(logging.INFO):
+        model_baseline.solve(
+            params={"discount_factor": 0.95, "interest_rate": 0.05},
+            log_level="progress",
+        )
+    baseline_lines = [r for r in caplog.records if "unique functions" in r.message]
+    assert len(baseline_lines) == 1
+
+    caplog.clear()
+
+    # With fixed_params (partial-wrapped), should get the same dedup count.
+    model_fixed = _make_model(extra_fixed_params={"interest_rate": 0.05})
+    with caplog.at_level(logging.INFO):
+        model_fixed.solve(params={"discount_factor": 0.95}, log_level="progress")
+    fixed_lines = [r for r in caplog.records if "unique functions" in r.message]
+    assert len(fixed_lines) == 1
+    assert baseline_lines[0].message == fixed_lines[0].message
 
 
 def test_regime_level_fixed_param():


### PR DESCRIPTION
## Summary

- When `fixed_params` wraps `max_Q_over_a` functions with `functools.partial`, AOT deduplication via `id(func)` treats each partial as unique — even when they wrap the same underlying JIT function with the same kwargs
- Add `_func_dedup_key()` helper that deduplicates by `(id(func.func), sorted_kwarg_names)` for partials, `id(func)` for plain callables
- Two new tests: solve parity (V arrays identical with/without fixed_params) and dedup count (same number of unique functions)

## Test plan

- [x] `test_solve_fixed_params_aot_parity` — V arrays match
- [x] `test_aot_dedup_with_fixed_params` — dedup count matches baseline
- [x] Full test suite: 833 passed, 5 skipped, 2 xfailed
- [x] `prek` clean
- [x] `ty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)