### PR TITLE
Drop `regime__state` flat keys from simulation state carrier (#343 phase 1)

### DIFF
--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -31,6 +31,7 @@ from lcm.typing import (
     RegimeIdsToNames,
     RegimeName,
     RegimeNamesToIds,
+    StateName,
     StatesPerRegime,
 )
 from lcm.utils.containers import invert_regime_ids
@@ -44,7 +45,7 @@ MISSING_CAT_CODE = jnp.iinfo(jnp.int32).min
 
 def build_initial_states(
     *,
-    initial_states: Mapping[str, Array],
+    initial_states: Mapping[StateName, Array],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
 ) -> StatesPerRegime:
     """Build the regime-keyed state carrier from user-provided initial states.
@@ -62,10 +63,10 @@ def build_initial_states(
 
     """
     n_subjects = len(next(iter(initial_states.values())))
-    nested: dict[RegimeName, MappingProxyType[str, Array]] = {}
+    states_per_regime: dict[RegimeName, MappingProxyType[StateName, Array]] = {}
 
     for regime_name, internal_regime in internal_regimes.items():
-        regime_states: dict[str, Array] = {}
+        regime_states: dict[StateName, Array] = {}
         for state_name in _get_regime_state_names(internal_regime):
             grid = internal_regime.grids[state_name]
             if isinstance(grid, DiscreteGrid):
@@ -92,9 +93,9 @@ def build_initial_states(
                 regime_states[state_name] = jnp.full(
                     n_subjects, jnp.nan, dtype=canonical_float_dtype()
                 )
-        nested[regime_name] = MappingProxyType(regime_states)
+        states_per_regime[regime_name] = MappingProxyType(regime_states)
 
-    return MappingProxyType(nested)
+    return MappingProxyType(states_per_regime)
 
 
 def validate_initial_conditions(
@@ -232,7 +233,7 @@ def _format_missing_states_message(missing: set[str], required: set[str]) -> str
 
 def _collect_state_name_errors(
     *,
-    initial_states: Mapping[str, Array],
+    initial_states: Mapping[StateName, Array],
     regime_id_arr: Array,
     regime_ids_to_names: RegimeIdsToNames,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
@@ -290,7 +291,7 @@ def _collect_state_name_errors(
 
 def _collect_structural_errors(
     *,
-    initial_states: Mapping[str, Array],
+    initial_states: Mapping[StateName, Array],
     regime_id_arr: Array,
     regime_ids_to_names: RegimeIdsToNames,
     regime_names_to_ids: RegimeNamesToIds,
@@ -390,7 +391,7 @@ def _collect_structural_errors(
 
 def _collect_feasibility_errors(
     *,
-    initial_states: Mapping[str, Array],
+    initial_states: Mapping[StateName, Array],
     regime_id_arr: Array,
     regime_names_to_ids: RegimeNamesToIds,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
@@ -441,7 +442,7 @@ def _collect_feasibility_errors(
 
 def _validate_discrete_state_values(
     *,
-    initial_states: Mapping[str, Array],
+    initial_states: Mapping[StateName, Array],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     regime_id_arr: Array,
     regime_names_to_ids: RegimeNamesToIds,
@@ -508,7 +509,7 @@ _BYTES_PER_ACTION_ELEMENT = 4
 def _batched_feasibility_check(
     *,
     feasibility_func: Callable[..., Array],
-    subject_states: Mapping[str, Array],
+    subject_states: Mapping[StateName, Array],
     action_kwargs: Mapping[str, Array],
     filtered_params: Mapping[str, object],
     flat_actions: Mapping[ActionName, Array],
@@ -576,7 +577,7 @@ def _check_regime_feasibility(  # noqa: C901
     *,
     internal_regime: InternalRegime,
     regime_name: RegimeName,
-    initial_states: Mapping[str, Array],
+    initial_states: Mapping[StateName, Array],
     subject_indices: list[int],
     regime_params: Mapping[str, object],
     ages: AgeGrid,
@@ -628,7 +629,7 @@ def _check_regime_feasibility(  # noqa: C901
 
     # Build per-subject state arrays
     idx_arr = jnp.array(subject_indices)
-    subject_states: dict[str, Array] = {}
+    subject_states: dict[StateName, Array] = {}
     for sn in state_names:
         if sn in accepted:
             subject_states[sn] = initial_states[sn][idx_arr]
@@ -717,7 +718,7 @@ def _admits_any_action(
 def _per_constraint_feasibility(
     *,
     internal_regime: InternalRegime,
-    subject_states: Mapping[str, Array],
+    subject_states: Mapping[StateName, Array],
     regime_params: Mapping[str, object],
     flat_actions: Mapping[ActionName, Array],
     idx_arr: Array,
@@ -784,7 +785,7 @@ def _raise_feasibility_type_error(
     exc: TypeError,
     regime_name: RegimeName,
     internal_regime: InternalRegime,
-    subject_states: dict[str, Array],
+    subject_states: dict[StateName, Array],
 ) -> Never:
     """Re-raise a TypeError from feasibility checking with diagnostic context.
 
@@ -830,7 +831,7 @@ def _format_infeasibility_message(
     infeasible_indices: Sequence[int],
     internal_regime: InternalRegime,
     regime_name: RegimeName,
-    initial_states: Mapping[str, Array],
+    initial_states: Mapping[StateName, Array],
     state_names: Sequence[str],
     per_constraint_admits_any: Mapping[str, np.ndarray],
 ) -> str:

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -31,6 +31,7 @@ from lcm.typing import (
     RegimeIdsToNames,
     RegimeName,
     RegimeNamesToIds,
+    StatesPerRegime,
 )
 from lcm.utils.containers import invert_regime_ids
 from lcm.utils.functools import get_union_of_args
@@ -45,8 +46,8 @@ def build_initial_states(
     *,
     initial_states: Mapping[str, Array],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
-) -> MappingProxyType[str, Array]:
-    """Build flat regime-namespaced state dict from user-provided initial states.
+) -> StatesPerRegime:
+    """Build the regime-keyed state carrier from user-provided initial states.
 
     For each regime, copies provided states and fills missing ones with
     `jnp.nan` (continuous) or `MISSING_CAT_CODE` (discrete).
@@ -57,16 +58,15 @@ def build_initial_states(
             instances.
 
     Returns:
-        Immutable mapping of regime-namespaced state names to arrays.
-        Example: `{"work__wealth": arr, "work__health": arr, ...}`
+        Nested immutable mapping `{regime_name: {state_name: array}}`.
 
     """
-    flat: dict[str, Array] = {}
     n_subjects = len(next(iter(initial_states.values())))
+    nested: dict[RegimeName, MappingProxyType[str, Array]] = {}
 
     for regime_name, internal_regime in internal_regimes.items():
+        regime_states: dict[str, Array] = {}
         for state_name in _get_regime_state_names(internal_regime):
-            key = f"{regime_name}__{state_name}"
             grid = internal_regime.grids[state_name]
             if isinstance(grid, DiscreteGrid):
                 # Cast user-supplied discrete states to the grid's index
@@ -74,22 +74,27 @@ def build_initial_states(
                 # for that state.
                 target_dtype = grid.to_jax().dtype
                 if state_name in initial_states:
-                    flat[key] = initial_states[state_name].astype(target_dtype)
+                    regime_states[state_name] = initial_states[state_name].astype(
+                        target_dtype
+                    )
                 else:
-                    flat[key] = jnp.full(
+                    regime_states[state_name] = jnp.full(
                         n_subjects, MISSING_CAT_CODE, dtype=target_dtype
                     )
             elif state_name in initial_states:
                 # Cast user-supplied continuous states to the canonical float
                 # dtype so the simulate state pool has one signature across
                 # periods regardless of the user-supplied dtype.
-                flat[key] = safe_to_float_dtype(
+                regime_states[state_name] = safe_to_float_dtype(
                     initial_states[state_name], name=f"initial_states.{state_name}"
                 )
             else:
-                flat[key] = jnp.full(n_subjects, jnp.nan, dtype=canonical_float_dtype())
+                regime_states[state_name] = jnp.full(
+                    n_subjects, jnp.nan, dtype=canonical_float_dtype()
+                )
+        nested[regime_name] = MappingProxyType(regime_states)
 
-    return MappingProxyType(flat)
+    return MappingProxyType(nested)
 
 
 def validate_initial_conditions(

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -252,7 +252,7 @@ def _simulate_regime_in_period(
 
     state_action_space = create_regime_state_action_space(
         internal_regime=internal_regime,
-        current_states_per_regime=states,
+        regime_states=states[regime_name],
         regime_params=internal_params[regime_name],
     )
     # Compute optimal actions
@@ -309,7 +309,7 @@ def _simulate_regime_in_period(
             period=period,
             age=age,
             regime_params=internal_params[regime_name],
-            current_states_per_regime=states,
+            states_per_regime=states,
             state_action_space=state_action_space,
             key=next_states_key,
             subjects_in_regime=subject_ids_in_regime,

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -33,6 +33,7 @@ from lcm.typing import (
     RegimeNamesToIds,
     ScalarFloat,
     ScalarInt,
+    StatesPerRegime,
 )
 from lcm.utils.containers import invert_regime_ids
 from lcm.utils.error_handling import validate_V
@@ -205,7 +206,7 @@ def _simulate_regime_in_period(
     internal_regime: InternalRegime,
     period: int,
     age: ScalarInt | ScalarFloat,
-    states: MappingProxyType[str, Array],
+    states: StatesPerRegime,
     subject_regime_ids: Int1D,
     new_subject_regime_ids: Int1D,
     period_to_regime_to_V_arr: MappingProxyType[
@@ -215,7 +216,7 @@ def _simulate_regime_in_period(
     regime_names_to_ids: RegimeNamesToIds,
     active_regimes_next_period: tuple[RegimeName, ...],
     key: Array,
-) -> tuple[PeriodRegimeSimulationData, MappingProxyType[str, Array], Int1D, Array]:
+) -> tuple[PeriodRegimeSimulationData, StatesPerRegime, Int1D, Array]:
     """Simulate one regime for one period.
 
     This function processes all subjects in a given regime for a single period,
@@ -226,7 +227,8 @@ def _simulate_regime_in_period(
         internal_regime: Internal representation of the regime.
         period: Current period (0-indexed).
         age: Age corresponding to current period.
-        states: Current states for all subjects (namespaced by regime).
+        states: Carrier of current-period state arrays for every regime and
+            state.
         subject_regime_ids: Current regime membership for all subjects.
         new_subject_regime_ids: Array to populate with next period's regime memberships.
         period_to_regime_to_V_arr: Value function arrays for all periods and regimes.
@@ -238,7 +240,7 @@ def _simulate_regime_in_period(
     Returns:
         Tuple containing:
         - PeriodRegimeSimulationData for this regime-period
-        - Updated states dictionary
+        - Updated state carrier
         - Updated new_subject_regime_ids array
         - Updated JAX random key
 
@@ -250,7 +252,7 @@ def _simulate_regime_in_period(
 
     state_action_space = create_regime_state_action_space(
         internal_regime=internal_regime,
-        states=states,
+        current_states_per_regime=states,
         regime_params=internal_params[regime_name],
     )
     # Compute optimal actions
@@ -290,16 +292,10 @@ def _simulate_regime_in_period(
     if V_arr.ndim == 0:
         V_arr = jnp.broadcast_to(V_arr, (n_subjects,))
 
-    res = {
-        state_name.removeprefix(f"{regime_name}__"): state
-        for state_name, state in states.items()
-        if state_name.startswith(f"{regime_name}__")
-    }
-
     simulation_result = PeriodRegimeSimulationData(
         V_arr=V_arr,
         actions=optimal_actions,
-        states=MappingProxyType(res),
+        states=states[regime_name],
         in_regime=subject_ids_in_regime,
     )
 
@@ -313,7 +309,7 @@ def _simulate_regime_in_period(
             period=period,
             age=age,
             regime_params=internal_params[regime_name],
-            states=states,
+            current_states_per_regime=states,
             state_action_space=state_action_space,
             key=next_states_key,
             subjects_in_regime=subject_ids_in_regime,

--- a/src/lcm/simulation/transitions.py
+++ b/src/lcm/simulation/transitions.py
@@ -19,14 +19,13 @@ from lcm.state_action_space import _validate_all_states_present
 from lcm.typing import (
     ActionName,
     Bool1D,
-    ContinuousState,
-    DiscreteState,
     FlatRegimeParams,
     Int1D,
     RegimeName,
     RegimeNamesToIds,
     ScalarFloat,
     ScalarInt,
+    StatesPerRegime,
 )
 from lcm.utils.namespace import flatten_regime_namespace
 
@@ -34,7 +33,7 @@ from lcm.utils.namespace import flatten_regime_namespace
 def create_regime_state_action_space(
     *,
     internal_regime: InternalRegime,
-    states: MappingProxyType[str, Array],
+    current_states_per_regime: StatesPerRegime,
     regime_params: FlatRegimeParams,
 ) -> StateActionSpace:
     """Create the state-action space containing only the relevant subjects in a regime.
@@ -45,7 +44,8 @@ def create_regime_state_action_space(
 
     Args:
         internal_regime: The internal regime instance.
-        states: The current states of all subjects.
+        current_states_per_regime: Carrier of state arrays for every regime and
+            state, indexed by regime name then state name.
         regime_params: Flat regime parameters supplied at runtime, used to
             substitute runtime-supplied action gridpoints.
 
@@ -56,8 +56,9 @@ def create_regime_state_action_space(
     base = internal_regime.state_action_space(regime_params=regime_params)
 
     relevant_state_names = internal_regime.variable_info.query("is_state").index
+    regime_states = current_states_per_regime[internal_regime.name]
     states_for_state_action_space = {
-        sn: states[f"{internal_regime.name}__{sn}"] for sn in relevant_state_names
+        sn: regime_states[sn] for sn in relevant_state_names
     }
     _validate_all_states_present(
         provided_states=states_for_state_action_space,
@@ -74,11 +75,11 @@ def calculate_next_states(
     period: int,
     age: ScalarInt | ScalarFloat,
     regime_params: FlatRegimeParams,
-    states: MappingProxyType[str, Array],
+    current_states_per_regime: StatesPerRegime,
     state_action_space: StateActionSpace,
     key: Array,
     subjects_in_regime: Bool1D,
-) -> MappingProxyType[str, Array]:
+) -> StatesPerRegime:
     """Calculate next period states for subjects in a regime.
 
     Args:
@@ -88,14 +89,14 @@ def calculate_next_states(
         period: Current period.
         age: Age corresponding to current period.
         regime_params: Flat regime parameters.
-        states: Current states for all subjects (all regimes).
+        current_states_per_regime: Carrier of current-period state arrays for
+            every regime and state, indexed by regime name then state name.
         state_action_space: State-action space for subjects in this regime.
         key: JAX random key.
 
     Returns:
-        Updated states dictionary with next period states for subjects in this regime.
-        Immutable mapping of updated states for all subjects, with updates only for
-        those in the current regime.
+        Updated carrier with next-period state values for subjects in this regime;
+        entries for other subjects are left untouched.
 
     """
     # Identify stochastic transitions and generate random keys
@@ -133,13 +134,25 @@ def calculate_next_states(
         **regime_params,
     )
 
-    # Update global states array with computed next states for subjects in regime
-    # ---------------------------------------------------------------------------------
-    # The transition function adds a 'next_' prefix to all state names. We remove
-    # this prefix and update only the entries corresponding to subjects in this regime.
-    return _update_states_for_subjects(
-        all_states=states,
-        computed_next_states=states_with_next_prefix,
+    # Transition functions are DAG-named `next_<state>` to distinguish them from
+    # the current-period state values they consume. Strip the prefix here so
+    # `_advance_states_for_subjects` sees keys that line up with the carrier's
+    # `StateName` keys directly.
+    next_states_per_regime = MappingProxyType(
+        {
+            target: MappingProxyType(
+                {
+                    name.removeprefix("next_"): value
+                    for name, value in target_next_states.items()
+                }
+            )
+            for target, target_next_states in states_with_next_prefix.items()
+        }
+    )
+
+    return _advance_states_for_subjects(
+        current_states_per_regime=current_states_per_regime,
+        next_states_per_regime=next_states_per_regime,
         subject_indices=subjects_in_regime,
     )
 
@@ -259,37 +272,42 @@ def draw_key_from_dict(
     return random_ids(keys, regime_transition_probs)
 
 
-def _update_states_for_subjects(
+def _advance_states_for_subjects(
     *,
-    all_states: MappingProxyType[str, Array],
-    computed_next_states: MappingProxyType[
-        RegimeName, MappingProxyType[str, DiscreteState | ContinuousState]
-    ],
+    current_states_per_regime: StatesPerRegime,
+    next_states_per_regime: StatesPerRegime,
     subject_indices: Bool1D,
-) -> MappingProxyType[str, Array]:
-    """Update the global states dictionary with next states for specific subjects.
+) -> StatesPerRegime:
+    """Merge next-period state values into the carrier for selected subjects.
 
-    Outputs from `get_next_state_function_for_simulation` are nested by target
-    regime, with inner keys carrying the `next_` prefix
-    (`{target: {next_<state>: array}}`). Strip the prefix and combine with the
-    target name into the flat `<target>__<state>` key used in `all_states`,
-    updating only the entries corresponding to the specified subjects.
+    The carrier and the per-regime update share the `StatesPerRegime` shape: an
+    outer mapping by regime name, an inner mapping by state name. Where
+    `subject_indices` is true, the corresponding slot is replaced with the
+    matching entry from `next_states_per_regime`; otherwise the carrier value
+    is left untouched. Regimes that don't appear in `next_states_per_regime`
+    are passed through unchanged.
 
     Args:
-        all_states: Current states for all subjects across all regimes.
-        computed_next_states: Newly computed states, nested by target regime
-            and keyed by `next_<state>`, for specific subjects.
-        subject_indices: Indices of subjects whose states should be updated.
+        current_states_per_regime: Carrier of state arrays prior to this advance,
+            indexed by regime name then state name.
+        next_states_per_regime: Per-regime next-period state values to merge in,
+            indexed by regime name then state name (no `next_` prefix — the
+            caller in `calculate_next_states` strips it before invoking).
+        subject_indices: Boolean mask selecting which subjects' values are
+            overwritten by the next-period entries.
 
     Returns:
-        Updated states dictionary with next states for the specified subjects.
+        Updated carrier with next-period values written in for selected subjects.
 
     """
-    updated_states = dict(all_states)
-    for target, target_next_states in computed_next_states.items():
-        for next_state_name, next_state_values in target_next_states.items():
-            state_name = f"{target}__{next_state_name.removeprefix('next_')}"
-            target_dtype = all_states[state_name].dtype
+    updated: dict[RegimeName, dict[str, Array]] = {
+        regime_name: dict(regime_states)
+        for regime_name, regime_states in current_states_per_regime.items()
+    }
+    for target, target_next_states in next_states_per_regime.items():
+        for state_name, next_state_values in target_next_states.items():
+            current_arr = current_states_per_regime[target][state_name]
+            target_dtype = current_arr.dtype
             # Preserve storage dtype only when the transition output is the
             # same numeric kind. Across kinds (e.g. int storage + float
             # transition output) leave JAX's promotion in place; the
@@ -299,10 +317,15 @@ def _update_states_for_subjects(
                 if next_state_values.dtype.kind == target_dtype.kind
                 else next_state_values
             )
-            updated_states[state_name] = jnp.where(
+            updated[target][state_name] = jnp.where(
                 subject_indices,
                 new_values,
-                all_states[state_name],
+                current_arr,
             )
 
-    return MappingProxyType(updated_states)
+    return MappingProxyType(
+        {
+            regime_name: MappingProxyType(regime_states)
+            for regime_name, regime_states in updated.items()
+        }
+    )

--- a/src/lcm/simulation/transitions.py
+++ b/src/lcm/simulation/transitions.py
@@ -23,8 +23,10 @@ from lcm.typing import (
     Int1D,
     RegimeName,
     RegimeNamesToIds,
+    RegimeStates,
     ScalarFloat,
     ScalarInt,
+    StateName,
     StatesPerRegime,
 )
 from lcm.utils.namespace import flatten_regime_namespace
@@ -33,7 +35,7 @@ from lcm.utils.namespace import flatten_regime_namespace
 def create_regime_state_action_space(
     *,
     internal_regime: InternalRegime,
-    current_states_per_regime: StatesPerRegime,
+    regime_states: RegimeStates,
     regime_params: FlatRegimeParams,
 ) -> StateActionSpace:
     """Create the state-action space containing only the relevant subjects in a regime.
@@ -44,8 +46,7 @@ def create_regime_state_action_space(
 
     Args:
         internal_regime: The internal regime instance.
-        current_states_per_regime: Carrier of state arrays for every regime and
-            state, indexed by regime name then state name.
+        regime_states: State arrays for this regime, keyed by state name.
         regime_params: Flat regime parameters supplied at runtime, used to
             substitute runtime-supplied action gridpoints.
 
@@ -56,7 +57,6 @@ def create_regime_state_action_space(
     base = internal_regime.state_action_space(regime_params=regime_params)
 
     relevant_state_names = internal_regime.variable_info.query("is_state").index
-    regime_states = current_states_per_regime[internal_regime.name]
     states_for_state_action_space = {
         sn: regime_states[sn] for sn in relevant_state_names
     }
@@ -75,7 +75,7 @@ def calculate_next_states(
     period: int,
     age: ScalarInt | ScalarFloat,
     regime_params: FlatRegimeParams,
-    current_states_per_regime: StatesPerRegime,
+    states_per_regime: StatesPerRegime,
     state_action_space: StateActionSpace,
     key: Array,
     subjects_in_regime: Bool1D,
@@ -89,7 +89,7 @@ def calculate_next_states(
         period: Current period.
         age: Age corresponding to current period.
         regime_params: Flat regime parameters.
-        current_states_per_regime: Carrier of current-period state arrays for
+        states_per_regime: Carrier of current-period state arrays for
             every regime and state, indexed by regime name then state name.
         state_action_space: State-action space for subjects in this regime.
         key: JAX random key.
@@ -151,7 +151,7 @@ def calculate_next_states(
     )
 
     return _advance_states_for_subjects(
-        current_states_per_regime=current_states_per_regime,
+        states_per_regime=states_per_regime,
         next_states_per_regime=next_states_per_regime,
         subject_indices=subjects_in_regime,
     )
@@ -274,7 +274,7 @@ def draw_key_from_dict(
 
 def _advance_states_for_subjects(
     *,
-    current_states_per_regime: StatesPerRegime,
+    states_per_regime: StatesPerRegime,
     next_states_per_regime: StatesPerRegime,
     subject_indices: Bool1D,
 ) -> StatesPerRegime:
@@ -288,7 +288,7 @@ def _advance_states_for_subjects(
     are passed through unchanged.
 
     Args:
-        current_states_per_regime: Carrier of state arrays prior to this advance,
+        states_per_regime: Carrier of state arrays prior to this advance,
             indexed by regime name then state name.
         next_states_per_regime: Per-regime next-period state values to merge in,
             indexed by regime name then state name (no `next_` prefix — the
@@ -300,13 +300,13 @@ def _advance_states_for_subjects(
         Updated carrier with next-period values written in for selected subjects.
 
     """
-    updated: dict[RegimeName, dict[str, Array]] = {
+    updated: dict[RegimeName, dict[StateName, Array]] = {
         regime_name: dict(regime_states)
-        for regime_name, regime_states in current_states_per_regime.items()
+        for regime_name, regime_states in states_per_regime.items()
     }
     for target, target_next_states in next_states_per_regime.items():
         for state_name, next_state_values in target_next_states.items():
-            current_arr = current_states_per_regime[target][state_name]
+            current_arr = states_per_regime[target][state_name]
             target_dtype = current_arr.dtype
             # Preserve storage dtype only when the transition output is the
             # same numeric kind. Across kinds (e.g. int storage + float

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -45,9 +45,6 @@ type TransitionFunctionsMapping = MappingProxyType[
     RegimeName, MappingProxyType[TransitionFunctionName, InternalUserFunction]
 ]
 
-# Nested state carrier threading through the simulation loop.
-# `RegimeStates`: one regime's state arrays, keyed by state name.
-# `StatesPerRegime`: every regime's `RegimeStates` bundle, keyed by regime name.
 type RegimeStates = MappingProxyType[StateName, Array]
 type StatesPerRegime = MappingProxyType[RegimeName, RegimeStates]
 

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -45,6 +45,12 @@ type TransitionFunctionsMapping = MappingProxyType[
     RegimeName, MappingProxyType[TransitionFunctionName, InternalUserFunction]
 ]
 
+# Nested state carrier threading through the simulation loop.
+# `RegimeStates`: one regime's state arrays, keyed by state name.
+# `StatesPerRegime`: every regime's `RegimeStates` bundle, keyed by regime name.
+type RegimeStates = MappingProxyType[StateName, Array]
+type StatesPerRegime = MappingProxyType[RegimeName, RegimeStates]
+
 
 type _ParamsLeaf = bool | float | Array | pd.Series | MappingLeaf | SequenceLeaf
 type UserParams = Mapping[

--- a/tests/simulation/test_initial_conditions.py
+++ b/tests/simulation/test_initial_conditions.py
@@ -88,19 +88,19 @@ def internal_params(model: Model) -> InternalParams:
 
 
 def test_build_initial_states_single_regime(model: Model) -> None:
-    """Single regime gets its states from flat dict."""
-    flat = {
+    """Each regime's state arrays land under its name in the nested carrier."""
+    initial = {
         "wealth": jnp.array([10.0, 50.0]),
         "health": jnp.array([0, 1]),
     }
     result = build_initial_states(
-        initial_states=flat, internal_regimes=model.internal_regimes
+        initial_states=initial, internal_regimes=model.internal_regimes
     )
 
-    assert "active__wealth" in result
-    assert "active__health" in result
-    # Terminal regime has no states, so no terminal__ keys should exist
-    assert not any(k.startswith("terminal__") for k in result)
+    assert "wealth" in result["active"]
+    assert "health" in result["active"]
+    # Terminal regime has no states, so its inner mapping is empty.
+    assert dict(result["terminal"]) == {}
 
 
 def test_validate_initial_conditions_valid_input(

--- a/tests/simulation/test_update_states.py
+++ b/tests/simulation/test_update_states.py
@@ -8,7 +8,7 @@ from lcm.simulation.transitions import _advance_states_for_subjects
 
 def test_advance_states_writes_new_values_for_selected_subjects():
     """Selected subjects receive the next-period array; others stay put."""
-    current_states_per_regime = MappingProxyType(
+    states_per_regime = MappingProxyType(
         {
             "working": MappingProxyType({"wealth": jnp.array([10.0, 20.0, 30.0])}),
         }
@@ -20,18 +20,18 @@ def test_advance_states_writes_new_values_for_selected_subjects():
     )
     subject_indices = jnp.array([True, False, True])
 
-    result = _advance_states_for_subjects(
-        current_states_per_regime=current_states_per_regime,
+    next_states = _advance_states_for_subjects(
+        states_per_regime=states_per_regime,
         next_states_per_regime=next_states_per_regime,
         subject_indices=subject_indices,
     )
 
-    assert_array_equal(result["working"]["wealth"], jnp.array([15.0, 20.0, 35.0]))
+    assert_array_equal(next_states["working"]["wealth"], jnp.array([15.0, 20.0, 35.0]))
 
 
 def test_advance_states_handles_multiple_regimes_and_states():
     """Regimes named in `next_states_per_regime` get updated; others stay intact."""
-    current_states_per_regime = MappingProxyType(
+    states_per_regime = MappingProxyType(
         {
             "working": MappingProxyType(
                 {
@@ -54,20 +54,20 @@ def test_advance_states_handles_multiple_regimes_and_states():
     )
     subject_indices = jnp.array([True, True])
 
-    result = _advance_states_for_subjects(
-        current_states_per_regime=current_states_per_regime,
+    next_states = _advance_states_for_subjects(
+        states_per_regime=states_per_regime,
         next_states_per_regime=next_states_per_regime,
         subject_indices=subject_indices,
     )
 
-    assert_array_equal(result["working"]["wealth"], jnp.array([15.0, 25.0]))
-    assert_array_equal(result["working"]["health"], jnp.array([1.5, 2.5]))
-    assert_array_equal(result["retired"]["wealth"], jnp.array([100.0, 200.0]))
+    assert_array_equal(next_states["working"]["wealth"], jnp.array([15.0, 25.0]))
+    assert_array_equal(next_states["working"]["health"], jnp.array([1.5, 2.5]))
+    assert_array_equal(next_states["retired"]["wealth"], jnp.array([100.0, 200.0]))
 
 
 def test_advance_states_no_subjects_selected_leaves_carrier_unchanged():
     """When no subject is selected, the next-period values are ignored entirely."""
-    current_states_per_regime = MappingProxyType(
+    states_per_regime = MappingProxyType(
         {
             "r": MappingProxyType({"wealth": jnp.array([10.0, 20.0])}),
         }
@@ -79,10 +79,10 @@ def test_advance_states_no_subjects_selected_leaves_carrier_unchanged():
     )
     subject_indices = jnp.array([False, False])
 
-    result = _advance_states_for_subjects(
-        current_states_per_regime=current_states_per_regime,
+    next_states = _advance_states_for_subjects(
+        states_per_regime=states_per_regime,
         next_states_per_regime=next_states_per_regime,
         subject_indices=subject_indices,
     )
 
-    assert_array_equal(result["r"]["wealth"], jnp.array([10.0, 20.0]))
+    assert_array_equal(next_states["r"]["wealth"], jnp.array([10.0, 20.0]))

--- a/tests/simulation/test_update_states.py
+++ b/tests/simulation/test_update_states.py
@@ -3,80 +3,86 @@ from types import MappingProxyType
 import jax.numpy as jnp
 from numpy.testing import assert_array_equal
 
-from lcm.simulation.transitions import _update_states_for_subjects
+from lcm.simulation.transitions import _advance_states_for_subjects
 
 
-def test_update_states_strips_next_prefix():
-    all_states = MappingProxyType(
+def test_advance_states_writes_new_values_for_selected_subjects():
+    """Selected subjects receive the next-period array; others stay put."""
+    current_states_per_regime = MappingProxyType(
         {
-            "working__wealth": jnp.array([10.0, 20.0, 30.0]),
+            "working": MappingProxyType({"wealth": jnp.array([10.0, 20.0, 30.0])}),
         }
     )
-    computed_next_states = MappingProxyType(
+    next_states_per_regime = MappingProxyType(
         {
-            "working": MappingProxyType({"next_wealth": jnp.array([15.0, 25.0, 35.0])}),
+            "working": MappingProxyType({"wealth": jnp.array([15.0, 25.0, 35.0])}),
         }
     )
     subject_indices = jnp.array([True, False, True])
 
-    result = _update_states_for_subjects(
-        all_states=all_states,
-        computed_next_states=computed_next_states,
+    result = _advance_states_for_subjects(
+        current_states_per_regime=current_states_per_regime,
+        next_states_per_regime=next_states_per_regime,
         subject_indices=subject_indices,
     )
 
-    assert_array_equal(result["working__wealth"], jnp.array([15.0, 20.0, 35.0]))
+    assert_array_equal(result["working"]["wealth"], jnp.array([15.0, 20.0, 35.0]))
 
 
-def test_update_states_multiple_regimes_and_states():
-    all_states = MappingProxyType(
-        {
-            "working__wealth": jnp.array([10.0, 20.0]),
-            "working__health": jnp.array([1.0, 2.0]),
-            "retired__wealth": jnp.array([100.0, 200.0]),
-        }
-    )
-    computed_next_states = MappingProxyType(
+def test_advance_states_handles_multiple_regimes_and_states():
+    """Regimes named in `next_states_per_regime` get updated; others stay intact."""
+    current_states_per_regime = MappingProxyType(
         {
             "working": MappingProxyType(
                 {
-                    "next_wealth": jnp.array([15.0, 25.0]),
-                    "next_health": jnp.array([1.5, 2.5]),
+                    "wealth": jnp.array([10.0, 20.0]),
+                    "health": jnp.array([1.0, 2.0]),
+                }
+            ),
+            "retired": MappingProxyType({"wealth": jnp.array([100.0, 200.0])}),
+        }
+    )
+    next_states_per_regime = MappingProxyType(
+        {
+            "working": MappingProxyType(
+                {
+                    "wealth": jnp.array([15.0, 25.0]),
+                    "health": jnp.array([1.5, 2.5]),
                 }
             ),
         }
     )
     subject_indices = jnp.array([True, True])
 
-    result = _update_states_for_subjects(
-        all_states=all_states,
-        computed_next_states=computed_next_states,
+    result = _advance_states_for_subjects(
+        current_states_per_regime=current_states_per_regime,
+        next_states_per_regime=next_states_per_regime,
         subject_indices=subject_indices,
     )
 
-    assert_array_equal(result["working__wealth"], jnp.array([15.0, 25.0]))
-    assert_array_equal(result["working__health"], jnp.array([1.5, 2.5]))
-    # Untouched state remains unchanged
-    assert_array_equal(result["retired__wealth"], jnp.array([100.0, 200.0]))
+    assert_array_equal(result["working"]["wealth"], jnp.array([15.0, 25.0]))
+    assert_array_equal(result["working"]["health"], jnp.array([1.5, 2.5]))
+    assert_array_equal(result["retired"]["wealth"], jnp.array([100.0, 200.0]))
 
 
-def test_update_states_no_subjects_selected():
-    all_states = MappingProxyType(
+def test_advance_states_no_subjects_selected_leaves_carrier_unchanged():
+    """When no subject is selected, the next-period values are ignored entirely."""
+    current_states_per_regime = MappingProxyType(
         {
-            "r__wealth": jnp.array([10.0, 20.0]),
+            "r": MappingProxyType({"wealth": jnp.array([10.0, 20.0])}),
         }
     )
-    computed_next_states = MappingProxyType(
+    next_states_per_regime = MappingProxyType(
         {
-            "r": MappingProxyType({"next_wealth": jnp.array([99.0, 99.0])}),
+            "r": MappingProxyType({"wealth": jnp.array([99.0, 99.0])}),
         }
     )
     subject_indices = jnp.array([False, False])
 
-    result = _update_states_for_subjects(
-        all_states=all_states,
-        computed_next_states=computed_next_states,
+    result = _advance_states_for_subjects(
+        current_states_per_regime=current_states_per_regime,
+        next_states_per_regime=next_states_per_regime,
         subject_indices=subject_indices,
     )
 
-    assert_array_equal(result["r__wealth"], jnp.array([10.0, 20.0]))
+    assert_array_equal(result["r"]["wealth"], jnp.array([10.0, 20.0]))

--- a/tests/test_float_dtype_invariants.py
+++ b/tests/test_float_dtype_invariants.py
@@ -39,7 +39,7 @@ def test_build_initial_states_casts_user_float64_to_canonical(x64_disabled: None
         initial_states=initial_states,  # ty: ignore[invalid-argument-type]
         internal_regimes=model.internal_regimes,
     )
-    assert flat["working_life__wealth"].dtype == canonical_float_dtype()
+    assert flat["working_life"]["wealth"].dtype == canonical_float_dtype()
 
 
 def test_build_initial_states_casts_user_int_to_canonical(x64_disabled: None):
@@ -53,7 +53,7 @@ def test_build_initial_states_casts_user_int_to_canonical(x64_disabled: None):
         initial_states=initial_states,
         internal_regimes=model.internal_regimes,
     )
-    assert flat["working_life__wealth"].dtype == canonical_float_dtype()
+    assert flat["working_life"]["wealth"].dtype == canonical_float_dtype()
 
 
 def test_build_initial_states_missing_continuous_fallback_dtype_is_canonical(
@@ -66,7 +66,7 @@ def test_build_initial_states_missing_continuous_fallback_dtype_is_canonical(
         initial_states={"placeholder": jnp.asarray([0.0, 0.0])},
         internal_regimes=model.internal_regimes,
     )
-    assert flat["working_life__wealth"].dtype == canonical_float_dtype()
+    assert flat["working_life"]["wealth"].dtype == canonical_float_dtype()
 
 
 def test_build_initial_states_missing_continuous_fallback_values_are_nan(
@@ -82,7 +82,7 @@ def test_build_initial_states_missing_continuous_fallback_values_are_nan(
         initial_states={"placeholder": jnp.asarray([0.0, 0.0])},
         internal_regimes=model.internal_regimes,
     )
-    assert bool(jnp.all(jnp.isnan(flat["working_life__wealth"])))
+    assert bool(jnp.all(jnp.isnan(flat["working_life"]["wealth"])))
 
 
 def test_process_params_casts_float64_array_to_canonical_under_no_x64(

--- a/tests/test_float_dtype_invariants.py
+++ b/tests/test_float_dtype_invariants.py
@@ -35,11 +35,11 @@ def test_build_initial_states_casts_user_float64_to_canonical(x64_disabled: None
         "wealth": np.asarray([20.0, 50.0], dtype=np.float64),
         "age": np.asarray([18.0, 18.0], dtype=np.float64),
     }
-    flat = build_initial_states(
+    states_per_regime = build_initial_states(
         initial_states=initial_states,  # ty: ignore[invalid-argument-type]
         internal_regimes=model.internal_regimes,
     )
-    assert flat["working_life"]["wealth"].dtype == canonical_float_dtype()
+    assert states_per_regime["working_life"]["wealth"].dtype == canonical_float_dtype()
 
 
 def test_build_initial_states_casts_user_int_to_canonical(x64_disabled: None):
@@ -49,11 +49,11 @@ def test_build_initial_states_casts_user_int_to_canonical(x64_disabled: None):
         "wealth": jnp.asarray([20, 50], dtype=jnp.int32),
         "age": jnp.asarray([18, 18], dtype=jnp.int32),
     }
-    flat = build_initial_states(
+    states_per_regime = build_initial_states(
         initial_states=initial_states,
         internal_regimes=model.internal_regimes,
     )
-    assert flat["working_life"]["wealth"].dtype == canonical_float_dtype()
+    assert states_per_regime["working_life"]["wealth"].dtype == canonical_float_dtype()
 
 
 def test_build_initial_states_missing_continuous_fallback_dtype_is_canonical(
@@ -62,11 +62,11 @@ def test_build_initial_states_missing_continuous_fallback_dtype_is_canonical(
     """A missing continuous state falls back to a canonical-dtype array."""
     model = get_model(n_periods=3)
     # Supply a placeholder state to set n_subjects without touching `wealth`.
-    flat = build_initial_states(
+    states_per_regime = build_initial_states(
         initial_states={"placeholder": jnp.asarray([0.0, 0.0])},
         internal_regimes=model.internal_regimes,
     )
-    assert flat["working_life"]["wealth"].dtype == canonical_float_dtype()
+    assert states_per_regime["working_life"]["wealth"].dtype == canonical_float_dtype()
 
 
 def test_build_initial_states_missing_continuous_fallback_values_are_nan(
@@ -78,11 +78,11 @@ def test_build_initial_states_missing_continuous_fallback_values_are_nan(
     with zeros (or anything else representable) pass; assert the values.
     """
     model = get_model(n_periods=3)
-    flat = build_initial_states(
+    states_per_regime = build_initial_states(
         initial_states={"placeholder": jnp.asarray([0.0, 0.0])},
         internal_regimes=model.internal_regimes,
     )
-    assert bool(jnp.all(jnp.isnan(flat["working_life"]["wealth"])))
+    assert bool(jnp.all(jnp.isnan(states_per_regime["working_life"]["wealth"])))
 
 
 def test_process_params_casts_float64_array_to_canonical_under_no_x64(

--- a/tests/test_int_dtype_invariants.py
+++ b/tests/test_int_dtype_invariants.py
@@ -53,11 +53,11 @@ def test_build_initial_states_discrete_dtype_is_int32() -> None:
         "wealth": jnp.array([20.0, 50.0]),
         "age": jnp.array([18.0, 18.0]),
     }
-    nested = build_initial_states(
+    states_per_regime = build_initial_states(
         initial_states=initial_states,
         internal_regimes=model.internal_regimes,
     )
-    for regime_name, regime_states in nested.items():
+    for regime_name, regime_states in states_per_regime.items():
         for state_name, arr in regime_states.items():
             if arr.dtype.kind == "i":
                 assert arr.dtype == jnp.int32, (
@@ -81,7 +81,7 @@ def test_advance_states_for_subjects_keeps_same_dtype_round_trip() -> None:
     function does not defend against transitions that violate the canonical-
     dtype invariant.
     """
-    current_states_per_regime = MappingProxyType(
+    states_per_regime = MappingProxyType(
         {
             "work": MappingProxyType(
                 {"health": jnp.asarray([0, 1, 0, 1], dtype=jnp.int32)}
@@ -94,13 +94,13 @@ def test_advance_states_for_subjects_keeps_same_dtype_round_trip() -> None:
     )
     subjects = jnp.asarray([True, False, True, False])
 
-    updated = _advance_states_for_subjects(
-        current_states_per_regime=current_states_per_regime,
+    next_states = _advance_states_for_subjects(
+        states_per_regime=states_per_regime,
         next_states_per_regime=next_states_per_regime,
         subject_indices=subjects,
     )
 
-    assert updated["work"]["health"].dtype == jnp.int32
+    assert next_states["work"]["health"].dtype == jnp.int32
 
 
 def test_process_params_casts_python_int_to_int32() -> None:

--- a/tests/test_int_dtype_invariants.py
+++ b/tests/test_int_dtype_invariants.py
@@ -16,7 +16,7 @@ from lcm.simulation.initial_conditions import (
     MISSING_CAT_CODE,
     build_initial_states,
 )
-from lcm.simulation.transitions import _update_states_for_subjects
+from lcm.simulation.transitions import _advance_states_for_subjects
 from tests.test_models.deterministic.regression import (
     RegimeId,
     dead,
@@ -53,15 +53,17 @@ def test_build_initial_states_discrete_dtype_is_int32() -> None:
         "wealth": jnp.array([20.0, 50.0]),
         "age": jnp.array([18.0, 18.0]),
     }
-    flat = build_initial_states(
+    nested = build_initial_states(
         initial_states=initial_states,
         internal_regimes=model.internal_regimes,
     )
-    for key, arr in flat.items():
-        if arr.dtype.kind == "i":
-            assert arr.dtype == jnp.int32, (
-                f"Initial state {key} has dtype {arr.dtype}, expected int32."
-            )
+    for regime_name, regime_states in nested.items():
+        for state_name, arr in regime_states.items():
+            if arr.dtype.kind == "i":
+                assert arr.dtype == jnp.int32, (
+                    f"Initial state {regime_name}.{state_name} has dtype "
+                    f"{arr.dtype}, expected int32."
+                )
 
 
 def test_missing_cat_code_is_int32_minimum() -> None:
@@ -69,32 +71,36 @@ def test_missing_cat_code_is_int32_minimum() -> None:
     assert jnp.iinfo(jnp.int32).min == MISSING_CAT_CODE
 
 
-def test_update_states_for_subjects_keeps_same_dtype_round_trip() -> None:
+def test_advance_states_for_subjects_keeps_same_dtype_round_trip() -> None:
     """Canonical-dtype transition outputs round-trip through the state pool.
 
     With every input boundary pinned to the canonical dtype, a well-typed user
-    transition returns canonical-dtype outputs and `_update_states_for_subjects`
+    transition returns canonical-dtype outputs and `_advance_states_for_subjects`
     writes them through `jnp.where` without dtype change. This test pins the
     contract for the int side; mixed-dtype inputs are out of scope — the
     function does not defend against transitions that violate the canonical-
     dtype invariant.
     """
-    all_states = MappingProxyType(
-        {"work__health": jnp.asarray([0, 1, 0, 1], dtype=jnp.int32)}
+    current_states_per_regime = MappingProxyType(
+        {
+            "work": MappingProxyType(
+                {"health": jnp.asarray([0, 1, 0, 1], dtype=jnp.int32)}
+            )
+        }
     )
     next_values = jnp.asarray([1, 1, 1, 1], dtype=jnp.int32)
-    computed = MappingProxyType(
-        {"work": MappingProxyType({"next_health": next_values})}
+    next_states_per_regime = MappingProxyType(
+        {"work": MappingProxyType({"health": next_values})}
     )
     subjects = jnp.asarray([True, False, True, False])
 
-    updated = _update_states_for_subjects(
-        all_states=all_states,
-        computed_next_states=computed,
+    updated = _advance_states_for_subjects(
+        current_states_per_regime=current_states_per_regime,
+        next_states_per_regime=next_states_per_regime,
         subject_indices=subjects,
     )
 
-    assert updated["work__health"].dtype == jnp.int32
+    assert updated["work"]["health"].dtype == jnp.int32
 
 
 def test_process_params_casts_python_int_to_int32() -> None:


### PR DESCRIPTION
## Summary

Phase 1 of [#343](https://github.com/OpenSourceEconomics/pylcm/issues/343): flip the simulation state carrier from flat `{regime}__{state}` qname-joined keys to nested `MappingProxyType[RegimeName, MappingProxyType[StateName, Array]]`. Pylcm code on the simulation read/write path stops producing or parsing the `__` separator.

- New type aliases in `lcm/typing.py`:
  - `RegimeStates = MappingProxyType[StateName, Array]`
  - `StatesPerRegime = MappingProxyType[RegimeName, RegimeStates]`
- Rename `_update_states_for_subjects` → `_advance_states_for_subjects`, paired `current_states_per_regime` / `next_states_per_regime` arguments, pure `StatesPerRegime`-in/out merge.
- The `next_` prefix strip moves upstream into `calculate_next_states`, immediately after `next_state_vmapped(...)`, so the advance helper's inputs share inner-key naming.
- Updated sites: `build_initial_states`, `create_regime_state_action_space`, `calculate_next_states`, `_advance_states_for_subjects`, `_simulate_regime_in_period:294-296`.

Phase 2 (nest the `regime_building` DAG function dict via `dags.tree` namespaces and rewrite the three `tree_path_from_qname` introspection sites in `transitions.py:111`, `compile.py:381`, `result.py:436`) lands in a follow-up PR stacked on this one.

## Test plan
- [x] `pixi run -e tests-cpu pytest tests -n 4` — 957 passed, 5 skipped
- [x] `pixi run -e type-checking ty` — clean
- [x] `prek run --all-files` — clean
- [x] aca-baseline benchmark run on the cascade branch (no performance regression expected; pytree leaf order of the simulate-loop carrier changes shape but inner JIT'd functions still receive per-regime arrays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)