### PR TITLE
Benchmark mahler/yum with external discount-factor loop

### DIFF
--- a/benchmarks/bench_mahler_yum.py
+++ b/benchmarks/bench_mahler_yum.py
@@ -1,4 +1,9 @@
-"""End-to-end benchmark for the Mahler & Yum (2024) replication model."""
+"""End-to-end benchmark for the Mahler & Yum (2024) replication model.
+
+Loops over the two discount-factor types externally: one solve+simulate per
+type, covering disjoint subsets of the subject population. Total simulated
+subjects across the two runs equal `_N_SUBJECTS`.
+"""
 
 import gc
 import time
@@ -25,58 +30,62 @@ class MahlerYum:
         }
 
         self.model = MAHLER_YUM_MODEL
-        common_params, initial_states, _discount_factor_type = create_inputs(
+        common_params, initial_states, discount_factor_type = create_inputs(
             seed=0,
             n_simulation_subjects=_N_SUBJECTS,
             **start_params_without_beta,
         )
-        self.model_params = {
-            "alive": {
-                "discount_factor": START_PARAMS["beta"]["mean"],
-                **common_params,
-            },
-        }
-        self.initial_conditions = {
-            **initial_states,
-            "regime": jnp.full(
-                _N_SUBJECTS,
-                self.model.regime_names_to_ids["alive"],
-                dtype=jnp.int32,
-            ),
-        }
+
+        beta_mean = START_PARAMS["beta"]["mean"]
+        beta_std = START_PARAMS["beta"]["std"]
+        alive_id = self.model.regime_names_to_ids["alive"]
+
+        self._runs = []
+        for type_idx, beta in enumerate([beta_mean - beta_std, beta_mean + beta_std]):
+            subset_ids = jnp.flatnonzero(discount_factor_type == type_idx)
+            subset_initial_states = {
+                state: values[subset_ids] for state, values in initial_states.items()
+            }
+            params = {
+                "alive": {
+                    "discount_factor": beta,
+                    **common_params,
+                },
+            }
+            initial_conditions = {
+                **subset_initial_states,
+                "regime": jnp.full(
+                    subset_ids.shape[0],
+                    alive_id,
+                    dtype=jnp.int32,
+                ),
+            }
+            self._runs.append((params, initial_conditions))
+
+    def _simulate_all(self):
+        for params, initial_conditions in self._runs:
+            self.model.simulate(
+                params=params,
+                initial_conditions=initial_conditions,
+                period_to_regime_to_V_arr=None,
+                log_level="off",
+                check_initial_conditions=False,
+            )
 
     def setup(self):
         self._build()
         start = time.perf_counter()
-        self.model.simulate(
-            params=self.model_params,
-            initial_conditions=self.initial_conditions,
-            period_to_regime_to_V_arr=None,
-            log_level="off",
-            check_initial_conditions=False,
-        )
+        self._simulate_all()
         self._compile_time = time.perf_counter() - start
 
     def setup_for_gpu_measurement(self):
         self._build()
 
     def time_execution(self):
-        self.model.simulate(
-            params=self.model_params,
-            initial_conditions=self.initial_conditions,
-            period_to_regime_to_V_arr=None,
-            log_level="off",
-            check_initial_conditions=False,
-        )
+        self._simulate_all()
 
     def peakmem_execution(self):
-        self.model.simulate(
-            params=self.model_params,
-            initial_conditions=self.initial_conditions,
-            period_to_regime_to_V_arr=None,
-            log_level="off",
-            check_initial_conditions=False,
-        )
+        self._simulate_all()
 
     def teardown(self):
         import jax


### PR DESCRIPTION
## Summary

- Rework `benchmarks/bench_mahler_yum.py` so `setup()`, `time_execution()`,
  and `peakmem_execution()` loop over the two discount-factor types
  externally: one solve+simulate per type at `β_mean ± β_std`, over
  disjoint subject subsets that sum to `_N_SUBJECTS`.
- Purpose: provide a fair baseline against benchmarks in #327, which
  runs a single solve+simulate with `discount_type` as an in-model state
  (grid size 2× on that dimension). Comparing #327's numbers to the
  single-β version on `main` mixes a 1-type workload with a 2-type
  workload; this branch measures the 2-type workload using the external
  loop a user would write without the H-consumes-DAG feature.
- Draft so ASV benchmarks run on the PR.

## Test plan

- [x] Local smoke test: `setup()` builds 2 runs (53 + 47 subjects at
  β≈0.914 / 0.971), `time_execution()` completes without error.
- [x] CI benchmark workflow on this draft PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)