### PR TITLE
benchmarks: bump aca-model pin to c31b5dd

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -270,7 +270,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/aca-model.git?rev=d9339ab1a00861b2d8f4b5c3f70aa216b9cbd0a6#d9339ab1a00861b2d8f4b5c3f70aa216b9cbd0a6
+      - pypi: git+https://github.com/OpenSourceEconomics/aca-model.git?rev=9ac20430f499a8b1cdb056af85bc2a26e850bad2#9ac20430f499a8b1cdb056af85bc2a26e850bad2
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2c/1a/aff8bb287a4b1400f69e09a53bd65de96aa5cee5691925b38731c67fc695/click_default_group-1.2.4-py2.py3-none-any.whl
@@ -5328,7 +5328,7 @@ packages:
   purls: []
   size: 8191
   timestamp: 1744137672556
-- pypi: git+https://github.com/OpenSourceEconomics/aca-model.git?rev=d9339ab1a00861b2d8f4b5c3f70aa216b9cbd0a6#d9339ab1a00861b2d8f4b5c3f70aa216b9cbd0a6
+- pypi: git+https://github.com/OpenSourceEconomics/aca-model.git?rev=9ac20430f499a8b1cdb056af85bc2a26e850bad2#9ac20430f499a8b1cdb056af85bc2a26e850bad2
   name: aca-model
   version: 0.0.0
   requires_dist:
@@ -13962,8 +13962,8 @@ packages:
   timestamp: 1774796815820
 - pypi: ./
   name: pylcm
-  version: 0.0.2.dev256+g61c2436b6.d20260509
-  sha256: 80f8e8823a9b7d58cdd78b45377e426887832da149342b1563ba0bfbe91653ea
+  version: 0.0.2.dev261+g35f8cfa5f.d20260510
+  sha256: 3b192d6c0a89d70a251241e56de1daa0353112648427184c478d6561d37f367c
   requires_dist:
   - cloudpickle>=3.1.2
   - dags>=0.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ tests-cuda13 = { features = [ "tests", "cuda13" ], solve-group = "cuda13" }
 tests-metal = { features = [ "tests", "metal" ], solve-group = "metal" }
 type-checking = { features = [ "type-checking", "tests" ], solve-group = "default" }
 [tool.pixi.feature.benchmarks.pypi-dependencies]
-aca-model = { git = "https://github.com/OpenSourceEconomics/aca-model.git", rev = "d9339ab1a00861b2d8f4b5c3f70aa216b9cbd0a6" }
+aca-model = { git = "https://github.com/OpenSourceEconomics/aca-model.git", rev = "9ac20430f499a8b1cdb056af85bc2a26e850bad2" }
 [tool.pixi.feature.cuda12]
 platforms = [ "linux-64" ]
 system-requirements = { cuda = "12" }


### PR DESCRIPTION
## Summary
- Single-line bump of the aca-model rev pinned by the `benchmarks` pixi feature
- Picks up the aca-model consumption_unequiv rename + the regenerated benchmark snapshot (workarounds removed)

## Test plan
- [ ] `pixi run -e benchmarks-cuda12 asv run --quick` smoke-tests the bench harness against the new aca-model

🤖 Generated with [Claude Code](https://claude.com/claude-code)