### PR TITLE
mahler_yum_2024: drop batch_size=1 on discount_type

### DIFF
--- a/src/lcm_examples/mahler_yum_2024/_model.py
+++ b/src/lcm_examples/mahler_yum_2024/_model.py
@@ -326,7 +326,7 @@ ALIVE_REGIME = Regime(
         "education": DiscreteGrid(Education),
         "productivity": DiscreteGrid(ProductivityType),
         "health_type": DiscreteGrid(HealthType),
-        "discount_type": DiscreteGrid(DiscountType, batch_size=1),
+        "discount_type": DiscreteGrid(DiscountType),
     },
     state_transitions={
         "wealth": next_wealth,
@@ -380,7 +380,7 @@ DEAD_REGIME = Regime(
     transition=None,
     active=partial(dead_is_active, initial_age=ages.values[0]),
     states={
-        "discount_type": DiscreteGrid(DiscountType, batch_size=1),
+        "discount_type": DiscreteGrid(DiscountType),
     },
     functions={"utility": dead_utility},
 )


### PR DESCRIPTION
## Summary

Extracted from #331. The partition-dispatch feature itself is on hold pending a benchmark model that proves the win, but this single example tweak is independent and worth landing on its own.

`DiscreteGrid(DiscountType, batch_size=1)` serialises across the 2-element discount-type axis via lax.map. With Mahler-Yum's main-baseline GPU peak at 401 MB (well under any reasonable bound), the chunk-of-one buys nothing here — removing it lets `jax.vmap` fuse the two slices into the inner Bellman kernel.

## Verification

- Full f64 + CUDA test suite: **850 passed, 2 skipped, 0 failed** (~7 min on RTX A6000).
- `tests/test_regression_test.py::test_regression_mahler_yum` passes at the existing tight tolerance (`atol=1e-5`) on f64. Earlier tolerance loosening on #331 was partition-kernel-induced, not from this commit.

## Test plan

- [x] f64 GPU regression test passes at `atol=1e-5`
- [x] Full f64 GPU test suite passes
- [x] prek hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)