### PR TITLE
Lift discrete fixed states as partition dimensions

### DIFF
--- a/src/lcm/interfaces.py
+++ b/src/lcm/interfaces.py
@@ -296,3 +296,11 @@ class PeriodRegimeSimulationData:
 
     in_regime: Bool1D
     """Boolean mask indicating which subjects are in this regime at this period."""
+
+    subject_ids: Array
+    """Global subject-id array aligned with `in_regime` / `V_arr` / states / actions.
+
+    Threaded explicitly (rather than recomputed as `jnp.arange(n_subjects)`) so
+    that downstream concatenation across partition-dispatch groups preserves
+    the caller's subject ordering.
+    """

--- a/src/lcm/interfaces.py
+++ b/src/lcm/interfaces.py
@@ -6,7 +6,7 @@ from typing import cast
 import pandas as pd
 from jax import Array
 
-from lcm.grids import Grid, IrregSpacedGrid
+from lcm.grids import DiscreteGrid, Grid, IrregSpacedGrid
 from lcm.shocks import _ShockGrid
 from lcm.typing import (
     ArgmaxQOverAFunction,
@@ -232,6 +232,18 @@ class InternalRegime:
 
     resolved_fixed_params: FlatRegimeParams = MappingProxyType({})
     """Flat resolved fixed params for this regime, used by to_dataframe targets."""
+
+    partitions: MappingProxyType[str, DiscreteGrid] = MappingProxyType({})
+    """Immutable mapping of partition-dimension names to their discrete grids.
+
+    Partitions are states declared via `state_transitions[name] = None`:
+    because their value never changes along its own axis in the Bellman
+    equation, they are lifted out of `grids` / `variable_info` at
+    regime-processing time. Solve and simulate iterate over the product
+    of partition grids once per point, compile-once / run-N-times, instead
+    of vectorising over a partition axis. Empty when the user declared no
+    `None` transitions (default — no behavioural change).
+    """
 
     def state_action_space(self, regime_params: FlatRegimeParams) -> StateActionSpace:
         """Return the state-action space with runtime state grids filled in.

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -150,7 +150,9 @@ class Model:
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
         )
-        self._partition_grid = _build_partition_grid(self.internal_regimes)
+        self._partition_grid = _build_partition_grid(
+            internal_regimes=self.internal_regimes
+        )
         self._regime_partitions = MappingProxyType(
             {
                 name: internal_regime.partitions
@@ -224,7 +226,9 @@ class Model:
             MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]
         ] = []
         try:
-            for partition_point in iterate_partition_points(self._partition_grid):
+            for partition_point in iterate_partition_points(
+                partition_grid=self._partition_grid
+            ):
                 partition_params = inject_partition_scalars(
                     internal_params=internal_params,
                     partition_point=partition_point,
@@ -353,9 +357,11 @@ class Model:
             )
         subject_ids = jnp.arange(initial_conditions["regime"].shape[0], dtype=jnp.int32)
         sub_results: list[SimulationResult] = []
-        for partition_point, subject_mask in group_subjects_by_partition(
-            initial_conditions=initial_conditions,
-            partition_grid=self._partition_grid,
+        for group_index, (partition_point, subject_mask) in enumerate(
+            group_subjects_by_partition(
+                initial_conditions=initial_conditions,
+                partition_grid=self._partition_grid,
+            )
         ):
             if not bool(jnp.any(subject_mask)):
                 continue
@@ -377,6 +383,11 @@ class Model:
                 partition_point=partition_point,
                 partition_grid=self._partition_grid,
             )
+            # Derive a distinct seed per partition group so stochastic
+            # transitions do not draw identical key streams across groups.
+            # `seed=None` still hits `draw_random_seed()` independently per
+            # call, so no derivation is needed.
+            group_seed = None if seed is None else seed + group_index
             sub_results.append(
                 simulate(
                     internal_params=partition_params,
@@ -387,7 +398,7 @@ class Model:
                     period_to_regime_to_V_arr=group_V,
                     ages=self.ages,
                     simulation_output_dtypes=self.simulation_output_dtypes,
-                    seed=seed,
+                    seed=group_seed,
                     subject_ids=subject_ids[subject_mask],
                 )
             )
@@ -507,17 +518,6 @@ def _merge_sub_simulation_results(
         A single `SimulationResult`.
 
     """
-    if len(sub_results) == 1:
-        only = sub_results[0]
-        return SimulationResult(
-            raw_results=only.raw_results,
-            internal_regimes=internal_regimes,
-            internal_params=internal_params,
-            period_to_regime_to_V_arr=period_to_regime_to_V_arr,
-            ages=ages,
-            simulation_output_dtypes=simulation_output_dtypes,
-        )
-
     merged_raw: dict[RegimeName, dict[int, PeriodRegimeSimulationData]] = {
         regime_name: {} for regime_name in internal_regimes
     }
@@ -533,15 +533,28 @@ def _merge_sub_simulation_results(
             ]
             if not slices:
                 continue
-            V_arr = jnp.concatenate([s.V_arr for s in slices])
+            state_names = tuple(slices[0].states)
             action_names = tuple(slices[0].actions)
+            # Every sub-result for the same (regime, period) must expose
+            # identical state/action keys — regime structure is fixed at
+            # model build time, so differing sets indicate a bug in the
+            # partition dispatch.
+            for s in slices[1:]:
+                if tuple(s.states) != state_names or tuple(s.actions) != action_names:
+                    msg = (
+                        f"Inconsistent state/action keys across partition groups "
+                        f"for regime '{regime_name}' period {period}. Expected "
+                        f"states={state_names} actions={action_names}, got "
+                        f"states={tuple(s.states)} actions={tuple(s.actions)}."
+                    )
+                    raise RuntimeError(msg)
+            V_arr = jnp.concatenate([s.V_arr for s in slices])
             actions = MappingProxyType(
                 {
                     name: jnp.concatenate([s.actions[name] for s in slices])
                     for name in action_names
                 }
             )
-            state_names = tuple(slices[0].states)
             states = MappingProxyType(
                 {
                     name: jnp.concatenate([s.states[name] for s in slices])
@@ -575,6 +588,7 @@ def _merge_sub_simulation_results(
 
 
 def _build_partition_grid(
+    *,
     internal_regimes: Mapping[RegimeName, InternalRegime],
 ) -> MappingProxyType[str, DiscreteGrid]:
     """Aggregate `InternalRegime.partitions` into a single model-level grid.

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -29,6 +29,11 @@ from lcm.persistence import (
     save_solve_snapshot,
 )
 from lcm.regime import Regime
+from lcm.regime_building.partitions import (
+    inject_partition_scalars,
+    iterate_partition_points,
+    stack_partition_V_arrays,
+)
 from lcm.regime_building.processing import InternalRegime
 from lcm.simulation.initial_conditions import validate_initial_conditions
 from lcm.simulation.result import SimulationResult, get_simulation_output_dtypes
@@ -140,6 +145,7 @@ class Model:
             enable_jit=enable_jit,
             fixed_params=self.fixed_params,
         )
+        self._partition_grid = _build_partition_grid(self.internal_regimes)
         self.enable_jit = enable_jit
         self.simulation_output_dtypes = get_simulation_output_dtypes(
             regimes=self.regimes,
@@ -207,15 +213,25 @@ class Model:
             internal_params=internal_params,
             ages=self.ages,
         )
+        logger = get_logger(log_level=log_level)
+        sub_V_arrays: list[
+            MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]
+        ] = []
         try:
-            period_to_regime_to_V_arr = solve(
-                internal_params=internal_params,
-                ages=self.ages,
-                internal_regimes=self.internal_regimes,
-                logger=get_logger(log_level=log_level),
-                enable_jit=self.enable_jit,
-                max_compilation_workers=max_compilation_workers,
-            )
+            for partition_point in iterate_partition_points(self._partition_grid):
+                partition_params = inject_partition_scalars(
+                    internal_params=internal_params, partition_point=partition_point
+                )
+                sub_V_arrays.append(
+                    solve(
+                        internal_params=partition_params,
+                        ages=self.ages,
+                        internal_regimes=self.internal_regimes,
+                        logger=logger,
+                        enable_jit=self.enable_jit,
+                        max_compilation_workers=max_compilation_workers,
+                    )
+                )
         except InvalidValueFunctionError as exc:
             if log_path is not None and exc.partial_solution is not None:
                 save_solve_snapshot(
@@ -226,6 +242,9 @@ class Model:
                     log_keep_n_latest=log_keep_n_latest,
                 )
             raise
+        period_to_regime_to_V_arr = stack_partition_V_arrays(
+            sub_V_arrays=sub_V_arrays, partition_grid=self._partition_grid
+        )
         if log_level == "debug" and log_path is not None:
             save_solve_snapshot(
                 model=self,
@@ -419,3 +438,42 @@ def _validate_log_args(*, log_level: LogLevel, log_path: str | Path | None) -> N
     if log_level == "debug" and log_path is None:
         msg = "log_path is required when log_level='debug'"
         raise ValueError(msg)
+
+
+def _build_partition_grid(
+    internal_regimes: Mapping[RegimeName, InternalRegime],
+) -> MappingProxyType[str, DiscreteGrid]:
+    """Aggregate `InternalRegime.partitions` into a single model-level grid.
+
+    Every regime that declares a partition name must agree on its grid
+    (same categories). A partition name declared in one regime and absent
+    from another is allowed — the outer partition loop simply iterates
+    identical sub-solves for regimes that do not reference the partition.
+
+    Args:
+        internal_regimes: Mapping of regime names to `InternalRegime` instances.
+
+    Returns:
+        Immutable mapping of partition name to `DiscreteGrid`. Empty when
+        no regime declares any partition.
+
+    Raises:
+        ModelInitializationError: If two regimes declare the same partition
+            name with different categories.
+
+    """
+    grid: dict[str, DiscreteGrid] = {}
+    for regime_name, internal_regime in internal_regimes.items():
+        for name, spec in internal_regime.partitions.items():
+            existing = grid.get(name)
+            if existing is None:
+                grid[name] = spec
+            elif existing.categories != spec.categories:
+                msg = (
+                    f"Partition dimension '{name}' has inconsistent categories "
+                    f"across regimes: {existing.categories} vs {spec.categories} "
+                    f"(regime '{regime_name}'). All regimes that declare a "
+                    f"partition must agree on its grid."
+                )
+                raise ModelInitializationError(msg)
+    return MappingProxyType(grid)

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -43,7 +43,7 @@ from lcm.regime_building.processing import InternalRegime
 from lcm.simulation.initial_conditions import validate_initial_conditions
 from lcm.simulation.result import SimulationResult, get_simulation_output_dtypes
 from lcm.simulation.simulate import simulate
-from lcm.solution.solve_brute import solve
+from lcm.solution.solve_brute import compile_solve, run_compiled_solve
 from lcm.typing import (
     FloatND,
     InternalParams,
@@ -222,31 +222,51 @@ class Model:
         _validate_log_args(log_level=log_level, log_path=log_path)
         internal_params = self._process_params(params)
         logger = get_logger(log_level=log_level)
+
+        # Build the per-iteration param pytrees up-front so compile_solve
+        # sees the full signature (partition scalars included). All points
+        # are shape/dtype-equivalent, so compiling against the first point's
+        # params gives a kernel reusable for every point.
+        partition_params_per_point = [
+            inject_partition_scalars(
+                internal_params=internal_params,
+                partition_point=partition_point,
+                regime_partitions=self._regime_partitions,
+            )
+            for partition_point in iterate_partition_points(
+                partition_grid=self._partition_grid
+            )
+        ]
+
+        # Compile once. Partition scalars flow in through `internal_params`
+        # at run time and hit the JAX dispatch cache — no recompile per
+        # partition point.
+        compiled = compile_solve(
+            internal_params=partition_params_per_point[0],
+            ages=self.ages,
+            internal_regimes=self.internal_regimes,
+            logger=logger,
+            enable_jit=self.enable_jit,
+            max_compilation_workers=max_compilation_workers,
+        )
+
         sub_V_arrays: list[
             MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]
         ] = []
         try:
-            for partition_point in iterate_partition_points(
-                partition_grid=self._partition_grid
-            ):
-                partition_params = inject_partition_scalars(
-                    internal_params=internal_params,
-                    partition_point=partition_point,
-                    regime_partitions=self._regime_partitions,
-                )
+            for partition_params in partition_params_per_point:
                 validate_regime_transitions_all_periods(
                     internal_regimes=self.internal_regimes,
                     internal_params=partition_params,
                     ages=self.ages,
                 )
                 sub_V_arrays.append(
-                    solve(
+                    run_compiled_solve(
+                        compiled=compiled,
                         internal_params=partition_params,
                         ages=self.ages,
                         internal_regimes=self.internal_regimes,
                         logger=logger,
-                        enable_jit=self.enable_jit,
-                        max_compilation_workers=max_compilation_workers,
                     )
                 )
         except InvalidValueFunctionError as exc:

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -5,12 +5,14 @@ from collections.abc import Mapping
 from pathlib import Path
 from types import MappingProxyType
 
+import jax.numpy as jnp
 import pandas as pd
 from jax import Array
 
 from lcm.ages import AgeGrid
 from lcm.exceptions import InvalidValueFunctionError, ModelInitializationError
 from lcm.grids import DiscreteGrid
+from lcm.interfaces import PeriodRegimeSimulationData
 from lcm.model_processing import (
     _validate_param_types,
     build_regimes_and_template,
@@ -30,8 +32,11 @@ from lcm.persistence import (
 )
 from lcm.regime import Regime
 from lcm.regime_building.partitions import (
+    group_subjects_by_partition,
     inject_partition_scalars,
     iterate_partition_points,
+    slice_initial_conditions,
+    slice_V_at_partition_point,
     stack_partition_V_arrays,
 )
 from lcm.regime_building.processing import InternalRegime
@@ -146,6 +151,12 @@ class Model:
             fixed_params=self.fixed_params,
         )
         self._partition_grid = _build_partition_grid(self.internal_regimes)
+        self._regime_partitions = MappingProxyType(
+            {
+                name: internal_regime.partitions
+                for name, internal_regime in self.internal_regimes.items()
+            }
+        )
         self.enable_jit = enable_jit
         self.simulation_output_dtypes = get_simulation_output_dtypes(
             regimes=self.regimes,
@@ -208,11 +219,6 @@ class Model:
         """
         _validate_log_args(log_level=log_level, log_path=log_path)
         internal_params = self._process_params(params)
-        validate_regime_transitions_all_periods(
-            internal_regimes=self.internal_regimes,
-            internal_params=internal_params,
-            ages=self.ages,
-        )
         logger = get_logger(log_level=log_level)
         sub_V_arrays: list[
             MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]
@@ -220,7 +226,14 @@ class Model:
         try:
             for partition_point in iterate_partition_points(self._partition_grid):
                 partition_params = inject_partition_scalars(
-                    internal_params=internal_params, partition_point=partition_point
+                    internal_params=internal_params,
+                    partition_point=partition_point,
+                    regime_partitions=self._regime_partitions,
+                )
+                validate_regime_transitions_all_periods(
+                    internal_regimes=self.internal_regimes,
+                    internal_params=partition_params,
+                    ages=self.ages,
                 )
                 sub_V_arrays.append(
                     solve(
@@ -329,42 +342,62 @@ class Model:
                 internal_params=internal_params,
                 ages=self.ages,
             )
-        validate_regime_transitions_all_periods(
-            internal_regimes=self.internal_regimes,
-            internal_params=internal_params,
-            ages=self.ages,
-        )
         log = get_logger(log_level=log_level)
         if period_to_regime_to_V_arr is None:
-            try:
-                period_to_regime_to_V_arr = solve(
-                    internal_params=internal_params,
-                    ages=self.ages,
-                    internal_regimes=self.internal_regimes,
-                    logger=log,
-                    enable_jit=self.enable_jit,
-                    max_compilation_workers=max_compilation_workers,
-                )
-            except InvalidValueFunctionError as exc:
-                if log_path is not None and exc.partial_solution is not None:
-                    save_solve_snapshot(
-                        model=self,
-                        params=params,
-                        period_to_regime_to_V_arr=exc.partial_solution,  # ty: ignore[invalid-argument-type]
-                        log_path=Path(log_path),
-                        log_keep_n_latest=log_keep_n_latest,
-                    )
-                raise
-        result = simulate(
-            internal_params=internal_params,
+            period_to_regime_to_V_arr = self.solve(
+                params=params,
+                max_compilation_workers=max_compilation_workers,
+                log_level=log_level,
+                log_path=log_path,
+                log_keep_n_latest=log_keep_n_latest,
+            )
+        subject_ids = jnp.arange(initial_conditions["regime"].shape[0], dtype=jnp.int32)
+        sub_results: list[SimulationResult] = []
+        for partition_point, subject_mask in group_subjects_by_partition(
             initial_conditions=initial_conditions,
-            internal_regimes=self.internal_regimes,
-            regime_names_to_ids=self.regime_names_to_ids,
-            logger=log,
+            partition_grid=self._partition_grid,
+        ):
+            if not bool(jnp.any(subject_mask)):
+                continue
+            partition_params = inject_partition_scalars(
+                internal_params=internal_params,
+                partition_point=partition_point,
+                regime_partitions=self._regime_partitions,
+            )
+            validate_regime_transitions_all_periods(
+                internal_regimes=self.internal_regimes,
+                internal_params=partition_params,
+                ages=self.ages,
+            )
+            group_conditions = slice_initial_conditions(
+                initial_conditions=initial_conditions, subject_mask=subject_mask
+            )
+            group_V = slice_V_at_partition_point(
+                period_to_regime_to_V_arr=period_to_regime_to_V_arr,
+                partition_point=partition_point,
+                partition_grid=self._partition_grid,
+            )
+            sub_results.append(
+                simulate(
+                    internal_params=partition_params,
+                    initial_conditions=group_conditions,
+                    internal_regimes=self.internal_regimes,
+                    regime_names_to_ids=self.regime_names_to_ids,
+                    logger=log,
+                    period_to_regime_to_V_arr=group_V,
+                    ages=self.ages,
+                    simulation_output_dtypes=self.simulation_output_dtypes,
+                    seed=seed,
+                    subject_ids=subject_ids[subject_mask],
+                )
+            )
+        result = _merge_sub_simulation_results(
+            sub_results=sub_results,
+            internal_params=internal_params,
             period_to_regime_to_V_arr=period_to_regime_to_V_arr,
+            internal_regimes=self.internal_regimes,
             ages=self.ages,
             simulation_output_dtypes=self.simulation_output_dtypes,
-            seed=seed,
         )
         if log_level == "debug" and log_path is not None:
             save_simulate_snapshot(
@@ -438,6 +471,107 @@ def _validate_log_args(*, log_level: LogLevel, log_path: str | Path | None) -> N
     if log_level == "debug" and log_path is None:
         msg = "log_path is required when log_level='debug'"
         raise ValueError(msg)
+
+
+def _merge_sub_simulation_results(
+    *,
+    sub_results: list[SimulationResult],
+    internal_params: InternalParams,
+    period_to_regime_to_V_arr: MappingProxyType[
+        int, MappingProxyType[RegimeName, FloatND]
+    ],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    ages: AgeGrid,
+    simulation_output_dtypes: Mapping[str, pd.CategoricalDtype],
+) -> SimulationResult:
+    """Merge per-partition sub-simulation results into one `SimulationResult`.
+
+    For every (regime, period) present in any sub-result, concatenate the
+    per-subject arrays (`V_arr`, `actions[*]`, `states[*]`, `in_regime`,
+    `subject_ids`) across sub-results. Partition scalars injected into
+    each sub-result's `internal_params` are NOT carried forward; the
+    returned object reports the user-supplied `internal_params` and the
+    stacked V-arrays so downstream consumers see an undivided view.
+
+    Args:
+        sub_results: Non-empty list of per-partition-group sub-results.
+        internal_params: Original internal params (without partition
+            injection).
+        period_to_regime_to_V_arr: Stacked V-arrays (with partition axes
+            appended).
+        internal_regimes: Mapping of regime names to internal regimes.
+        ages: AgeGrid for the model.
+        simulation_output_dtypes: Metadata for categorical dtypes.
+
+    Returns:
+        A single `SimulationResult`.
+
+    """
+    if len(sub_results) == 1:
+        only = sub_results[0]
+        return SimulationResult(
+            raw_results=only.raw_results,
+            internal_regimes=internal_regimes,
+            internal_params=internal_params,
+            period_to_regime_to_V_arr=period_to_regime_to_V_arr,
+            ages=ages,
+            simulation_output_dtypes=simulation_output_dtypes,
+        )
+
+    merged_raw: dict[RegimeName, dict[int, PeriodRegimeSimulationData]] = {
+        regime_name: {} for regime_name in internal_regimes
+    }
+    for regime_name in internal_regimes:
+        periods = set()
+        for sub in sub_results:
+            periods |= set(sub.raw_results[regime_name])
+        for period in sorted(periods):
+            slices = [
+                sub.raw_results[regime_name][period]
+                for sub in sub_results
+                if period in sub.raw_results[regime_name]
+            ]
+            if not slices:
+                continue
+            V_arr = jnp.concatenate([s.V_arr for s in slices])
+            action_names = tuple(slices[0].actions)
+            actions = MappingProxyType(
+                {
+                    name: jnp.concatenate([s.actions[name] for s in slices])
+                    for name in action_names
+                }
+            )
+            state_names = tuple(slices[0].states)
+            states = MappingProxyType(
+                {
+                    name: jnp.concatenate([s.states[name] for s in slices])
+                    for name in state_names
+                }
+            )
+            in_regime = jnp.concatenate([s.in_regime for s in slices])
+            subject_ids = jnp.concatenate([s.subject_ids for s in slices])
+            merged_raw[regime_name][period] = PeriodRegimeSimulationData(
+                V_arr=V_arr,
+                actions=actions,
+                states=states,
+                in_regime=in_regime,
+                subject_ids=subject_ids,
+            )
+
+    wrapped = MappingProxyType(
+        {
+            regime_name: MappingProxyType(periods)
+            for regime_name, periods in merged_raw.items()
+        }
+    )
+    return SimulationResult(
+        raw_results=wrapped,
+        internal_regimes=internal_regimes,
+        internal_params=internal_params,
+        period_to_regime_to_V_arr=period_to_regime_to_V_arr,
+        ages=ages,
+        simulation_output_dtypes=simulation_output_dtypes,
+    )
 
 
 def _build_partition_grid(

--- a/src/lcm/regime_building/partitions.py
+++ b/src/lcm/regime_building/partitions.py
@@ -1,18 +1,23 @@
-"""Partition-dimension iteration and result stacking.
+"""Partition-dimension detection, iteration, and result stacking.
 
-A partition dimension is a state declared via `state_transitions[name] = None`.
-The Bellman backward induction never couples values across such a dimension,
-so instead of vectorising over the partition axis (doubling memory per added
-partition dim), pylcm compiles the reduced sub-model once and runs it once
-per point in the Cartesian product of all partition grids.
+A partition dimension is a state declared via `state_transitions[name] = None`
+on a `DiscreteGrid`. The Bellman backward induction never couples values
+across such a dimension, so instead of vectorising over the partition axis
+(doubling memory per added partition dim), pylcm compiles the reduced
+sub-model once and runs it once per point in the Cartesian product of all
+partition grids.
 
-This module provides the small set of helpers that model.solve / model.simulate
-use to iterate over partition points, inject partition-scalar values into
-`internal_params`, group subjects by their partition values at simulate time,
-and stack sub-solve V-arrays back into the user-visible shape.
+The module exposes two layers:
 
-All helpers handle the empty-partition case transparently: a single iteration
-with an empty scalar dict, no subject grouping, no axis stacking.
+- **Model-building** (called from `process_regimes`):
+  `detect_model_partitions`, `lift_partitions_from_regime`.
+- **Solve / simulate runtime** (called from `Model.solve` / `Model.simulate`):
+  `iterate_partition_points`, `inject_partition_scalars`,
+  `stack_partition_V_arrays`, `group_subjects_by_partition`,
+  `slice_V_at_partition_point`, `slice_initial_conditions`.
+
+All helpers handle the empty-partition case transparently: a single
+iteration with an empty scalar dict, no subject grouping, no axis stacking.
 """
 
 import dataclasses
@@ -35,6 +40,7 @@ PartitionPoint = Mapping[str, ScalarInt]
 
 
 def detect_model_partitions(
+    *,
     regimes: Mapping[str, Regime],
 ) -> MappingProxyType[str, DiscreteGrid]:
     """Identify states that qualify as partition dimensions.
@@ -156,6 +162,7 @@ def lift_partitions_from_regime(
 
 
 def iterate_partition_points(
+    *,
     partition_grid: PartitionGrid,
 ) -> Iterator[PartitionPoint]:
     """Yield each point in the Cartesian product of partition grids.
@@ -313,7 +320,7 @@ def group_subjects_by_partition(
         yield MappingProxyType({}), jnp.ones(n_subjects, dtype=bool)
         return
 
-    for point in iterate_partition_points(partition_grid):
+    for point in iterate_partition_points(partition_grid=partition_grid):
         mask = jnp.ones_like(initial_conditions["regime"], dtype=bool)
         for name, scalar in point.items():
             mask = mask & (initial_conditions[name] == scalar)
@@ -335,6 +342,11 @@ def slice_V_at_partition_point(
     `stack_partition_V_arrays`). To hand a slice to one simulation
     dispatch group, fix each partition axis at its corresponding scalar
     code and drop the axis.
+
+    The stacked V-arrays violate `V._fail_if_interpolation_axes_are_not_last`
+    because continuous state axes are no longer the trailing axes; this
+    invariant is restored by slicing here. **`Model.simulate` must call
+    this before handing the V-arrays to the per-subject interpolator.**
 
     Args:
         period_to_regime_to_V_arr: V-arrays with partition axes appended.

--- a/src/lcm/regime_building/partitions.py
+++ b/src/lcm/regime_building/partitions.py
@@ -1,0 +1,176 @@
+"""Partition-dimension iteration and result stacking.
+
+A partition dimension is a state declared via `state_transitions[name] = None`.
+The Bellman backward induction never couples values across such a dimension,
+so instead of vectorising over the partition axis (doubling memory per added
+partition dim), pylcm compiles the reduced sub-model once and runs it once
+per point in the Cartesian product of all partition grids.
+
+This module provides the small set of helpers that model.solve / model.simulate
+use to iterate over partition points, inject partition-scalar values into
+`internal_params`, group subjects by their partition values at simulate time,
+and stack sub-solve V-arrays back into the user-visible shape.
+
+All helpers handle the empty-partition case transparently: a single iteration
+with an empty scalar dict, no subject grouping, no axis stacking.
+"""
+
+from collections.abc import Iterator, Mapping
+from itertools import product
+from types import MappingProxyType
+
+import jax.numpy as jnp
+from jax import Array
+
+from lcm.grids import DiscreteGrid
+from lcm.typing import FloatND, InternalParams, RegimeName, ScalarInt
+
+# Mapping of partition-dimension name to its discrete grid.
+PartitionGrid = Mapping[str, DiscreteGrid]
+
+# One concrete partition value per partition-dimension name.
+PartitionPoint = Mapping[str, ScalarInt]
+
+
+def iterate_partition_points(
+    partition_grid: PartitionGrid,
+) -> Iterator[PartitionPoint]:
+    """Yield each point in the Cartesian product of partition grids.
+
+    Empty `partition_grid` yields a single empty dict so callers can loop
+    unconditionally.
+
+    Args:
+        partition_grid: Mapping of partition names to their discrete grids.
+
+    Yields:
+        Immutable mapping of partition name to scalar integer code for each
+        point in the product.
+
+    """
+    if not partition_grid:
+        yield MappingProxyType({})
+        return
+
+    names = tuple(partition_grid)
+    codes_per_name = tuple(partition_grid[name].codes for name in names)
+    for codes in product(*codes_per_name):
+        yield MappingProxyType(
+            {name: jnp.int32(code) for name, code in zip(names, codes, strict=True)}
+        )
+
+
+def inject_partition_scalars(
+    *,
+    internal_params: InternalParams,
+    partition_point: PartitionPoint,
+) -> InternalParams:
+    """Return a copy of `internal_params` with partition scalars injected.
+
+    Each partition value is added to every regime's flat params so that the
+    compiled Q_and_F / max_Q_over_a closure receives it as a kwarg (the same
+    channel user-supplied scalars flow through). No-op when the point is empty.
+
+    Args:
+        internal_params: Existing internal params, keyed by regime name.
+        partition_point: Partition scalars to inject.
+
+    Returns:
+        New internal-params mapping with partition scalars added to each
+        regime. The original is unchanged.
+
+    """
+    if not partition_point:
+        return internal_params
+    return MappingProxyType(
+        {
+            regime_name: MappingProxyType({**regime_params, **partition_point})
+            for regime_name, regime_params in internal_params.items()
+        }
+    )
+
+
+def stack_partition_V_arrays(
+    *,
+    sub_V_arrays: list[MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]],
+    partition_grid: PartitionGrid,
+) -> MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]:
+    """Stack per-partition V-arrays along trailing axes.
+
+    Partition axes are appended after all existing discrete/continuous state
+    axes, in `partition_grid` insertion order. When `partition_grid` is empty,
+    `sub_V_arrays` has a single entry and is returned as-is.
+
+    Args:
+        sub_V_arrays: One `period → regime → V` mapping per partition point,
+            in the order produced by `iterate_partition_points`.
+        partition_grid: Partition grids defining axis shape and order.
+
+    Returns:
+        A single `period → regime → V` mapping whose V-arrays carry the
+        partition axes at the end.
+
+    """
+    if not partition_grid:
+        (single,) = sub_V_arrays
+        return single
+
+    names = tuple(partition_grid)
+    shape = tuple(len(partition_grid[name].codes) for name in names)
+
+    periods = sub_V_arrays[0].keys()
+    regimes = sub_V_arrays[0][next(iter(periods))].keys()
+
+    stacked: dict[int, dict[RegimeName, FloatND]] = {}
+    for period in periods:
+        stacked[period] = {}
+        for regime in regimes:
+            per_point = [sub[period][regime] for sub in sub_V_arrays]
+            stacked_arr = jnp.stack(per_point, axis=0).reshape(
+                shape + per_point[0].shape
+            )
+            # Move the prepended partition axes to the end so the convention
+            # is [non-partition state/action axes..., partition axes...].
+            n_partition = len(shape)
+            axes_in = tuple(range(stacked_arr.ndim))
+            axes_out = axes_in[n_partition:] + axes_in[:n_partition]
+            stacked[period][regime] = jnp.transpose(stacked_arr, axes_out)
+
+    return MappingProxyType(
+        {
+            period: MappingProxyType(regime_dict)
+            for period, regime_dict in stacked.items()
+        }
+    )
+
+
+def group_subjects_by_partition(
+    *,
+    initial_conditions: Mapping[str, Array],
+    partition_grid: PartitionGrid,
+) -> Iterator[tuple[PartitionPoint, Array]]:
+    """Yield (partition_point, subject_mask) for each partition group.
+
+    Subjects are grouped by the tuple of their partition-state values read
+    from `initial_conditions`. Empty `partition_grid` yields a single group
+    containing all subjects.
+
+    Args:
+        initial_conditions: Flat mapping that must contain one array per
+            partition name (integer category codes).
+        partition_grid: Partition grids defining which columns to read.
+
+    Yields:
+        Tuples of (partition scalars, boolean subject mask).
+
+    """
+    if not partition_grid:
+        n_subjects = initial_conditions["regime"].shape[0]
+        yield MappingProxyType({}), jnp.ones(n_subjects, dtype=bool)
+        return
+
+    for point in iterate_partition_points(partition_grid):
+        mask = jnp.ones_like(initial_conditions["regime"], dtype=bool)
+        for name, scalar in point.items():
+            mask = mask & (initial_conditions[name] == scalar)
+        yield point, mask

--- a/src/lcm/regime_building/partitions.py
+++ b/src/lcm/regime_building/partitions.py
@@ -65,8 +65,15 @@ def detect_model_partitions(
     """
     candidates: dict[str, DiscreteGrid] = {}
     disqualified: set[str] = set()
+    # A partition value must come from initial_conditions, which implies the
+    # state exists in at least one non-terminal regime where subjects can
+    # start. Target-only states (declared only in terminal regimes, populated
+    # by per-target transitions at the boundary) are therefore excluded.
+    seen_in_non_terminal: set[str] = set()
 
     for regime in regimes.values():
+        if not regime.terminal:
+            seen_in_non_terminal.update(regime.states)
         for name, grid in regime.states.items():
             if name in disqualified:
                 continue
@@ -74,7 +81,12 @@ def detect_model_partitions(
                 disqualified.add(name)
                 candidates.pop(name, None)
                 continue
-            if regime.state_transitions.get(name, "MISSING") is not None:
+            # Terminal regimes require `state_transitions` to be empty by
+            # validation, so the absence of an entry is the terminal-regime
+            # analogue of `None` — the value is carried through unchanged.
+            if not regime.terminal and (
+                regime.state_transitions.get(name, "MISSING") is not None
+            ):
                 disqualified.add(name)
                 candidates.pop(name, None)
                 continue
@@ -84,7 +96,13 @@ def detect_model_partitions(
             elif existing.categories != grid.categories:
                 disqualified.add(name)
                 candidates.pop(name, None)
-    return MappingProxyType(candidates)
+    return MappingProxyType(
+        {
+            name: grid
+            for name, grid in candidates.items()
+            if name in seen_in_non_terminal
+        }
+    )
 
 
 def lift_partitions_from_regime(

--- a/src/lcm/regime_building/partitions.py
+++ b/src/lcm/regime_building/partitions.py
@@ -15,6 +15,7 @@ All helpers handle the empty-partition case transparently: a single iteration
 with an empty scalar dict, no subject grouping, no axis stacking.
 """
 
+import dataclasses
 from collections.abc import Iterator, Mapping
 from itertools import product
 from types import MappingProxyType
@@ -23,6 +24,7 @@ import jax.numpy as jnp
 from jax import Array
 
 from lcm.grids import DiscreteGrid
+from lcm.regime import Regime
 from lcm.typing import FloatND, InternalParams, RegimeName, ScalarInt
 
 # Mapping of partition-dimension name to its discrete grid.
@@ -30,6 +32,109 @@ PartitionGrid = Mapping[str, DiscreteGrid]
 
 # One concrete partition value per partition-dimension name.
 PartitionPoint = Mapping[str, ScalarInt]
+
+
+def detect_model_partitions(
+    regimes: Mapping[str, Regime],
+) -> MappingProxyType[str, DiscreteGrid]:
+    """Identify states that qualify as partition dimensions.
+
+    A partition dimension is a discrete state whose value truly never
+    changes — not just within one regime, but across the entire model.
+    The qualification is:
+
+    1. The state's grid is a `DiscreteGrid`.
+    2. Every regime that includes the state declares `state_transitions[name]
+       = None` for it (never via a non-None transition or per-target dict).
+    3. All such regimes agree on the `DiscreteGrid.categories`.
+
+    Why all three: if any regime carries a non-identity transition for the
+    state, the state changes in that regime, so it cannot be modelled as a
+    fixed partition dimension. If categories differ across regimes, the
+    state behaves like different things in different regimes — again not a
+    partition. Continuous fixed states are never lifted (identity
+    transitions remain the correct implementation for them).
+
+    Args:
+        regimes: Mapping of regime names to user-facing regimes.
+
+    Returns:
+        Immutable mapping of partition name to its `DiscreteGrid`. Empty
+        when no state in the model meets the criteria above.
+
+    """
+    candidates: dict[str, DiscreteGrid] = {}
+    disqualified: set[str] = set()
+
+    for regime in regimes.values():
+        for name, grid in regime.states.items():
+            if name in disqualified:
+                continue
+            if not isinstance(grid, DiscreteGrid):
+                disqualified.add(name)
+                candidates.pop(name, None)
+                continue
+            if regime.state_transitions.get(name, "MISSING") is not None:
+                disqualified.add(name)
+                candidates.pop(name, None)
+                continue
+            existing = candidates.get(name)
+            if existing is None:
+                candidates[name] = grid
+            elif existing.categories != grid.categories:
+                disqualified.add(name)
+                candidates.pop(name, None)
+    return MappingProxyType(candidates)
+
+
+def lift_partitions_from_regime(
+    *,
+    regime: Regime,
+    partition_names: frozenset[str],
+) -> tuple[Regime, MappingProxyType[str, DiscreteGrid]]:
+    """Return a regime with the given partition states removed.
+
+    Used after `detect_model_partitions` identifies which states qualify
+    as partition dimensions across the whole model. Strips those states
+    (and their `None` `state_transitions` entries) from the regime so
+    downstream machinery sees only the varying state space.
+
+    Args:
+        regime: User-facing regime.
+        partition_names: Names of partition states at the model level.
+            States a regime does not include are ignored.
+
+    Returns:
+        Tuple of `(reduced_regime, partitions)` — the subset of
+        `partition_names` this regime actually declared (so solve /
+        simulate know which scalars to inject for this regime).
+
+    """
+    to_strip = {name for name in partition_names if name in regime.states}
+    if not to_strip:
+        return regime, MappingProxyType({})
+
+    partitions: dict[str, DiscreteGrid] = {}
+    for name in to_strip:
+        grid = regime.states[name]
+        assert isinstance(grid, DiscreteGrid)  # noqa: S101 — model-level check
+        partitions[name] = grid
+    reduced_states = MappingProxyType(
+        {name: grid for name, grid in regime.states.items() if name not in to_strip}
+    )
+    reduced_state_transitions = MappingProxyType(
+        {
+            name: transition
+            for name, transition in regime.state_transitions.items()
+            if name not in to_strip
+        }
+    )
+    reduced = dataclasses.replace(
+        regime,
+        states=reduced_states,
+        state_transitions=reduced_state_transitions,
+    )
+    return reduced, MappingProxyType(partitions)
 
 
 def iterate_partition_points(
@@ -64,19 +169,25 @@ def inject_partition_scalars(
     *,
     internal_params: InternalParams,
     partition_point: PartitionPoint,
+    regime_partitions: Mapping[RegimeName, Mapping[str, DiscreteGrid]],
 ) -> InternalParams:
     """Return a copy of `internal_params` with partition scalars injected.
 
-    Each partition value is added to every regime's flat params so that the
-    compiled Q_and_F / max_Q_over_a closure receives it as a kwarg (the same
-    channel user-supplied scalars flow through). No-op when the point is empty.
+    For each regime, only partition values *declared on that regime* are
+    injected — a regime whose functions never reference a partition name
+    would otherwise receive it as an unexpected kwarg and the compiled
+    closure's enforced signature would reject it.
 
     Args:
         internal_params: Existing internal params, keyed by regime name.
-        partition_point: Partition scalars to inject.
+        partition_point: Partition scalars to inject (all partitions in
+            the model-level grid).
+        regime_partitions: Per-regime mapping of partition names → grid.
+            Used to filter `partition_point` down to the subset each
+            regime actually declares.
 
     Returns:
-        New internal-params mapping with partition scalars added to each
+        New internal-params mapping with partition scalars added per
         regime. The original is unchanged.
 
     """
@@ -84,7 +195,16 @@ def inject_partition_scalars(
         return internal_params
     return MappingProxyType(
         {
-            regime_name: MappingProxyType({**regime_params, **partition_point})
+            regime_name: MappingProxyType(
+                {
+                    **regime_params,
+                    **{
+                        name: partition_point[name]
+                        for name in regime_partitions.get(regime_name, {})
+                        if name in partition_point
+                    },
+                }
+            )
             for regime_name, regime_params in internal_params.items()
         }
     )
@@ -117,21 +237,27 @@ def stack_partition_V_arrays(
 
     names = tuple(partition_grid)
     shape = tuple(len(partition_grid[name].codes) for name in names)
-
-    periods = sub_V_arrays[0].keys()
-    regimes = sub_V_arrays[0][next(iter(periods))].keys()
+    n_partition = len(shape)
 
     stacked: dict[int, dict[RegimeName, FloatND]] = {}
-    for period in periods:
+    for period in sub_V_arrays[0]:
         stacked[period] = {}
-        for regime in regimes:
+        # Regimes may differ across periods (a regime only appears in
+        # `sub[period]` when it is active there); take the union.
+        regimes_this_period: list[RegimeName] = []
+        seen: set[RegimeName] = set()
+        for sub in sub_V_arrays:
+            for regime in sub[period]:
+                if regime not in seen:
+                    seen.add(regime)
+                    regimes_this_period.append(regime)
+        for regime in regimes_this_period:
             per_point = [sub[period][regime] for sub in sub_V_arrays]
             stacked_arr = jnp.stack(per_point, axis=0).reshape(
                 shape + per_point[0].shape
             )
             # Move the prepended partition axes to the end so the convention
             # is [non-partition state/action axes..., partition axes...].
-            n_partition = len(shape)
             axes_in = tuple(range(stacked_arr.ndim))
             axes_out = axes_in[n_partition:] + axes_in[:n_partition]
             stacked[period][regime] = jnp.transpose(stacked_arr, axes_out)
@@ -174,3 +300,71 @@ def group_subjects_by_partition(
         for name, scalar in point.items():
             mask = mask & (initial_conditions[name] == scalar)
         yield point, mask
+
+
+def slice_V_at_partition_point(
+    *,
+    period_to_regime_to_V_arr: MappingProxyType[
+        int, MappingProxyType[RegimeName, FloatND]
+    ],
+    partition_point: PartitionPoint,
+    partition_grid: PartitionGrid,
+) -> MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]:
+    """Slice stacked V-arrays at a single partition point.
+
+    The V-arrays returned by `Model.solve` carry partition axes appended
+    after all discrete/continuous state axes (see
+    `stack_partition_V_arrays`). To hand a slice to one simulation
+    dispatch group, fix each partition axis at its corresponding scalar
+    code and drop the axis.
+
+    Args:
+        period_to_regime_to_V_arr: V-arrays with partition axes appended.
+        partition_point: Scalar value per partition dimension.
+        partition_grid: Partition grids defining name/position.
+
+    Returns:
+        V-arrays without partition axes.
+
+    """
+    if not partition_grid:
+        return period_to_regime_to_V_arr
+
+    names = tuple(partition_grid)
+    codes_by_name = tuple(tuple(partition_grid[name].codes) for name in names)
+    index_per_axis = tuple(
+        codes_by_name[i].index(int(partition_point[name]))
+        for i, name in enumerate(names)
+    )
+
+    sliced: dict[int, dict[RegimeName, FloatND]] = {}
+    for period, regime_to_V in period_to_regime_to_V_arr.items():
+        sliced[period] = {}
+        for regime, V in regime_to_V.items():
+            idx: tuple[slice | int, ...] = (slice(None),) * (
+                V.ndim - len(partition_grid)
+            ) + index_per_axis
+            sliced[period][regime] = V[idx]
+    return MappingProxyType({p: MappingProxyType(rd) for p, rd in sliced.items()})
+
+
+def slice_initial_conditions(
+    *,
+    initial_conditions: Mapping[str, Array],
+    subject_mask: Array,
+) -> MappingProxyType[str, Array]:
+    """Filter every array in `initial_conditions` by a boolean subject mask.
+
+    Args:
+        initial_conditions: Flat mapping of state names (plus `"regime"`) to
+            subject-indexed arrays.
+        subject_mask: Boolean 1-D array marking the subjects to keep.
+
+    Returns:
+        Immutable mapping with the same keys but arrays filtered to the
+        selected subjects.
+
+    """
+    return MappingProxyType(
+        {name: arr[subject_mask] for name, arr in initial_conditions.items()}
+    )

--- a/src/lcm/regime_building/processing.py
+++ b/src/lcm/regime_building/processing.py
@@ -313,22 +313,6 @@ def _build_solve_functions(
         enable_jit=enable_jit,
     )
 
-    compute_intermediates = _build_compute_intermediates_per_period(
-        regime=regime,
-        flat_param_names=frozenset(get_flat_param_names(regime_params_template)),
-        regimes_to_active_periods=regimes_to_active_periods,
-        functions=core.functions,
-        constraints=core.constraints,
-        transitions=core.transitions,
-        stochastic_transition_names=core.stochastic_transition_names,
-        compute_regime_transition_probs=compute_regime_transition_probs,
-        regime_to_v_interpolation_info=regime_to_v_interpolation_info,
-        state_action_space=state_action_space,
-        grids=all_grids[regime_name],
-        ages=ages,
-        enable_jit=enable_jit,
-    )
-
     return SolveFunctions(
         functions=core.functions,
         constraints=core.constraints,

--- a/src/lcm/regime_building/processing.py
+++ b/src/lcm/regime_building/processing.py
@@ -34,6 +34,10 @@ from lcm.regime_building.max_Q_over_a import (
 )
 from lcm.regime_building.ndimage import map_coordinates
 from lcm.regime_building.next_state import get_next_state_function_for_simulation
+from lcm.regime_building.partitions import (
+    detect_model_partitions,
+    lift_partitions_from_regime,
+)
 from lcm.regime_building.Q_and_F import (
     get_complete_targets,
     get_Q_and_F,
@@ -75,10 +79,15 @@ def process_regimes(
 ) -> MappingProxyType[RegimeName, InternalRegime]:
     """Process user regimes into internal regimes.
 
-    Extract state transitions from `regime.state_transitions` and
-    regime transitions from `regime.transition`. For fixed states (value `None`
-    in `state_transitions`), an identity transition is auto-generated. ShockGrid
-    transitions are generated from the grid's intrinsic transition logic.
+    Before any downstream machinery runs, states declared with
+    `state_transitions[name] = None` are lifted out of the regime via
+    `lift_partitions` and stored on the returned `InternalRegime` as
+    `partitions`. Solve and simulate iterate over the product of
+    partition grids once per point — the reduced regime below never
+    sees a partition state as a vmap'd axis.
+
+    ShockGrid transitions are still generated from the grid's intrinsic
+    transition logic. Regime transitions come from `regime.transition`.
 
     Args:
         regimes: Mapping of regime names to Regime instances.
@@ -90,43 +99,60 @@ def process_regimes(
         The processed regimes.
 
     """
+    partition_names = frozenset(detect_model_partitions(regimes))
+    lifted = {
+        name: lift_partitions_from_regime(
+            regime=regime, partition_names=partition_names
+        )
+        for name, regime in regimes.items()
+    }
+    reduced_regimes = MappingProxyType({n: rp[0] for n, rp in lifted.items()})
+    partitions_per_regime = MappingProxyType({n: rp[1] for n, rp in lifted.items()})
+
     states_per_regime: dict[RegimeName, set[str]] = {
-        name: set(regime.states.keys()) for name, regime in regimes.items()
+        name: set(regime.states.keys()) for name, regime in reduced_regimes.items()
     }
 
     nested_transitions = {}
-    for name, regime in regimes.items():
+    for name, regime in reduced_regimes.items():
         nested_transitions[name] = _extract_transitions_from_regime(
             regime=regime,
             states_per_regime=states_per_regime,
         )
+    # Validate against user-facing regimes so partition states still appear
+    # in `regime.states` — category-mismatch checks must see the original
+    # grids regardless of which states have been lifted.
     _validate_categoricals(regimes)
 
     variable_info = MappingProxyType(
-        {n: get_variable_info(r) for n, r in regimes.items()}
+        {n: get_variable_info(r) for n, r in reduced_regimes.items()}
     )
-    all_grids = MappingProxyType({n: get_grids(r) for n, r in regimes.items()})
+    all_grids = MappingProxyType({n: get_grids(r) for n, r in reduced_regimes.items()})
 
-    _fail_if_action_has_batch_size(regimes)
+    _fail_if_action_has_batch_size(reduced_regimes)
 
     regime_to_v_interpolation_info = MappingProxyType(
-        {n: create_v_interpolation_info(r) for n, r in regimes.items()}
+        {n: create_v_interpolation_info(r) for n, r in reduced_regimes.items()}
     )
     state_action_spaces = MappingProxyType(
         {
             n: create_state_action_space(
                 variable_info=variable_info[n], grids=all_grids[n]
             )
-            for n in regimes
+            for n in reduced_regimes
         }
     )
     regimes_to_active_periods = MappingProxyType(
-        {n: ages.get_periods_where(r.active) for n, r in regimes.items()}
+        {n: ages.get_periods_where(r.active) for n, r in reduced_regimes.items()}
     )
 
     internal_regimes = {}
-    for name, regime in regimes.items():
-        regime_params_template = create_regime_params_template(regime)
+    for name, regime in reduced_regimes.items():
+        partition_names = frozenset(partitions_per_regime[name])
+        # Template is built from the user-facing regime so partition states
+        # (still in `regimes[name].states`) remain excluded from function
+        # params — they are never user-supplied.
+        regime_params_template = create_regime_params_template(regimes[name])
 
         solve_functions = _build_solve_functions(
             regime=regime,
@@ -139,6 +165,7 @@ def process_regimes(
             regimes_to_active_periods=regimes_to_active_periods,
             regime_to_v_interpolation_info=regime_to_v_interpolation_info,
             state_action_space=state_action_spaces[name],
+            partition_names=partition_names,
             ages=ages,
             enable_jit=enable_jit,
         )
@@ -154,6 +181,7 @@ def process_regimes(
             regimes_to_active_periods=regimes_to_active_periods,
             regime_to_v_interpolation_info=regime_to_v_interpolation_info,
             state_action_space=state_action_spaces[name],
+            partition_names=partition_names,
             ages=ages,
             enable_jit=enable_jit,
             solve_transitions=solve_functions.transitions,
@@ -171,6 +199,7 @@ def process_regimes(
             solve_functions=solve_functions,
             simulate_functions=simulate_functions,
             _base_state_action_space=state_action_spaces[name],
+            partitions=partitions_per_regime[name],
         )
 
     return ensure_containers_are_immutable(internal_regimes)
@@ -188,6 +217,7 @@ def _build_solve_functions(
     regimes_to_active_periods: MappingProxyType[RegimeName, tuple[int, ...]],
     regime_to_v_interpolation_info: MappingProxyType[RegimeName, VInterpolationInfo],
     state_action_space: StateActionSpace,
+    partition_names: frozenset[str],
     ages: AgeGrid,
     enable_jit: bool,
 ) -> SolveFunctions:
@@ -204,6 +234,9 @@ def _build_solve_functions(
         regimes_to_active_periods: Mapping of regime names to active period tuples.
         regime_to_v_interpolation_info: Mapping of regime names to state space info.
         state_action_space: The state-action space for this regime.
+        partition_names: Frozenset of partition-dimension names lifted out of
+            the state space. Threaded into `flat_param_names` so downstream
+            builders treat them as scalar kwargs (not vmap'd axes).
         ages: The AgeGrid for the model.
         enable_jit: Whether to jit the internal functions.
 
@@ -220,7 +253,9 @@ def _build_solve_functions(
         phase="solve",
     )
 
-    flat_param_names = frozenset(get_flat_param_names(regime_params_template))
+    flat_param_names = (
+        frozenset(get_flat_param_names(regime_params_template)) | partition_names
+    )
 
     if regime.terminal:
         compute_regime_transition_probs = None
@@ -240,6 +275,7 @@ def _build_solve_functions(
             grids=all_grids[regime_name],
             regime_names_to_ids=regime_names_to_ids,
             regime_params_template=regime_params_template,
+            partition_names=partition_names,
             is_stochastic=regime.stochastic_regime_transition,
             enable_jit=enable_jit,
             phase="solve",
@@ -300,6 +336,7 @@ def _build_simulate_functions(
     regimes_to_active_periods: MappingProxyType[RegimeName, tuple[int, ...]],
     regime_to_v_interpolation_info: MappingProxyType[RegimeName, VInterpolationInfo],
     state_action_space: StateActionSpace,
+    partition_names: frozenset[str],
     ages: AgeGrid,
     enable_jit: bool,
     solve_transitions: TransitionFunctionsMapping,
@@ -351,7 +388,9 @@ def _build_simulate_functions(
     functions = core.functions
     constraints = core.constraints
 
-    flat_param_names = frozenset(get_flat_param_names(regime_params_template))
+    flat_param_names = (
+        frozenset(get_flat_param_names(regime_params_template)) | partition_names
+    )
 
     if regime.terminal:
         compute_regime_transition_probs = None
@@ -370,6 +409,7 @@ def _build_simulate_functions(
             grids=all_grids[regime_name],
             regime_names_to_ids=regime_names_to_ids,
             regime_params_template=regime_params_template,
+            partition_names=partition_names,
             is_stochastic=regime.stochastic_regime_transition,
             enable_jit=enable_jit,
             phase="simulate",
@@ -405,6 +445,7 @@ def _build_simulate_functions(
         all_grids=all_grids,
         variable_info=variable_info,
         regime_params_template=regime_params_template,
+        partition_names=partition_names,
         enable_jit=enable_jit,
     )
 
@@ -1135,6 +1176,7 @@ def build_regime_transition_probs_functions(
     grids: MappingProxyType[str, Grid],
     regime_names_to_ids: RegimeNamesToIds,
     regime_params_template: RegimeParamsTemplate,
+    partition_names: frozenset[str],
     is_stochastic: bool,
     enable_jit: bool,
     phase: Literal["solve", "simulate"],
@@ -1194,6 +1236,7 @@ def build_regime_transition_probs_functions(
         variables=_get_vmap_params(
             all_args=tuple(inspect.signature(next_regime_accepting_all).parameters),
             regime_params_template=regime_params_template,
+            partition_names=partition_names,
         ),
     )
 
@@ -1287,9 +1330,18 @@ def _get_vmap_params(
     *,
     all_args: tuple[str, ...],
     regime_params_template: RegimeParamsTemplate,
+    partition_names: frozenset[str] = frozenset(),
 ) -> tuple[str, ...]:
-    """Get parameter names that should be vmapped (states and actions)."""
-    non_vmap = {"period", "age"} | get_flat_param_names(regime_params_template)
+    """Get parameter names that should be vmapped (states and actions).
+
+    Partition names, `period`, `age`, and any user-supplied flat param are
+    runtime scalars, not vmap'd axes.
+    """
+    non_vmap = (
+        {"period", "age"}
+        | get_flat_param_names(regime_params_template)
+        | partition_names
+    )
     return tuple(arg for arg in all_args if arg not in non_vmap)
 
 
@@ -1436,6 +1488,7 @@ def _build_next_state_vmapped(
     all_grids: MappingProxyType[RegimeName, MappingProxyType[str, Grid]],
     variable_info: pd.DataFrame,
     regime_params_template: RegimeParamsTemplate,
+    partition_names: frozenset[str],
     enable_jit: bool,
 ) -> NextStateSimulationFunction:
     """Build a vmapped next-state function for simulation."""
@@ -1448,7 +1501,11 @@ def _build_next_state_vmapped(
     )
     sig_args = tuple(inspect.signature(next_state).parameters)
 
-    non_vmap = {"period", "age"} | get_flat_param_names(regime_params_template)
+    non_vmap = (
+        {"period", "age"}
+        | get_flat_param_names(regime_params_template)
+        | partition_names
+    )
     vmap_variables = tuple(arg for arg in sig_args if arg not in non_vmap)
 
     next_state_vmapped = vmap_1d(func=next_state, variables=vmap_variables)

--- a/src/lcm/regime_building/processing.py
+++ b/src/lcm/regime_building/processing.py
@@ -99,7 +99,7 @@ def process_regimes(
         The processed regimes.
 
     """
-    partition_names = frozenset(detect_model_partitions(regimes))
+    partition_names = frozenset(detect_model_partitions(regimes=regimes))
     lifted = {
         name: lift_partitions_from_regime(
             regime=regime, partition_names=partition_names
@@ -148,7 +148,7 @@ def process_regimes(
 
     internal_regimes = {}
     for name, regime in reduced_regimes.items():
-        partition_names = frozenset(partitions_per_regime[name])
+        regime_partition_names = frozenset(partitions_per_regime[name])
         # Template is built from the user-facing regime so partition states
         # (still in `regimes[name].states`) remain excluded from function
         # params — they are never user-supplied.
@@ -165,7 +165,7 @@ def process_regimes(
             regimes_to_active_periods=regimes_to_active_periods,
             regime_to_v_interpolation_info=regime_to_v_interpolation_info,
             state_action_space=state_action_spaces[name],
-            partition_names=partition_names,
+            partition_names=regime_partition_names,
             ages=ages,
             enable_jit=enable_jit,
         )
@@ -181,7 +181,7 @@ def process_regimes(
             regimes_to_active_periods=regimes_to_active_periods,
             regime_to_v_interpolation_info=regime_to_v_interpolation_info,
             state_action_space=state_action_spaces[name],
-            partition_names=partition_names,
+            partition_names=regime_partition_names,
             ages=ages,
             enable_jit=enable_jit,
             solve_transitions=solve_functions.transitions,

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -596,7 +596,10 @@ def _check_regime_feasibility(  # noqa: C901
     flat_actions = _build_flat_action_grid(action_names=action_names, grids=grids)
 
     filtered_params = {k: v for k, v in regime_params.items() if k in accepted}
-    state_names = list(internal_regime.variable_info.query("is_state").index)
+    state_names = [
+        *internal_regime.variable_info.query("is_state").index,
+        *internal_regime.partitions,
+    ]
     needs_age = "age" in accepted
     needs_period = "period" in accepted
 

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -447,20 +447,24 @@ def _validate_discrete_state_values(
         InvalidInitialConditionsError: If any discrete state contains invalid codes.
 
     """
-    # Build per-state: valid codes + regime IDs that have this state
+    # Build per-state: valid codes + regime IDs that have this state.
+    # Partitions are lifted out of variable_info but still carry valid-code sets
+    # the user's initial_conditions must respect.
     discrete_info: dict[str, tuple[set[int], set[int]]] = {}
     for regime_name, internal_regime in internal_regimes.items():
         regime_id = regime_names_to_ids[regime_name]
-        for state_name in internal_regime.variable_info.query(
-            "is_state and is_discrete"
-        ).index:
-            grid = internal_regime.grids[state_name]
+        discrete_state_grids: dict[str, DiscreteGrid] = {}
+        for sn in internal_regime.variable_info.query("is_state and is_discrete").index:
+            grid = internal_regime.grids[sn]
             if isinstance(grid, DiscreteGrid):
-                codes, regime_ids = discrete_info.get(state_name, (set(), set()))
-                discrete_info[state_name] = (
-                    codes | set(grid.codes),
-                    regime_ids | {regime_id},
-                )
+                discrete_state_grids[sn] = grid
+        discrete_state_grids.update(internal_regime.partitions)
+        for state_name, grid in discrete_state_grids.items():
+            codes, regime_ids = discrete_info.get(state_name, (set(), set()))
+            discrete_info[state_name] = (
+                codes | set(grid.codes),
+                regime_ids | {regime_id},
+            )
 
     for state_name, (valid_codes, regime_ids) in discrete_info.items():
         if state_name not in initial_states:
@@ -596,10 +600,7 @@ def _check_regime_feasibility(  # noqa: C901
     flat_actions = _build_flat_action_grid(action_names=action_names, grids=grids)
 
     filtered_params = {k: v for k, v in regime_params.items() if k in accepted}
-    state_names = [
-        *internal_regime.variable_info.query("is_state").index,
-        *internal_regime.partitions,
-    ]
+    state_names = list(_get_regime_state_names(internal_regime))
     needs_age = "age" in accepted
     needs_period = "period" in accepted
 
@@ -687,7 +688,10 @@ def _raise_feasibility_type_error(
     """
     discrete_names = {
         name
-        for name, grid in internal_regime.grids.items()
+        for name, grid in {
+            **internal_regime.grids,
+            **internal_regime.partitions,
+        }.items()
         if isinstance(grid, DiscreteGrid)
     }
 

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -64,7 +64,11 @@ def build_initial_states(
             key = f"{regime_name}__{state_name}"
             if state_name in initial_states:
                 flat[key] = initial_states[state_name]
-            elif isinstance(internal_regime.grids[state_name], DiscreteGrid):
+                continue
+            spec = internal_regime.grids.get(
+                state_name
+            ) or internal_regime.partitions.get(state_name)
+            if isinstance(spec, DiscreteGrid):
                 flat[key] = jnp.full(n_subjects, MISSING_CAT_CODE, dtype=jnp.int32)
             else:
                 flat[key] = jnp.full(n_subjects, jnp.nan)
@@ -168,14 +172,21 @@ def _get_regime_state_names(
 ) -> set[str]:
     """Get state names from an internal regime's variable info.
 
+    Partition dimensions count as "states" at the initial-conditions boundary
+    even though they are lifted out of the state-action space internally:
+    subjects must supply a concrete value per partition dim so simulate can
+    dispatch them into the correct sub-solution.
+
     Args:
         internal_regime: The internal regime instance.
 
     Returns:
-        Set of state variable names.
+        Set of state variable names plus partition names.
 
     """
-    return set(internal_regime.variable_info.query("is_state").index)
+    return set(internal_regime.variable_info.query("is_state").index) | set(
+        internal_regime.partitions
+    )
 
 
 def _format_missing_states_message(missing: set[str], required: set[str]) -> str:

--- a/src/lcm/simulation/result.py
+++ b/src/lcm/simulation/result.py
@@ -309,7 +309,10 @@ def _compute_metadata(
 
     for regime_name, regime in internal_regimes.items():
         vi = regime.variable_info
-        states = tuple(vi.query("is_state").index.tolist())
+        # Partition dimensions were lifted out of `variable_info` but the
+        # simulation output must still surface them as "state" columns —
+        # every subject's value is tracked in `raw_results.states`.
+        states = tuple(vi.query("is_state").index.tolist()) + tuple(regime.partitions)
         actions = tuple(vi.query("is_action").index.tolist())
         regime_to_states[regime_name] = states
         regime_to_actions[regime_name] = actions
@@ -331,6 +334,8 @@ def _compute_metadata(
         for var_name, grid in regime.grids.items():
             if isinstance(grid, DiscreteGrid):
                 regime_discrete_categories[(regime_name, var_name)] = grid.categories
+        for var_name, grid in regime.partitions.items():
+            regime_discrete_categories[(regime_name, var_name)] = grid.categories
 
     n_periods = ages.n_periods
     n_subjects = _get_n_subjects(raw_results)

--- a/src/lcm/simulation/result.py
+++ b/src/lcm/simulation/result.py
@@ -520,7 +520,7 @@ def _extract_period_data(
 ) -> dict[str, Array]:
     """Extract data from a single period's simulation results."""
     data: dict[str, Array] = {
-        "subject_id": jnp.arange(len(result.in_regime)),
+        "subject_id": result.subject_ids,
         "period": jnp.full_like(result.in_regime, period, dtype=jnp.int32),
         "_in_regime": result.in_regime,
         "value": result.V_arr,

--- a/src/lcm/simulation/result.py
+++ b/src/lcm/simulation/result.py
@@ -523,7 +523,13 @@ def _extract_period_data(
     regime_states: tuple[str, ...],
     regime_actions: tuple[str, ...],
 ) -> dict[str, Array]:
-    """Extract data from a single period's simulation results."""
+    """Extract data from a single period's simulation results.
+
+    `subject_id` is taken from `result.subject_ids` verbatim — it is the
+    caller-supplied global subject identifier, threaded through
+    `simulate()` so per-partition dispatch groups concatenate into one
+    dataframe with stable subject identity.
+    """
     data: dict[str, Array] = {
         "subject_id": result.subject_ids,
         "period": jnp.full_like(result.in_regime, period, dtype=jnp.int32),

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -55,6 +55,7 @@ def simulate(
     ages: AgeGrid,
     simulation_output_dtypes: Mapping[str, pd.CategoricalDtype],
     seed: int | None = None,
+    subject_ids: Int1D | None = None,
 ) -> SimulationResult:
     """Simulate the model forward in time given pre-computed value function arrays.
 
@@ -75,6 +76,11 @@ def simulate(
             used for building simulation metadata.
         seed: Random number seed; will be passed to `jax.random.key`. If not provided,
             a random seed will be generated.
+        subject_ids: Optional global subject-id array aligned with
+            `initial_conditions` row order. Defaults to
+            `jnp.arange(n_subjects)`. Pass explicit ids when this simulate call
+            is one of several partition groups so downstream concatenation
+            preserves the caller's subject ordering.
 
     Returns:
         SimulationResult object. Call .to_dataframe() to get a pandas DataFrame.
@@ -100,7 +106,8 @@ def simulate(
         initial_ages=initial_states["age"], ages=ages
     )
     subject_regime_ids = jnp.full_like(initial_conditions["regime"], MISSING_CAT_CODE)
-    subject_ids = jnp.arange(initial_conditions["regime"].shape[0], dtype=jnp.int32)
+    if subject_ids is None:
+        subject_ids = jnp.arange(initial_conditions["regime"].shape[0], dtype=jnp.int32)
 
     # Forward simulation
     simulation_results: dict[RegimeName, dict[int, PeriodRegimeSimulationData]] = {

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -100,6 +100,7 @@ def simulate(
         initial_ages=initial_states["age"], ages=ages
     )
     subject_regime_ids = jnp.full_like(initial_conditions["regime"], MISSING_CAT_CODE)
+    subject_ids = jnp.arange(initial_conditions["regime"].shape[0], dtype=jnp.int32)
 
     # Forward simulation
     simulation_results: dict[RegimeName, dict[int, PeriodRegimeSimulationData]] = {
@@ -145,6 +146,7 @@ def simulate(
                     states=states,
                     subject_regime_ids=subject_regime_ids,
                     new_subject_regime_ids=new_subject_regime_ids,
+                    subject_ids=subject_ids,
                     period_to_regime_to_V_arr=period_to_regime_to_V_arr,
                     internal_params=internal_params,
                     regime_names_to_ids=regime_names_to_ids,
@@ -201,6 +203,7 @@ def _simulate_regime_in_period(
     states: MappingProxyType[str, Array],
     subject_regime_ids: Int1D,
     new_subject_regime_ids: Int1D,
+    subject_ids: Int1D,
     period_to_regime_to_V_arr: MappingProxyType[
         int, MappingProxyType[RegimeName, FloatND]
     ],
@@ -222,6 +225,9 @@ def _simulate_regime_in_period(
         states: Current states for all subjects (namespaced by regime).
         subject_regime_ids: Current regime membership for all subjects.
         new_subject_regime_ids: Array to populate with next period's regime memberships.
+        subject_ids: Global subject-id array, stored verbatim on the returned
+            `PeriodRegimeSimulationData` so downstream concatenation (across
+            partition groups) can restore subject ordering.
         period_to_regime_to_V_arr: Value function arrays for all periods and regimes.
         internal_params: Model parameters for all regimes.
         regime_names_to_ids: Mapping from regime names to integer IDs.
@@ -293,6 +299,7 @@ def _simulate_regime_in_period(
         actions=optimal_actions,
         states=MappingProxyType(res),
         in_regime=subject_ids_in_regime,
+        subject_ids=subject_ids,
     )
 
     # Update states and regime membership for next period

--- a/src/lcm/solution/solve_brute.py
+++ b/src/lcm/solution/solve_brute.py
@@ -4,6 +4,7 @@ import os
 import time
 from collections.abc import Callable, Hashable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 from types import MappingProxyType
 
 import jax
@@ -22,6 +23,21 @@ from lcm.utils.logging import (
 )
 
 
+@dataclass(frozen=True)
+class CompiledSolve:
+    """AOT-compiled solve kernels plus the shape-consistent V template.
+
+    Reused across partition-point sweeps so `Model.solve` pays the compile
+    cost once, not once per point.
+    """
+
+    compiled_functions: dict[tuple[RegimeName, int], Callable]
+    """Compiled `max_Q_over_a` callable per `(regime_name, period)`."""
+    next_regime_to_V_arr_template: MappingProxyType[RegimeName, FloatND]
+    """Zero-initialised V-arrays keyed by regime name; used as starting
+    value for backward induction on every call to `run_compiled_solve`."""
+
+
 def solve(
     *,
     internal_params: InternalParams,
@@ -31,7 +47,11 @@ def solve(
     enable_jit: bool,
     max_compilation_workers: int | None = None,
 ) -> MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]:
-    """Solve a model using grid search.
+    """Solve a model using grid search (compile + run in one call).
+
+    Thin wrapper around `compile_solve` + `run_compiled_solve`. Callers
+    that sweep partition points should split these two steps themselves
+    so the compile cost is paid exactly once.
 
     Args:
         internal_params: Immutable mapping of regime names to flat parameter mappings.
@@ -47,9 +67,53 @@ def solve(
         Immutable mapping of periods to regime value function arrays.
 
     """
-    # Compute V array shapes and build a consistent next_regime_to_V_arr
-    # template.  Using the same pytree structure (keys and shapes) across
-    # all periods avoids JIT re-compilation from pytree mismatches.
+    compiled = compile_solve(
+        internal_params=internal_params,
+        ages=ages,
+        internal_regimes=internal_regimes,
+        logger=logger,
+        enable_jit=enable_jit,
+        max_compilation_workers=max_compilation_workers,
+    )
+    return run_compiled_solve(
+        compiled=compiled,
+        internal_params=internal_params,
+        ages=ages,
+        internal_regimes=internal_regimes,
+        logger=logger,
+    )
+
+
+def compile_solve(
+    *,
+    internal_params: InternalParams,
+    ages: AgeGrid,
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    logger: logging.Logger,
+    enable_jit: bool,
+    max_compilation_workers: int | None = None,
+) -> CompiledSolve:
+    """AOT-compile all max_Q_over_a functions and build the V template.
+
+    Separated from `run_compiled_solve` so callers can sweep partition
+    points (or similar scalar-param variations) over the same compiled
+    kernels, paying the compile cost exactly once.
+
+    Args:
+        internal_params: Regime params used to construct state-action
+            spaces for lowering (only shapes/dtypes are consulted).
+        ages: Age grid for the model.
+        internal_regimes: The internal regimes.
+        logger: Logger for compilation progress.
+        enable_jit: Whether to JIT-compile. When `False`, returns raw
+            functions bundled in a `CompiledSolve` unchanged.
+        max_compilation_workers: Maximum threads for parallel compilation.
+
+    Returns:
+        A `CompiledSolve` holding the compiled per-period kernels and
+        the zero-initialised V template.
+
+    """
     regime_V_shapes = _get_regime_V_shapes(
         internal_regimes=internal_regimes,
         internal_params=internal_params,
@@ -58,7 +122,6 @@ def solve(
         {name: jnp.zeros(shape) for name, shape in regime_V_shapes.items()}
     )
 
-    # AOT-compile all unique max_Q_over_a functions in parallel.
     compiled_functions = _compile_all_functions(
         internal_regimes=internal_regimes,
         internal_params=internal_params,
@@ -68,6 +131,39 @@ def solve(
         max_compilation_workers=max_compilation_workers,
         logger=logger,
     )
+    return CompiledSolve(
+        compiled_functions=compiled_functions,
+        next_regime_to_V_arr_template=next_regime_to_V_arr,
+    )
+
+
+def run_compiled_solve(
+    *,
+    compiled: CompiledSolve,
+    internal_params: InternalParams,
+    ages: AgeGrid,
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    logger: logging.Logger,
+) -> MappingProxyType[int, MappingProxyType[RegimeName, FloatND]]:
+    """Run backward induction using an already-compiled solve.
+
+    Args:
+        compiled: Result of `compile_solve`. Reused across partition
+            points so no recompilation happens between calls.
+        internal_params: Immutable mapping of regime names to flat
+            parameter mappings. Partition scalars flow in here and are
+            picked up at dispatch time — no new compile.
+        ages: Age grid.
+        internal_regimes: The internal regimes (needed for active-period
+            bookkeeping and diagnostic machinery).
+        logger: Logger.
+
+    Returns:
+        Immutable mapping of periods to regime value function arrays.
+
+    """
+    next_regime_to_V_arr = compiled.next_regime_to_V_arr_template
+    compiled_functions = compiled.compiled_functions
 
     solution: dict[int, MappingProxyType[RegimeName, FloatND]] = {}
 

--- a/tests/regime_building/test_partitions.py
+++ b/tests/regime_building/test_partitions.py
@@ -385,7 +385,7 @@ def test_simulate_feasibility_validation_sees_partition_states():
     )
 
     n_subjects = 3
-    model.simulate(
+    result = model.simulate(
         params={
             "discount_factor": 0.9,
             "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
@@ -399,3 +399,37 @@ def test_simulate_feasibility_validation_sees_partition_states():
         period_to_regime_to_V_arr=None,
         log_level="off",
     )
+    df = result.to_dataframe(use_labels=False)
+    # Each subject kept their pref_type across all periods, confirming the
+    # feasibility check actually saw the partition value (and so didn't just
+    # skip validation silently).
+    per_subject_pref_types = df.groupby("subject_id")["pref_type"].nunique()
+    assert (per_subject_pref_types == 1).all()
+    assert set(df["pref_type"].dropna().unique()) == {0.0, 1.0, 2.0}
+
+
+def test_invalid_partition_code_raises():
+    """A user-supplied partition code outside the grid must fail validation.
+
+    Regression guard: `_validate_discrete_state_values` used to skip
+    partition states entirely because they were absent from
+    `variable_info`. A bad code (e.g. 99 for a 3-category partition)
+    would silently propagate to sub-solution dispatch.
+    """
+    model = _make_model()
+    n_subjects = 3
+    with pytest.raises(Exception, match=r"(?i)invalid.*pref_type"):
+        model.simulate(
+            params={
+                "discount_factor": 0.9,
+                "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+            },
+            initial_conditions={
+                "wealth": jnp.full(n_subjects, 2.0),
+                "pref_type": jnp.array([0, 1, 99]),
+                "age": jnp.zeros(n_subjects),
+                "regime": jnp.full(n_subjects, _RegimeId.alive),
+            },
+            period_to_regime_to_V_arr=None,
+            log_level="off",
+        )

--- a/tests/regime_building/test_partitions.py
+++ b/tests/regime_building/test_partitions.py
@@ -52,7 +52,7 @@ def _next_regime(age: float, final_age_alive: float) -> ScalarInt:
 
 
 def _utility(consumption: ContinuousAction, pref_type: DiscreteState) -> FloatND:
-    """Utility scales with pref_type's integer code.
+    """Scale log-consumption by `pref_type`'s integer code.
 
     `pref_type` is used directly by utility (no H-DAG machinery needed on
     this branch). `type_c` gets 3x, `type_a` gets 1x.
@@ -112,7 +112,7 @@ def _make_model() -> Model:
 def test_detect_partitions_identifies_discrete_none():
     """`detect_model_partitions` picks up a DiscreteGrid state with None transition."""
     model = _make_model()
-    detected = detect_model_partitions(model.regimes)
+    detected = detect_model_partitions(regimes=model.regimes)
     assert set(detected) == {"pref_type"}
     assert detected["pref_type"].categories == ("type_a", "type_b", "type_c")
 
@@ -127,7 +127,7 @@ def test_detect_partitions_rejects_non_none_transition():
         transition=lambda: 0,
         active=lambda age: age < 1,
     )
-    assert detect_model_partitions({"r": regime}) == {}
+    assert detect_model_partitions(regimes={"r": regime}) == {}
 
 
 def test_detect_partitions_rejects_continuous():
@@ -140,7 +140,7 @@ def test_detect_partitions_rejects_continuous():
         transition=lambda: 0,
         active=lambda age: age < 1,
     )
-    assert detect_model_partitions({"r": regime}) == {}
+    assert detect_model_partitions(regimes={"r": regime}) == {}
 
 
 def test_lift_removes_partition_from_states_and_transitions():
@@ -172,7 +172,7 @@ def test_model_partition_grid_union():
 def test_iterate_partition_points_cardinality():
     """The product iterator yields one dict per category code."""
     model = _make_model()
-    points = list(iterate_partition_points(model._partition_grid))
+    points = list(iterate_partition_points(partition_grid=model._partition_grid))
     assert len(points) == 3  # type_a, type_b, type_c
     assert {int(p["pref_type"]) for p in points} == {0, 1, 2}
 

--- a/tests/regime_building/test_partitions.py
+++ b/tests/regime_building/test_partitions.py
@@ -287,7 +287,7 @@ def test_simulate_subject_ids_globally_unique():
 
 
 @pytest.mark.parametrize("reorder_subjects", [False, True])
-def test_simulate_invariant_to_subject_ordering(reorder_subjects: bool):
+def test_simulate_invariant_to_subject_ordering(*, reorder_subjects: bool):
     """Simulation results depend only on the (pref_type, wealth) pair per subject.
 
     Reordering the subjects in `initial_conditions` must yield the same

--- a/tests/regime_building/test_partitions.py
+++ b/tests/regime_building/test_partitions.py
@@ -330,3 +330,72 @@ def test_simulate_invariant_to_subject_ordering(*, reorder_subjects: bool):
     np.testing.assert_allclose(
         alive_period_0["wealth"].to_numpy(), np.asarray(wealth), atol=1e-10
     )
+
+
+def _borrowing_uses_pref_type(
+    consumption: ContinuousAction,
+    wealth: ContinuousState,
+    pref_type: DiscreteState,
+) -> BoolND:
+    """Feasibility function that references a partition state."""
+    return (consumption <= wealth) & (pref_type >= 0)
+
+
+def test_simulate_feasibility_validation_sees_partition_states():
+    """Feasibility check during `validate_initial_conditions` must see partition values.
+
+    Regression guard: the Mahler-Yum GPU regression test failed with
+    `InvalidFunctionArgumentsError: missing required arguments:
+    education, productivity` because partition states were lifted out
+    of `variable_info` but the feasibility validator still drew its
+    per-subject state set from there. Now `internal_regime.partitions`
+    is walked alongside `variable_info`.
+    """
+    alive = Regime(
+        actions={
+            "consumption": LinSpacedGrid(start=0.1, stop=5.0, n_points=20),
+        },
+        states={
+            "wealth": LinSpacedGrid(start=0.1, stop=5.0, n_points=10),
+            "pref_type": DiscreteGrid(TypeGrid),
+        },
+        state_transitions={
+            "wealth": _next_wealth,
+            "pref_type": None,
+        },
+        constraints={"borrowing": _borrowing_uses_pref_type},
+        functions={"utility": _utility},
+        transition=_next_regime,
+        active=lambda age: age <= _FINAL_AGE,
+    )
+
+    def dead_utility() -> float:
+        return 0.0
+
+    dead = Regime(
+        transition=None,
+        functions={"utility": dead_utility},
+        active=lambda age: age > _FINAL_AGE,
+    )
+
+    model = Model(
+        regimes={"alive": alive, "dead": dead},
+        ages=AgeGrid(start=0, stop=_FINAL_AGE + 1, step="Y"),
+        regime_id_class=_RegimeId,
+    )
+
+    n_subjects = 3
+    model.simulate(
+        params={
+            "discount_factor": 0.9,
+            "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+        },
+        initial_conditions={
+            "wealth": jnp.full(n_subjects, 2.0),
+            "pref_type": jnp.array([TypeGrid.type_a, TypeGrid.type_b, TypeGrid.type_c]),
+            "age": jnp.zeros(n_subjects),
+            "regime": jnp.full(n_subjects, _RegimeId.alive),
+        },
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )

--- a/tests/regime_building/test_partitions.py
+++ b/tests/regime_building/test_partitions.py
@@ -1,0 +1,332 @@
+"""Partition-dimension behavior on non-trivial models.
+
+Fixed states (`state_transitions[name] = None` on a `DiscreteGrid`) are lifted
+out of each regime's state-action space and iterated externally. The tests
+below check that the user-visible behavior is exactly what a monolithic
+model with those states vmap'd in-place would produce, and that the
+partition axes surface at the expected position in returned V-arrays.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from lcm import (
+    AgeGrid,
+    DiscreteGrid,
+    LinSpacedGrid,
+    Model,
+    Regime,
+    categorical,
+)
+from lcm.regime_building.partitions import (
+    detect_model_partitions,
+    iterate_partition_points,
+    lift_partitions_from_regime,
+)
+from lcm.typing import (
+    BoolND,
+    ContinuousAction,
+    ContinuousState,
+    DiscreteState,
+    FloatND,
+    ScalarInt,
+)
+
+
+@categorical(ordered=False)
+class TypeGrid:
+    type_a: int
+    type_b: int
+    type_c: int
+
+
+@categorical(ordered=False)
+class _RegimeId:
+    alive: int
+    dead: int
+
+
+def _next_regime(age: float, final_age_alive: float) -> ScalarInt:
+    return jnp.where(age >= final_age_alive, _RegimeId.dead, _RegimeId.alive)
+
+
+def _utility(consumption: ContinuousAction, pref_type: DiscreteState) -> FloatND:
+    """Utility scales with pref_type's integer code.
+
+    `pref_type` is used directly by utility (no H-DAG machinery needed on
+    this branch). `type_c` gets 3x, `type_a` gets 1x.
+    """
+    scale = 1.0 + pref_type.astype(jnp.float32)
+    return jnp.log(consumption) * scale
+
+
+def _next_wealth(
+    wealth: ContinuousState, consumption: ContinuousAction
+) -> ContinuousState:
+    return wealth - consumption + 1.0
+
+
+def _borrowing(consumption: ContinuousAction, wealth: ContinuousState) -> BoolND:
+    return consumption <= wealth
+
+
+_FINAL_AGE = 2
+
+
+def _make_model() -> Model:
+    alive = Regime(
+        actions={
+            "consumption": LinSpacedGrid(start=0.1, stop=5.0, n_points=20),
+        },
+        states={
+            "wealth": LinSpacedGrid(start=0.1, stop=5.0, n_points=10),
+            "pref_type": DiscreteGrid(TypeGrid),
+        },
+        state_transitions={
+            "wealth": _next_wealth,
+            "pref_type": None,  # partition
+        },
+        constraints={"borrowing": _borrowing},
+        functions={"utility": _utility},
+        transition=_next_regime,
+        active=lambda age: age <= _FINAL_AGE,
+    )
+
+    def dead_utility() -> float:
+        return 0.0
+
+    dead = Regime(
+        transition=None,
+        functions={"utility": dead_utility},
+        active=lambda age: age > _FINAL_AGE,
+    )
+
+    return Model(
+        regimes={"alive": alive, "dead": dead},
+        ages=AgeGrid(start=0, stop=_FINAL_AGE + 1, step="Y"),
+        regime_id_class=_RegimeId,
+    )
+
+
+def test_detect_partitions_identifies_discrete_none():
+    """`detect_model_partitions` picks up a DiscreteGrid state with None transition."""
+    model = _make_model()
+    detected = detect_model_partitions(model.regimes)
+    assert set(detected) == {"pref_type"}
+    assert detected["pref_type"].categories == ("type_a", "type_b", "type_c")
+
+
+def test_detect_partitions_rejects_non_none_transition():
+    """A state with any non-None transition is never a partition."""
+    regime = Regime(
+        actions={},
+        states={"x": DiscreteGrid(TypeGrid)},
+        state_transitions={"x": lambda x: x},
+        functions={"utility": lambda x: x},
+        transition=lambda: 0,
+        active=lambda age: age < 1,
+    )
+    assert detect_model_partitions({"r": regime}) == {}
+
+
+def test_detect_partitions_rejects_continuous():
+    """Continuous `None` transitions fall through to identity, not partition."""
+    regime = Regime(
+        actions={"consumption": LinSpacedGrid(start=0.1, stop=1.0, n_points=3)},
+        states={"wealth": LinSpacedGrid(start=0.1, stop=1.0, n_points=3)},
+        state_transitions={"wealth": None},
+        functions={"utility": lambda consumption, wealth: wealth + consumption},
+        transition=lambda: 0,
+        active=lambda age: age < 1,
+    )
+    assert detect_model_partitions({"r": regime}) == {}
+
+
+def test_lift_removes_partition_from_states_and_transitions():
+    """The reduced regime no longer contains the partition state."""
+    model = _make_model()
+    alive = model.regimes["alive"]
+    reduced, partitions = lift_partitions_from_regime(
+        regime=alive, partition_names=frozenset({"pref_type"})
+    )
+    assert "pref_type" not in reduced.states
+    assert "pref_type" not in reduced.state_transitions
+    assert set(partitions) == {"pref_type"}
+
+
+def test_internal_regime_exposes_partitions():
+    """`InternalRegime.partitions` carries the lifted grid; `grids` does not."""
+    model = _make_model()
+    alive = model.internal_regimes["alive"]
+    assert "pref_type" in alive.partitions
+    assert "pref_type" not in alive.grids
+
+
+def test_model_partition_grid_union():
+    """`Model._partition_grid` aggregates partitions across all regimes."""
+    model = _make_model()
+    assert set(model._partition_grid) == {"pref_type"}
+
+
+def test_iterate_partition_points_cardinality():
+    """The product iterator yields one dict per category code."""
+    model = _make_model()
+    points = list(iterate_partition_points(model._partition_grid))
+    assert len(points) == 3  # type_a, type_b, type_c
+    assert {int(p["pref_type"]) for p in points} == {0, 1, 2}
+
+
+def test_solve_V_has_trailing_partition_axis():
+    """Solved V for alive has shape (..., n_pref_type); dead has (n_pref_type,)."""
+    model = _make_model()
+    V = model.solve(
+        params={
+            "discount_factor": 0.9,
+            "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+        },
+        log_level="off",
+    )
+    # Alive at period 0: wealth grid size 10, partition axis 3 → shape (10, 3).
+    assert V[0]["alive"].shape[-1] == 3
+    assert V[0]["alive"].ndim == 2
+
+
+def test_solve_V_monotone_in_pref_type():
+    """Higher pref_type code ⇒ higher utility ⇒ higher V at the same state.
+
+    Each sub-solve uses a different `pref_type` scalar, so the trailing
+    axis of `V` distinguishes them. `_utility` scales with the code, so
+    `V[..., 2] > V[..., 1] > V[..., 0]` at non-terminal periods.
+    """
+    model = _make_model()
+    V = model.solve(
+        params={
+            "discount_factor": 0.9,
+            "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+        },
+        log_level="off",
+    )
+    non_terminal_periods = [p for p in V if p < max(V.keys())]
+    for period in non_terminal_periods:
+        v = V[period]["alive"]
+        v_a = float(jnp.mean(v[..., 0]))
+        v_b = float(jnp.mean(v[..., 1]))
+        v_c = float(jnp.mean(v[..., 2]))
+        assert v_a < v_b < v_c, (
+            f"V non-monotone in pref_type at period {period}: "
+            f"{v_a:.4f}, {v_b:.4f}, {v_c:.4f}"
+        )
+
+
+def test_simulate_routes_subjects_to_correct_partition():
+    """Subjects with different pref_types get dispatched per sub-solution.
+
+    All subjects start at the same wealth; the partition dispatch groups
+    them by `pref_type`. The realised DataFrame must preserve each
+    subject's pref_type label across all periods (it is a fixed state).
+    """
+    model = _make_model()
+    n_per_type = 4
+    n_subjects = 3 * n_per_type
+    initial_conditions = {
+        "wealth": jnp.full(n_subjects, 2.0),
+        "pref_type": jnp.array(
+            [TypeGrid.type_a] * n_per_type
+            + [TypeGrid.type_b] * n_per_type
+            + [TypeGrid.type_c] * n_per_type
+        ),
+        "age": jnp.zeros(n_subjects),
+        "regime": jnp.full(n_subjects, _RegimeId.alive),
+    }
+    result = model.simulate(
+        params={
+            "discount_factor": 0.9,
+            "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+        },
+        initial_conditions=initial_conditions,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+        seed=0,
+    )
+    df = result.to_dataframe(use_labels=False)
+    # pref_type is fixed: every subject's pref_type should be constant across periods.
+    per_subject = df.groupby("subject_id")["pref_type"].nunique()
+    assert (per_subject == 1).all()
+    # All three types must appear in the output.
+    assert set(df["pref_type"].dropna().unique()) == {0.0, 1.0, 2.0}
+
+
+def test_simulate_subject_ids_globally_unique():
+    """After per-partition dispatch, concatenated subject_ids cover [0, n)."""
+    model = _make_model()
+    n_subjects = 7
+    initial_conditions = {
+        "wealth": jnp.full(n_subjects, 2.0),
+        "pref_type": jnp.array(
+            [TypeGrid.type_a, TypeGrid.type_b, TypeGrid.type_c] * 2 + [TypeGrid.type_a]
+        ),
+        "age": jnp.zeros(n_subjects),
+        "regime": jnp.full(n_subjects, _RegimeId.alive),
+    }
+    result = model.simulate(
+        params={
+            "discount_factor": 0.9,
+            "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+        },
+        initial_conditions=initial_conditions,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+    )
+    df = result.to_dataframe(use_labels=False)
+    # Each period's subject_ids must be exactly [0, 1, ..., n_subjects-1] with no gaps.
+    for period, sub in df.groupby("period"):
+        assert set(sub["subject_id"].astype(int)) == set(range(n_subjects)), (
+            f"Period {period} missing subject_ids"
+        )
+
+
+@pytest.mark.parametrize("reorder_subjects", [False, True])
+def test_simulate_invariant_to_subject_ordering(reorder_subjects: bool):
+    """Simulation results depend only on the (pref_type, wealth) pair per subject.
+
+    Reordering the subjects in `initial_conditions` must yield the same
+    per-(subject_id) rows in the output after sorting — the partition
+    dispatch should not introduce order-dependent drift.
+    """
+    model = _make_model()
+    n_subjects = 6
+    wealth = jnp.array([1.0, 2.0, 3.0, 1.5, 2.5, 3.5])
+    types = jnp.array([TypeGrid.type_a, TypeGrid.type_b, TypeGrid.type_c] * 2)
+
+    if reorder_subjects:
+        perm = jnp.array([3, 0, 4, 1, 5, 2])
+        wealth = wealth[perm]
+        types = types[perm]
+
+    initial_conditions = {
+        "wealth": wealth,
+        "pref_type": types,
+        "age": jnp.zeros(n_subjects),
+        "regime": jnp.full(n_subjects, _RegimeId.alive),
+    }
+    result = model.simulate(
+        params={
+            "discount_factor": 0.9,
+            "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+        },
+        initial_conditions=initial_conditions,
+        period_to_regime_to_V_arr=None,
+        log_level="off",
+        seed=42,
+    )
+    df = result.to_dataframe(use_labels=False)
+    # After sorting by subject_id, each (period, subject_id) row corresponds to
+    # the subject at that index in initial_conditions.
+    alive_period_0 = df[(df["regime"] == "alive") & (df["period"] == 0)].sort_values(
+        "subject_id"
+    )
+    # The 0-th subject's wealth must match initial_conditions["wealth"][0].
+    np.testing.assert_allclose(
+        alive_period_0["wealth"].to_numpy(), np.asarray(wealth), atol=1e-10
+    )

--- a/tests/regime_building/test_partitions.py
+++ b/tests/regime_building/test_partitions.py
@@ -24,6 +24,7 @@ from lcm.regime_building.partitions import (
     iterate_partition_points,
     lift_partitions_from_regime,
 )
+from lcm.solution import solve_brute
 from lcm.typing import (
     BoolND,
     ContinuousAction,
@@ -433,3 +434,39 @@ def test_invalid_partition_code_raises():
             period_to_regime_to_V_arr=None,
             log_level="off",
         )
+
+
+def test_solve_compiles_once_for_multi_point_partition(monkeypatch):
+    """`Model.solve` compiles the solve kernel once regardless of partition cardinality.
+
+    Regression guard for the #326 performance issue: calling
+    `_compile_all_functions` inside the partition loop made every point
+    pay a full AOT pass, turning Mahler-Yum's 3.8s main baseline into
+    42s on #326. `Model.solve` now calls `compile_solve` outside the
+    loop and `run_compiled_solve` inside it, so only one compile
+    happens per solve call even with a 3-point (or larger) partition.
+    """
+    original = solve_brute._compile_all_functions
+    call_count = 0
+
+    def counting_compile(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original(**kwargs)
+
+    monkeypatch.setattr(solve_brute, "_compile_all_functions", counting_compile)
+
+    model = _make_model()
+    assert len(model._partition_grid["pref_type"].codes) >= 2
+    model.solve(
+        params={
+            "discount_factor": 0.9,
+            "alive": {"next_regime": {"final_age_alive": _FINAL_AGE}},
+        },
+        log_level="off",
+    )
+    assert call_count == 1, (
+        f"_compile_all_functions called {call_count} times for a "
+        f"{len(model._partition_grid['pref_type'].codes)}-point partition; "
+        "expected 1."
+    )

--- a/tests/solution/test_custom_aggregator.py
+++ b/tests/solution/test_custom_aggregator.py
@@ -333,10 +333,12 @@ def test_dag_output_feeds_default_h_monotone_in_discount_factor():
     }
     V = model.solve(params=params)
 
-    # Pick a non-terminal period; slice each pref_type.
-    non_terminal_periods = [p for p in V if p < max(V.keys())]
-    assert non_terminal_periods
-    for period in non_terminal_periods:
+    # At the last working_life-active period (FINAL_AGE_ALIVE), the deterministic
+    # transition goes to `dead` and V_dead = 0, so V = U is pref_type-independent.
+    # Check earlier periods where the discount factor actually multiplies E[V_next].
+    periods_with_future = [p for p in V if p < FINAL_AGE_ALIVE]
+    assert periods_with_future
+    for period in periods_with_future:
         # Shape is (..., n_pref_type). Compare averages across the
         # other axes so the comparison is robust to the grid layout.
         v = V[period]["working_life"]

--- a/tests/solution/test_custom_aggregator.py
+++ b/tests/solution/test_custom_aggregator.py
@@ -127,11 +127,9 @@ def _make_model(custom_H=None, *, with_pref_type: bool = False):
     working_life_state_transitions: dict = {
         "wealth": next_wealth,
     }
-    dead_states: dict = {}
     if with_pref_type:
         working_life_states["pref_type"] = DiscreteGrid(PrefType, batch_size=1)
         working_life_state_transitions["pref_type"] = None
-        dead_states["pref_type"] = DiscreteGrid(PrefType, batch_size=1)
 
     working_life_regime = Regime(
         actions={
@@ -146,23 +144,12 @@ def _make_model(custom_H=None, *, with_pref_type: bool = False):
         active=lambda age: age <= FINAL_AGE_ALIVE,
     )
 
-    # Terminal regime: when pref_type is declared as a state across
-    # regimes, dead_utility must reference it so pylcm's state-usage
-    # check accepts the declaration (terminal regimes have no H, so
-    # the H-DAG reachability fix does not apply here).
-    if with_pref_type:
-
-        def dead_utility(pref_type: DiscreteState) -> FloatND:  # noqa: ARG001
-            return jnp.asarray(0.0)
-    else:
-
-        def dead_utility() -> float:
-            return 0.0
+    def dead_utility() -> float:
+        return 0.0
 
     dead_regime = Regime(
         transition=None,
         functions={"utility": dead_utility},
-        states=dead_states,
         active=lambda age: age > FINAL_AGE_ALIVE,
     )
 


### PR DESCRIPTION
## Summary

`state_transitions[name] = None` on a `DiscreteGrid` state has always meant "this value never changes." Today pylcm implements that by vmap'ing an auto-generated identity transition alongside every other state, paying memory linearly in the fixed state's cardinality. Because the Bellman backward induction never couples values across such a dimension, each fixed state partitions the state space into independent sub-problems: pylcm can compile one reduced sub-model and run it once per point in the product of all partition grids.

This PR adds that machinery end-to-end. User-facing API is unchanged — `None` transitions still declare a fixed state; internally pylcm lifts them out of `variable_info` / state-action space / Q_and_F, iterates the partition product in `Model.solve` / `Model.simulate`, and restores partition axes at the API boundary.

## What changed

- **`src/lcm/regime_building/partitions.py`** (new). Shared helpers: `detect_model_partitions`, `lift_partitions_from_regime`, `iterate_partition_points`, `inject_partition_scalars`, `stack_partition_V_arrays`, `group_subjects_by_partition`, `slice_V_at_partition_point`, `slice_initial_conditions`. All handle the empty-grid case transparently (one iteration, no stacking, no grouping).
- **`src/lcm/regime_building/processing.py`**. `process_regimes` detects model-level partitions up-front and passes reduced regimes to every downstream builder. `InternalRegime` gains a `partitions` field; downstream machinery never sees partition states as vmap'd axes.
- **`src/lcm/model.py`**. `Model._partition_grid` aggregates partitions across regimes (validates category agreement). `Model.solve` wraps backward induction in a partition loop, stacks sub-V-arrays along trailing axes. `Model.simulate` groups subjects by their partition-value tuple, slices V-arrays per group, and concatenates `PeriodRegimeSimulationData` with globally-correct `subject_ids`.
- **`src/lcm/simulation/{simulate,result}.py`**. `PeriodRegimeSimulationData` gains an explicit `subject_ids` field; `simulate()` accepts it as a kwarg so per-partition dispatch groups stay aligned after concatenation. `to_dataframe` emits partition names as "state" columns with correct per-regime categorical mapping.
- **`src/lcm/simulation/initial_conditions.py`**. Partition names are required in `initial_conditions` — they supply each subject's fixed value.

## Qualification rules for partition lifting

A discrete state qualifies as a partition iff:
1. The grid is a `DiscreteGrid`.
2. Every non-terminal regime where the state appears declares `None`.
3. The state appears in at least one non-terminal regime (target-only states populated by per-target transitions at the boundary are excluded).
4. Categories agree across regimes.

Terminal regimes (which must have empty `state_transitions` by validation) count the absence of an entry as the equivalent of `None`.

Continuous fixed states (`None` on a continuous grid) fall through to an identity transition — partitioning a continuous value is meaningless.

## Mahler-Yum impact

Four fixed states (`productivity`, `education`, `discount_type`, `health_type`) auto-lift on this branch, giving a 32-point partition product.

- GPU peak memory (cuda13, 100 subjects): **501 MB**. Comparable to or slightly below the pre-heterogeneity baseline (~400 MB on older main, 522 MB on the h-consumes-dag-outputs branch). The win is larger for Replication_MY2024's 10K-subject / 37-period runs where memory pressure is real.
- Execution time dominated by compile once + run N times: only one JIT compile across all partition points (shape invariant across points).

## Test plan

- [x] `pixi run --environment tests-cpu tests -n 7` — **856 pass, 5 skipped** (843 existing + 13 new partition tests).
- [x] `pixi run ty` — clean.
- [x] `prek run --all-files` — clean.
- [x] Mahler-Yum GPU benchmark runs end-to-end on cuda13.
- [x] `test_dag_output_feeds_default_h_monotone_in_discount_factor` updated: skip the last working-life period where V = U (deterministic transition to `dead`, V_dead = 0) is pref_type-independent regardless of discount factor.

## Not in scope

- Removing `_IdentityTransition` entirely — continuous fixed states still need it. Narrower cleanup is a follow-up.
- Memory-optimal stacking via `jax.lax.scan` into a pre-allocated output buffer (current implementation holds all sub-V-arrays during stack). Peak could drop another ~30 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)