### PR TITLE
Activate scoped beartype claw on lcm.grids/shocks/params + drift fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,11 +527,16 @@ Code structure should be self-evident from function names and ordering.
 - **Helper function names follow `{verb}_{qualifier}_noun` patterns.** E.g.,
   `get_irreg_coordinate`, `find_irreg_coordinate`, `get_linspace_coordinate` — not
   `get_coordinate_irreg`.
-- **Use `@overload` when a function accepts both scalar and array inputs.** When a
-  function works with both `ScalarFloat` and `Array`, add overload declarations so the
-  type checker can track `(ScalarFloat) -> ScalarFloat` and `(Array) -> Array`
-  separately. Concrete subclass methods need their own overloads too (not just the
-  abstract base).
+- **Pick the single narrowest jaxtyping alias — never scalar/array `@overload` pairs,
+  never `ScalarX | XND` unions.** ty erases jaxtyping shape annotations: `ScalarFloat`,
+  `Float1D`, and `FloatND` all reveal as `Array`, so scalar/array `@overload` pairs and
+  `ScalarFloat | FloatND`-style unions add zero static precision — they are pure noise.
+  At runtime, beartype treats a 0-d float array as satisfying both `ScalarFloat` and
+  `FloatND`, so `ScalarFloat ⊆ FloatND` and the union is redundant. Annotate each slot
+  with the one alias that matches its genuine rank: `ScalarFloat`/`ScalarInt` for
+  fixed-0-d, `Float1D`/`Int1D` for fixed-1-d, `FloatND`/`IntND` for genuinely rank-
+  polymorphic. Never use a bare `Array` annotation — always reach for the narrowest
+  `lcm.typing` alias.
 - **`func` for callable abbreviations** — use `func`, `func_name`, `func_params` (never
   `fn`). Full word `function(s)` in dataclass field names and public method names.
 - **Singular `state_names` / `action_names`** — not `states_names` / `actions_names`.

--- a/src/lcm/__init__.py
+++ b/src/lcm/__init__.py
@@ -28,10 +28,26 @@ import jax
 with contextlib.suppress(ImportError):
     import pdbp  # noqa: F401
 
-from lcm import shocks
-from lcm._version import __version__
-from lcm.ages import AgeGrid
-from lcm.grids import (
+# Install beartype's AST-rewriting claw on `lcm.grids`, `lcm.shocks`,
+# and `lcm.params` before any submodule of those packages is imported.
+# The claw transforms each matching module's AST at first import to
+# insert runtime type checks; if it isn't registered before the import
+# happens, the affected module loads uninstrumented and `sys.modules`
+# caches the unchecked version for the rest of the process. The
+# per-package `BeartypeConf` maps type violations to the project
+# exception most natural to that subpackage (see `lcm._beartype_conf`).
+from beartype.claw import beartype_package
+
+from lcm._beartype_conf import GRID_CONF, PARAMS_CONF
+
+beartype_package("lcm.grids", conf=GRID_CONF)
+beartype_package("lcm.shocks", conf=GRID_CONF)
+beartype_package("lcm.params", conf=PARAMS_CONF)
+
+from lcm import shocks  # noqa: E402
+from lcm._version import __version__  # noqa: E402
+from lcm.ages import AgeGrid  # noqa: E402
+from lcm.grids import (  # noqa: E402
     DiscreteGrid,
     IrregSpacedGrid,
     LinSpacedGrid,
@@ -41,19 +57,19 @@ from lcm.grids import (
     PiecewiseLogSpacedGrid,
     categorical,
 )
-from lcm.interfaces import SolveSimulateFunctionPair
-from lcm.model import Model
-from lcm.persistence import (
+from lcm.interfaces import SolveSimulateFunctionPair  # noqa: E402
+from lcm.model import Model  # noqa: E402
+from lcm.persistence import (  # noqa: E402
     SimulateSnapshot,
     SolveSnapshot,
     load_snapshot,
     load_solution,
     save_solution,
 )
-from lcm.regime import MarkovTransition, Regime
-from lcm.simulation.result import SimulationResult
-from lcm.utils.containers import invert_regime_ids
-from lcm.utils.error_handling import validate_transition_probs
+from lcm.regime import MarkovTransition, Regime  # noqa: E402
+from lcm.simulation.result import SimulationResult  # noqa: E402
+from lcm.utils.containers import invert_regime_ids  # noqa: E402
+from lcm.utils.error_handling import validate_transition_probs  # noqa: E402
 
 # Register MappingProxyType as a JAX pytree so it can be used in JIT-traced functions.
 # This allows regime transition probabilities to use immutable mappings.

--- a/src/lcm/_beartype_conf.py
+++ b/src/lcm/_beartype_conf.py
@@ -6,9 +6,7 @@ preserving the documented exception hierarchy.
 
 """
 
-from collections.abc import Callable
-
-from beartype import BeartypeConf, BeartypeStrategy, beartype
+from beartype import BeartypeConf, BeartypeStrategy
 
 from lcm.exceptions import (
     CategoricalDefinitionError,
@@ -32,24 +30,6 @@ def _conf(exc: type[Exception]) -> BeartypeConf:
         strategy=BeartypeStrategy.On,
         is_pep484_tower=True,
     )
-
-
-def beartype_init[C](conf: BeartypeConf) -> Callable[[type[C]], type[C]]:
-    """Class decorator that beartype-checks `__init__` only.
-
-    Bare `@beartype` on a class wraps every method, which surfaces
-    annotation drift in helpers like `compute_gridpoints(**kwargs: float)`
-    where runtime kwargs are actually JAX arrays. Restricting decoration
-    to `__init__` keeps the perimeter check (parameter types at
-    construction) without policing every method's runtime types.
-
-    """
-
-    def deco(cls: type[C]) -> type[C]:
-        cls.__init__ = beartype(conf=conf)(cls.__init__)  # ty: ignore[invalid-assignment]
-        return cls
-
-    return deco
 
 
 # Used on `Regime` and `MarkovTransition`.

--- a/src/lcm/dtypes.py
+++ b/src/lcm/dtypes.py
@@ -18,12 +18,14 @@ _INT32_MAX = int(np.iinfo(np.int32).max)
 _FLOAT32_MAX = float(np.finfo(np.float32).max)
 
 
-def canonical_float_dtype() -> jnp.dtype:
+def canonical_float_dtype() -> type:
     """Return pylcm's canonical float dtype, derived from `jax_enable_x64`.
 
     Returns `jnp.float64` if `jax.config.jax_enable_x64` is True,
-    otherwise `jnp.float32`. The value is read at call time, not at
-    import, so toggling the JAX config (e.g. between tests) is honoured.
+    otherwise `jnp.float32`. The return is a JAX scalar type, passable
+    wherever JAX/NumPy accept a dtype-like specifier. The value is read
+    at call time, not at import, so toggling the JAX config (e.g.
+    between tests) is honoured.
     """
     return jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
 

--- a/src/lcm/dtypes.py
+++ b/src/lcm/dtypes.py
@@ -11,7 +11,8 @@ stack; downstream code does not re-cast.
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
+
+from lcm.typing import FloatND, IntND
 
 _INT32_MIN = int(np.iinfo(np.int32).min)
 _INT32_MAX = int(np.iinfo(np.int32).max)
@@ -30,7 +31,7 @@ def canonical_float_dtype() -> type:
     return jnp.float64 if jax.config.read("jax_enable_x64") else jnp.float32
 
 
-def safe_to_int_dtype(value: object, *, name: str) -> Array:
+def safe_to_int_dtype(value: object, *, name: str) -> IntND:
     """Cast a scalar, sequence, or array to `jnp.int32`, checking int32 range.
 
     Args:
@@ -60,7 +61,7 @@ def safe_to_int_dtype(value: object, *, name: str) -> Array:
     return jnp.asarray(np_value, dtype=jnp.int32)
 
 
-def safe_to_float_dtype(value: object, *, name: str) -> Array:
+def safe_to_float_dtype(value: object, *, name: str) -> FloatND:
     """Cast a scalar, sequence, or array to the canonical float dtype.
 
     Range check fires only on a down-cast:

--- a/src/lcm/grids/continuous.py
+++ b/src/lcm/grids/continuous.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 
 import jax.numpy as jnp
 
-from lcm._beartype_conf import GRID_CONF, beartype_init
 from lcm.dtypes import canonical_float_dtype
 from lcm.exceptions import GridInitializationError, format_messages
 from lcm.grids import coordinates as grid_coordinates
@@ -100,7 +99,6 @@ class UniformContinuousGrid(ContinuousGrid, ABC):
             ) from e
 
 
-@beartype_init(GRID_CONF)
 class LinSpacedGrid(UniformContinuousGrid):
     """A linearly spaced grid of continuous values.
 
@@ -126,7 +124,6 @@ class LinSpacedGrid(UniformContinuousGrid):
         )
 
 
-@beartype_init(GRID_CONF)
 class LogSpacedGrid(UniformContinuousGrid):
     """A logarithmically spaced grid of continuous values.
 
@@ -209,7 +206,6 @@ def _init_uniform_grid(
     object.__setattr__(grid, "distributed", distributed)
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True, init=False)
 class IrregSpacedGrid(ContinuousGrid):
     """A grid of continuous values at irregular (user-specified) points.

--- a/src/lcm/grids/continuous.py
+++ b/src/lcm/grids/continuous.py
@@ -34,11 +34,13 @@ class ContinuousGrid(Grid):
     """Whether to distribute the grid over the available devices."""
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
 
@@ -84,11 +86,13 @@ class UniformContinuousGrid(ContinuousGrid, ABC):
         """Convert the grid to a Jax array."""
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
     def replace(self, **kwargs: float) -> UniformContinuousGrid:
@@ -126,10 +130,12 @@ class LinSpacedGrid(UniformContinuousGrid):
         )
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_linspace_coordinate(
             value=value,
@@ -177,10 +183,12 @@ class LogSpacedGrid(UniformContinuousGrid):
         )
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_logspace_coordinate(
             value=value,
@@ -313,10 +321,12 @@ class IrregSpacedGrid(ContinuousGrid):
         return self.points
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if self.points is None:
             raise GridInitializationError(

--- a/src/lcm/grids/continuous.py
+++ b/src/lcm/grids/continuous.py
@@ -2,7 +2,6 @@ import dataclasses
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import overload
 
 import jax.numpy as jnp
 
@@ -33,12 +32,8 @@ class ContinuousGrid(Grid):
     distributed: bool = False
     """Whether to distribute the grid over the available devices."""
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
 
@@ -83,12 +78,8 @@ class UniformContinuousGrid(ContinuousGrid, ABC):
     def to_jax(self) -> Float1D:
         """Convert the grid to a Jax array."""
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
     def replace(self, **kwargs: float) -> UniformContinuousGrid:
@@ -125,11 +116,7 @@ class LinSpacedGrid(UniformContinuousGrid):
             start=self.start, stop=self.stop, n_points=self.n_points
         )
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_linspace_coordinate(
             value=value,
@@ -176,11 +163,7 @@ class LogSpacedGrid(UniformContinuousGrid):
             start=self.start, stop=self.stop, n_points=self.n_points
         )
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_logspace_coordinate(
             value=value,
@@ -312,11 +295,7 @@ class IrregSpacedGrid(ContinuousGrid):
             )
         return self.points
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if self.points is None:
             raise GridInitializationError(

--- a/src/lcm/grids/continuous.py
+++ b/src/lcm/grids/continuous.py
@@ -34,13 +34,11 @@ class ContinuousGrid(Grid):
     """Whether to distribute the grid over the available devices."""
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
 
@@ -86,13 +84,11 @@ class UniformContinuousGrid(ContinuousGrid, ABC):
         """Convert the grid to a Jax array."""
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
     def replace(self, **kwargs: float) -> UniformContinuousGrid:
@@ -130,12 +126,10 @@ class LinSpacedGrid(UniformContinuousGrid):
         )
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_linspace_coordinate(
             value=value,
@@ -183,12 +177,10 @@ class LogSpacedGrid(UniformContinuousGrid):
         )
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_logspace_coordinate(
             value=value,
@@ -321,12 +313,10 @@ class IrregSpacedGrid(ContinuousGrid):
         return self.points
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if self.points is None:
             raise GridInitializationError(

--- a/src/lcm/grids/continuous.py
+++ b/src/lcm/grids/continuous.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import overload
 
 import jax.numpy as jnp
-from jax import Array
 
 from lcm._beartype_conf import GRID_CONF, beartype_init
 from lcm.dtypes import canonical_float_dtype
@@ -14,6 +13,7 @@ from lcm.grids import coordinates as grid_coordinates
 from lcm.grids.base import Grid
 from lcm.typing import (
     Float1D,
+    FloatND,
     ScalarFloat,
     ScalarInt,
 )
@@ -34,9 +34,9 @@ class ContinuousGrid(Grid):
     @overload
     def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
 
@@ -82,9 +82,9 @@ class UniformContinuousGrid(ContinuousGrid, ABC):
     @overload
     def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
     @abstractmethod
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
 
     def replace(self, **kwargs: float) -> UniformContinuousGrid:
@@ -124,8 +124,8 @@ class LinSpacedGrid(UniformContinuousGrid):
     @overload
     def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_linspace_coordinate(
             value=value,
@@ -173,8 +173,8 @@ class LogSpacedGrid(UniformContinuousGrid):
     @overload
     def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         return grid_coordinates.get_logspace_coordinate(
             value=value,
@@ -305,8 +305,8 @@ class IrregSpacedGrid(ContinuousGrid):
     @overload
     def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if self.points is None:
             raise GridInitializationError(

--- a/src/lcm/grids/coordinates.py
+++ b/src/lcm/grids/coordinates.py
@@ -31,7 +31,7 @@ def linspace(
 @overload
 def get_linspace_coordinate(
     *,
-    value: float | ScalarFloat,
+    value: ScalarFloat,
     start: ScalarFloat | FloatND,
     stop: ScalarFloat | FloatND,
     n_points: ScalarInt | IntND,
@@ -46,7 +46,7 @@ def get_linspace_coordinate(
 ) -> FloatND: ...
 def get_linspace_coordinate(
     *,
-    value: float | ScalarFloat | FloatND,
+    value: ScalarFloat | FloatND,
     start: ScalarFloat | FloatND,
     stop: ScalarFloat | FloatND,
     n_points: ScalarInt | IntND,
@@ -85,7 +85,7 @@ def logspace(
 @overload
 def get_logspace_coordinate(
     *,
-    value: float | ScalarFloat,
+    value: ScalarFloat,
     start: ScalarFloat | FloatND,
     stop: ScalarFloat | FloatND,
     n_points: ScalarInt | IntND,
@@ -100,7 +100,7 @@ def get_logspace_coordinate(
 ) -> FloatND: ...
 def get_logspace_coordinate(
     *,
-    value: float | ScalarFloat | FloatND,
+    value: ScalarFloat | FloatND,
     start: ScalarFloat | FloatND,
     stop: ScalarFloat | FloatND,
     n_points: ScalarInt | IntND,
@@ -145,7 +145,7 @@ def get_logspace_coordinate(
 @overload
 def get_irreg_coordinate(
     *,
-    value: float | ScalarFloat,
+    value: ScalarFloat,
     points: Float1D,
 ) -> ScalarFloat: ...
 @overload
@@ -156,7 +156,7 @@ def get_irreg_coordinate(
 ) -> FloatND: ...
 def get_irreg_coordinate(
     *,
-    value: float | ScalarFloat | FloatND,
+    value: ScalarFloat | FloatND,
     points: Float1D,
 ) -> ScalarFloat | FloatND:
     """Return the generalized coordinate of a value in an irregularly spaced grid.

--- a/src/lcm/grids/coordinates.py
+++ b/src/lcm/grids/coordinates.py
@@ -9,9 +9,8 @@ scalar, or a piecewise dispatch that selects pieces via `searchsorted`.
 from typing import overload
 
 import jax.numpy as jnp
-from jax import Array
 
-from lcm.typing import Float1D, ScalarFloat, ScalarInt
+from lcm.typing import Float1D, FloatND, IntND, ScalarFloat, ScalarInt
 
 
 def linspace(
@@ -32,26 +31,26 @@ def linspace(
 @overload
 def get_linspace_coordinate(
     *,
-    value: ScalarFloat,
-    start: ScalarFloat | Array,
-    stop: ScalarFloat | Array,
-    n_points: ScalarInt,
+    value: float | ScalarFloat,
+    start: ScalarFloat | FloatND,
+    stop: ScalarFloat | FloatND,
+    n_points: ScalarInt | IntND,
 ) -> ScalarFloat: ...
 @overload
 def get_linspace_coordinate(
     *,
-    value: Array,
-    start: ScalarFloat | Array,
-    stop: ScalarFloat | Array,
-    n_points: ScalarInt,
-) -> Array: ...
+    value: FloatND,
+    start: ScalarFloat | FloatND,
+    stop: ScalarFloat | FloatND,
+    n_points: ScalarInt | IntND,
+) -> FloatND: ...
 def get_linspace_coordinate(
     *,
-    value: ScalarFloat | Array,
-    start: ScalarFloat | Array,
-    stop: ScalarFloat | Array,
-    n_points: ScalarInt,
-) -> ScalarFloat | Array:
+    value: float | ScalarFloat | FloatND,
+    start: ScalarFloat | FloatND,
+    stop: ScalarFloat | FloatND,
+    n_points: ScalarInt | IntND,
+) -> ScalarFloat | FloatND:
     """Map a value into the input needed for jax.scipy.ndimage.map_coordinates."""
     step_length = (stop - start) / (n_points - 1)
     return (value - start) / step_length
@@ -86,26 +85,26 @@ def logspace(
 @overload
 def get_logspace_coordinate(
     *,
-    value: ScalarFloat,
-    start: ScalarFloat | Array,
-    stop: ScalarFloat | Array,
-    n_points: ScalarInt,
+    value: float | ScalarFloat,
+    start: ScalarFloat | FloatND,
+    stop: ScalarFloat | FloatND,
+    n_points: ScalarInt | IntND,
 ) -> ScalarFloat: ...
 @overload
 def get_logspace_coordinate(
     *,
-    value: Array,
-    start: ScalarFloat | Array,
-    stop: ScalarFloat | Array,
-    n_points: ScalarInt,
-) -> Array: ...
+    value: FloatND,
+    start: ScalarFloat | FloatND,
+    stop: ScalarFloat | FloatND,
+    n_points: ScalarInt | IntND,
+) -> FloatND: ...
 def get_logspace_coordinate(
     *,
-    value: ScalarFloat | Array,
-    start: ScalarFloat | Array,
-    stop: ScalarFloat | Array,
-    n_points: ScalarInt,
-) -> ScalarFloat | Array:
+    value: float | ScalarFloat | FloatND,
+    start: ScalarFloat | FloatND,
+    stop: ScalarFloat | FloatND,
+    n_points: ScalarInt | IntND,
+) -> ScalarFloat | FloatND:
     """Map a value into the input needed for jax.scipy.ndimage.map_coordinates."""
     # Transform start, stop, and value to linear scale
     start_linear = jnp.log(start)
@@ -152,14 +151,14 @@ def get_irreg_coordinate(
 @overload
 def get_irreg_coordinate(
     *,
-    value: Array,
+    value: FloatND,
     points: Float1D,
-) -> Array: ...
+) -> FloatND: ...
 def get_irreg_coordinate(
     *,
-    value: ScalarFloat | Array,
+    value: ScalarFloat | FloatND,
     points: Float1D,
-) -> ScalarFloat | Array:
+) -> ScalarFloat | FloatND:
     """Return the generalized coordinate of a value in an irregularly spaced grid.
 
     Uses binary search (jnp.searchsorted) to find the position of the value among

--- a/src/lcm/grids/coordinates.py
+++ b/src/lcm/grids/coordinates.py
@@ -33,23 +33,23 @@ def linspace(
 def get_linspace_coordinate(
     *,
     value: ScalarFloat,
-    start: ScalarFloat,
-    stop: ScalarFloat,
+    start: ScalarFloat | Array,
+    stop: ScalarFloat | Array,
     n_points: ScalarInt,
 ) -> ScalarFloat: ...
 @overload
 def get_linspace_coordinate(
     *,
     value: Array,
-    start: ScalarFloat,
-    stop: ScalarFloat,
+    start: ScalarFloat | Array,
+    stop: ScalarFloat | Array,
     n_points: ScalarInt,
 ) -> Array: ...
 def get_linspace_coordinate(
     *,
     value: ScalarFloat | Array,
-    start: ScalarFloat,
-    stop: ScalarFloat,
+    start: ScalarFloat | Array,
+    stop: ScalarFloat | Array,
     n_points: ScalarInt,
 ) -> ScalarFloat | Array:
     """Map a value into the input needed for jax.scipy.ndimage.map_coordinates."""
@@ -87,23 +87,23 @@ def logspace(
 def get_logspace_coordinate(
     *,
     value: ScalarFloat,
-    start: ScalarFloat,
-    stop: ScalarFloat,
+    start: ScalarFloat | Array,
+    stop: ScalarFloat | Array,
     n_points: ScalarInt,
 ) -> ScalarFloat: ...
 @overload
 def get_logspace_coordinate(
     *,
     value: Array,
-    start: ScalarFloat,
-    stop: ScalarFloat,
+    start: ScalarFloat | Array,
+    stop: ScalarFloat | Array,
     n_points: ScalarInt,
 ) -> Array: ...
 def get_logspace_coordinate(
     *,
     value: ScalarFloat | Array,
-    start: ScalarFloat,
-    stop: ScalarFloat,
+    start: ScalarFloat | Array,
+    stop: ScalarFloat | Array,
     n_points: ScalarInt,
 ) -> ScalarFloat | Array:
     """Map a value into the input needed for jax.scipy.ndimage.map_coordinates."""

--- a/src/lcm/grids/coordinates.py
+++ b/src/lcm/grids/coordinates.py
@@ -1,12 +1,11 @@
 """Functions to generate and work with different kinds of grids.
 
-These helpers operate on JAX scalars (`ScalarFloat` for endpoints/values,
-`ScalarInt` or Python `int` for `n_points`) — every production caller is
-either a `Grid` method that has already converted user input to a JAX
-scalar, or a piecewise dispatch that selects pieces via `searchsorted`.
+The `get_*_coordinate` helpers take JAX arrays of any rank: a `Grid`
+method passes a 0-d value, while a piecewise dispatch selects pieces via
+`searchsorted` and passes `start` / `stop` / `n_points` indexed by an
+N-d `piece_idx`. `linspace` / `logspace` build a grid and take JAX
+scalars.
 """
-
-from typing import overload
 
 import jax.numpy as jnp
 
@@ -28,29 +27,13 @@ def linspace(
     return jnp.linspace(start, stop, n_points)  # ty: ignore[no-matching-overload]
 
 
-@overload
-def get_linspace_coordinate(
-    *,
-    value: ScalarFloat,
-    start: ScalarFloat | FloatND,
-    stop: ScalarFloat | FloatND,
-    n_points: ScalarInt | IntND,
-) -> ScalarFloat: ...
-@overload
 def get_linspace_coordinate(
     *,
     value: FloatND,
-    start: ScalarFloat | FloatND,
-    stop: ScalarFloat | FloatND,
-    n_points: ScalarInt | IntND,
-) -> FloatND: ...
-def get_linspace_coordinate(
-    *,
-    value: ScalarFloat | FloatND,
-    start: ScalarFloat | FloatND,
-    stop: ScalarFloat | FloatND,
-    n_points: ScalarInt | IntND,
-) -> ScalarFloat | FloatND:
+    start: FloatND,
+    stop: FloatND,
+    n_points: IntND,
+) -> FloatND:
     """Map a value into the input needed for jax.scipy.ndimage.map_coordinates."""
     step_length = (stop - start) / (n_points - 1)
     return (value - start) / step_length
@@ -82,29 +65,13 @@ def logspace(
     return grid.at[0].set(start).at[-1].set(stop)
 
 
-@overload
-def get_logspace_coordinate(
-    *,
-    value: ScalarFloat,
-    start: ScalarFloat | FloatND,
-    stop: ScalarFloat | FloatND,
-    n_points: ScalarInt | IntND,
-) -> ScalarFloat: ...
-@overload
 def get_logspace_coordinate(
     *,
     value: FloatND,
-    start: ScalarFloat | FloatND,
-    stop: ScalarFloat | FloatND,
-    n_points: ScalarInt | IntND,
-) -> FloatND: ...
-def get_logspace_coordinate(
-    *,
-    value: ScalarFloat | FloatND,
-    start: ScalarFloat | FloatND,
-    stop: ScalarFloat | FloatND,
-    n_points: ScalarInt | IntND,
-) -> ScalarFloat | FloatND:
+    start: FloatND,
+    stop: FloatND,
+    n_points: IntND,
+) -> FloatND:
     """Map a value into the input needed for jax.scipy.ndimage.map_coordinates."""
     # Transform start, stop, and value to linear scale
     start_linear = jnp.log(start)
@@ -142,23 +109,11 @@ def get_logspace_coordinate(
     return rank_lower_gridpoint + decimal_part
 
 
-@overload
-def get_irreg_coordinate(
-    *,
-    value: ScalarFloat,
-    points: Float1D,
-) -> ScalarFloat: ...
-@overload
 def get_irreg_coordinate(
     *,
     value: FloatND,
     points: Float1D,
-) -> FloatND: ...
-def get_irreg_coordinate(
-    *,
-    value: ScalarFloat | FloatND,
-    points: Float1D,
-) -> ScalarFloat | FloatND:
+) -> FloatND:
     """Return the generalized coordinate of a value in an irregularly spaced grid.
 
     Uses binary search (jnp.searchsorted) to find the position of the value among

--- a/src/lcm/grids/coordinates.py
+++ b/src/lcm/grids/coordinates.py
@@ -145,7 +145,7 @@ def get_logspace_coordinate(
 @overload
 def get_irreg_coordinate(
     *,
-    value: ScalarFloat,
+    value: float | ScalarFloat,
     points: Float1D,
 ) -> ScalarFloat: ...
 @overload
@@ -156,7 +156,7 @@ def get_irreg_coordinate(
 ) -> FloatND: ...
 def get_irreg_coordinate(
     *,
-    value: ScalarFloat | FloatND,
+    value: float | ScalarFloat | FloatND,
     points: Float1D,
 ) -> ScalarFloat | FloatND:
     """Return the generalized coordinate of a value in an irregularly spaced grid.

--- a/src/lcm/grids/discrete.py
+++ b/src/lcm/grids/discrete.py
@@ -1,13 +1,11 @@
 import jax.numpy as jnp
 
-from lcm._beartype_conf import GRID_CONF, beartype_init
 from lcm.grids.base import Grid
 from lcm.grids.categorical import _validate_discrete_grid
 from lcm.typing import Int1D
 from lcm.utils.containers import get_field_names_and_values
 
 
-@beartype_init(GRID_CONF)
 class DiscreteGrid(Grid):
     """A discrete grid defining the outcome space of a categorical variable.
 

--- a/src/lcm/grids/piecewise.py
+++ b/src/lcm/grids/piecewise.py
@@ -4,7 +4,6 @@ from typing import overload
 
 import jax.numpy as jnp
 import portion
-from jax import Array
 
 from lcm._beartype_conf import GRID_CONF, beartype_init
 from lcm.exceptions import GridInitializationError, format_messages
@@ -12,6 +11,7 @@ from lcm.grids import coordinates as grid_coordinates
 from lcm.grids.continuous import ContinuousGrid
 from lcm.typing import (
     Float1D,
+    FloatND,
     Int1D,
     ScalarFloat,
     ScalarInt,
@@ -98,10 +98,12 @@ class PiecewiseLinSpacedGrid(ContinuousGrid):
         return jnp.concatenate(piece_arrays)
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         piece_idx = jnp.searchsorted(self._breakpoints, value, side="right")
         local_coord = grid_coordinates.get_linspace_coordinate(
@@ -170,10 +172,12 @@ class PiecewiseLogSpacedGrid(ContinuousGrid):
         return jnp.concatenate(piece_arrays)
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         piece_idx = jnp.searchsorted(self._breakpoints, value, side="right")
         local_coord = grid_coordinates.get_logspace_coordinate(

--- a/src/lcm/grids/piecewise.py
+++ b/src/lcm/grids/piecewise.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 import jax.numpy as jnp
 import portion
 
-from lcm._beartype_conf import GRID_CONF, beartype_init
 from lcm.exceptions import GridInitializationError, format_messages
 from lcm.grids import coordinates as grid_coordinates
 from lcm.grids.continuous import ContinuousGrid
@@ -44,7 +43,6 @@ class Piece:
         object.__setattr__(self, "n_points", jnp.int32(n_points))
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class PiecewiseLinSpacedGrid(ContinuousGrid):
     """A piecewise linearly spaced grid with multiple segments.
@@ -108,7 +106,6 @@ class PiecewiseLinSpacedGrid(ContinuousGrid):
         return self._cumulative_offsets[piece_idx] + local_coord
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class PiecewiseLogSpacedGrid(ContinuousGrid):
     """A piecewise logarithmically spaced grid with multiple segments.

--- a/src/lcm/grids/piecewise.py
+++ b/src/lcm/grids/piecewise.py
@@ -1,6 +1,5 @@
 import dataclasses
 from dataclasses import dataclass
-from typing import overload
 
 import jax.numpy as jnp
 import portion
@@ -97,11 +96,7 @@ class PiecewiseLinSpacedGrid(ContinuousGrid):
         ]
         return jnp.concatenate(piece_arrays)
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
         piece_idx = jnp.searchsorted(self._breakpoints, value, side="right")
         local_coord = grid_coordinates.get_linspace_coordinate(
@@ -169,11 +164,7 @@ class PiecewiseLogSpacedGrid(ContinuousGrid):
         ]
         return jnp.concatenate(piece_arrays)
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
         piece_idx = jnp.searchsorted(self._breakpoints, value, side="right")
         local_coord = grid_coordinates.get_logspace_coordinate(

--- a/src/lcm/grids/piecewise.py
+++ b/src/lcm/grids/piecewise.py
@@ -87,7 +87,7 @@ class PiecewiseLinSpacedGrid(ContinuousGrid):
     @property
     def n_points(self) -> ScalarInt:
         """Return the total number of points in the grid."""
-        return self._piece_n_points.sum()
+        return self._piece_n_points.sum(dtype=jnp.int32)
 
     def to_jax(self) -> Float1D:
         """Convert the grid to a Jax array."""
@@ -157,7 +157,7 @@ class PiecewiseLogSpacedGrid(ContinuousGrid):
     @property
     def n_points(self) -> ScalarInt:
         """Return the total number of points in the grid."""
-        return self._piece_n_points.sum()
+        return self._piece_n_points.sum(dtype=jnp.int32)
 
     def to_jax(self) -> Float1D:
         """Convert the grid to a Jax array."""
@@ -243,8 +243,10 @@ def _init_piecewise_grid_cache(
     # Breakpoints are the effective starts of pieces 1..k-1
     breakpoints = starts[1:] if len(starts) > 1 else jnp.array([])
 
-    n_points = jnp.array([p.n_points for p in grid.pieces])
-    cumulative = jnp.concatenate([jnp.array([0]), jnp.cumsum(n_points[:-1])])
+    n_points = jnp.array([p.n_points for p in grid.pieces], dtype=jnp.int32)
+    cumulative = jnp.concatenate(
+        [jnp.array([0], dtype=jnp.int32), jnp.cumsum(n_points[:-1])]
+    )
 
     object.__setattr__(grid, "_breakpoints", breakpoints)
     object.__setattr__(grid, "_piece_starts", starts)

--- a/src/lcm/grids/piecewise.py
+++ b/src/lcm/grids/piecewise.py
@@ -98,12 +98,10 @@ class PiecewiseLinSpacedGrid(ContinuousGrid):
         return jnp.concatenate(piece_arrays)
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         piece_idx = jnp.searchsorted(self._breakpoints, value, side="right")
         local_coord = grid_coordinates.get_linspace_coordinate(
@@ -172,12 +170,10 @@ class PiecewiseLogSpacedGrid(ContinuousGrid):
         return jnp.concatenate(piece_arrays)
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         piece_idx = jnp.searchsorted(self._breakpoints, value, side="right")
         local_coord = grid_coordinates.get_logspace_coordinate(

--- a/src/lcm/interfaces.py
+++ b/src/lcm/interfaces.py
@@ -5,7 +5,6 @@ from types import MappingProxyType
 from typing import cast
 
 import jax
-from jax import Array
 
 from lcm.exceptions import PyLCMError
 from lcm.grids import Grid, IrregSpacedGrid
@@ -21,7 +20,9 @@ from lcm.typing import (
     DiscreteState,
     FlatRegimeParams,
     Float1D,
+    FloatND,
     FunctionsMapping,
+    IntND,
     MaxQOverAFunction,
     NextStateSimulationFunction,
     RegimeParamsTemplate,
@@ -421,9 +422,9 @@ def _build_regime_sharding(
 
 def _distribute_states_to_devices(
     *,
-    states: MappingProxyType[StateName, Array],
+    states: MappingProxyType[StateName, FloatND | IntND],
     grids: MappingProxyType[StateOrActionName, Grid],
-) -> MappingProxyType[StateName, Array]:
+) -> MappingProxyType[StateName, FloatND | IntND]:
     """Place each distributed state's array on its device mesh.
 
     States whose grid carries `distributed=True` are placed via
@@ -458,20 +459,18 @@ class PeriodRegimeSimulationData:
     V_arr: Float1D
     """Value function array for all subjects at this period."""
 
-    actions: MappingProxyType[ActionName, Array]
+    actions: MappingProxyType[ActionName, FloatND | IntND]
     """Immutable mapping of action names to optimal action arrays for all subjects.
 
     Action arrays carry the dtype of their grid — discrete actions are int,
-    continuous actions are float — so the value type stays the dtype-agnostic
-    `Array`.
+    continuous actions are float — hence the `FloatND | IntND` value type.
     """
 
-    states: MappingProxyType[StateName, Array]
+    states: MappingProxyType[StateName, FloatND | IntND]
     """Immutable mapping of state names to state value arrays for all subjects.
 
     State arrays carry the dtype of their grid — discrete states are int,
-    continuous states are float — so the value type stays the dtype-agnostic
-    `Array`.
+    continuous states are float — hence the `FloatND | IntND` value type.
     """
 
     in_regime: Bool1D

--- a/src/lcm/interfaces.py
+++ b/src/lcm/interfaces.py
@@ -10,6 +10,7 @@ from jax import Array
 from lcm.exceptions import PyLCMError
 from lcm.grids import Grid, IrregSpacedGrid
 from lcm.shocks import _ShockGrid
+from lcm.shocks._base import _params_to_jax
 from lcm.typing import (
     ActionName,
     ArgmaxQOverAFunction,
@@ -295,7 +296,9 @@ class InternalRegime:
                 shock_kw: dict[str, float] = dict(spec.params)
                 for p in spec.params_to_pass_at_runtime:
                     shock_kw[p] = cast("float", all_params[f"{name}__{p}"])
-                state_replacements[name] = spec.compute_gridpoints(**shock_kw)
+                state_replacements[name] = spec.compute_gridpoints(
+                    **_params_to_jax(MappingProxyType(shock_kw))
+                )
 
         new_states = (
             dict(self._base_state_action_space.states) | state_replacements

--- a/src/lcm/interfaces.py
+++ b/src/lcm/interfaces.py
@@ -20,6 +20,7 @@ from lcm.typing import (
     DiscreteAction,
     DiscreteState,
     FlatRegimeParams,
+    Float1D,
     FunctionsMapping,
     MaxQOverAFunction,
     NextStateSimulationFunction,
@@ -454,14 +455,24 @@ def _distribute_states_to_devices(
 class PeriodRegimeSimulationData:
     """Raw simulation data for one period in one regime."""
 
-    V_arr: Array
+    V_arr: Float1D
     """Value function array for all subjects at this period."""
 
     actions: MappingProxyType[ActionName, Array]
-    """Immutable mapping of action names to optimal action arrays for all subjects."""
+    """Immutable mapping of action names to optimal action arrays for all subjects.
+
+    Action arrays carry the dtype of their grid — discrete actions are int,
+    continuous actions are float — so the value type stays the dtype-agnostic
+    `Array`.
+    """
 
     states: MappingProxyType[StateName, Array]
-    """Immutable mapping of state names to state value arrays for all subjects."""
+    """Immutable mapping of state names to state value arrays for all subjects.
+
+    State arrays carry the dtype of their grid — discrete states are int,
+    continuous states are float — so the value type stays the dtype-agnostic
+    `Array`.
+    """
 
     in_regime: Bool1D
     """Boolean mask indicating which subjects are in this regime at this period."""

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -9,7 +9,6 @@ from types import MappingProxyType
 
 import pandas as pd
 from beartype import beartype
-from jax import Array
 
 from lcm._beartype_conf import MODEL_CONF, PARAMS_CONF
 from lcm.ages import AgeGrid
@@ -48,6 +47,7 @@ from lcm.typing import (
     RegimeName,
     RegimeNamesToIds,
     UserFacingParamsTemplate,
+    UserInitialConditions,
     UserParams,
 )
 from lcm.utils.containers import (
@@ -377,7 +377,7 @@ class Model:
         self,
         *,
         params: UserParams,
-        initial_conditions: Mapping[str, Array],
+        initial_conditions: UserInitialConditions,
         period_to_regime_to_V_arr: MappingProxyType[
             int, MappingProxyType[RegimeName, FloatND]
         ]

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -43,11 +43,11 @@ from lcm.typing import (
     FloatND,
     FunctionName,
     InternalParams,
+    IntND,
     ParamsTemplate,
     RegimeName,
     RegimeNamesToIds,
     UserFacingParamsTemplate,
-    UserInitialConditions,
     UserParams,
 )
 from lcm.utils.containers import (
@@ -377,7 +377,7 @@ class Model:
         self,
         *,
         params: UserParams,
-        initial_conditions: UserInitialConditions,
+        initial_conditions: Mapping[str, FloatND | IntND],
         period_to_regime_to_V_arr: MappingProxyType[
             int, MappingProxyType[RegimeName, FloatND]
         ]

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -20,6 +20,7 @@ from lcm.regime import Regime
 from lcm.shocks import _ShockGrid
 from lcm.simulation.initial_conditions import MISSING_CAT_CODE
 from lcm.typing import (
+    FloatND,
     FunctionName,
     InternalParams,
     RegimeName,
@@ -336,7 +337,7 @@ def array_from_series(
     regimes: Mapping[RegimeName, Regime],
     regime_names_to_ids: RegimeNamesToIds,
     regime_name: RegimeName | None = None,
-) -> Array:
+) -> FloatND:
     """Convert a pandas Series to a JAX array.
 
     Inspect `func` to determine indexing dimensions (states, actions,
@@ -683,7 +684,7 @@ def _scatter_series(
     series: pd.Series,
     level_mappings: tuple[_LevelMapping, ...],
     fill_value: float = np.nan,
-) -> Array:
+) -> FloatND:
     """Scatter a MultiIndex Series into an N-dimensional JAX array.
 
     Each `_LevelMapping` defines one axis: its size, and how to map labels from

--- a/src/lcm/pandas_utils.py
+++ b/src/lcm/pandas_utils.py
@@ -9,7 +9,6 @@ import jax.numpy as jnp
 import numpy as np
 import pandas as pd
 from dags.tree import qname_from_tree_path, tree_path_from_qname
-from jax import Array
 
 from lcm.ages import PSEUDO_STATE_NAMES, AgeGrid
 from lcm.dtypes import canonical_float_dtype
@@ -23,6 +22,7 @@ from lcm.typing import (
     FloatND,
     FunctionName,
     InternalParams,
+    IntND,
     RegimeName,
     RegimeNamesToIds,
     StateName,
@@ -53,7 +53,7 @@ def initial_conditions_from_dataframe(  # noqa: C901
     df: pd.DataFrame,
     regimes: Mapping[RegimeName, Regime],
     regime_names_to_ids: RegimeNamesToIds,
-) -> dict[str, Array]:
+) -> dict[str, FloatND | IntND]:
     """Convert a DataFrame of initial conditions to LCM initial conditions format.
 
     Args:
@@ -148,7 +148,7 @@ def initial_conditions_from_dataframe(  # noqa: C901
             nan_mask = np.isnan(result_arrays[col])
             result_arrays[col][nan_mask] = MISSING_CAT_CODE
 
-    initial_conditions: dict[str, Array] = {
+    initial_conditions: dict[str, FloatND | IntND] = {
         col: jnp.array(arr, dtype=jnp.int32)
         if col in discrete_state_names
         else jnp.array(arr, dtype=canonical_float_dtype())

--- a/src/lcm/params/mapping_leaf.py
+++ b/src/lcm/params/mapping_leaf.py
@@ -1,6 +1,6 @@
 """A Mapping wrapper that is a JAX pytree but not itself a Mapping."""
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import jax
@@ -41,7 +41,7 @@ def _flatten(nmp: MappingLeaf) -> tuple[list[Any], tuple[str, ...]]:
     return values, keys
 
 
-def _unflatten(keys: tuple[str, ...], values: list[Any]) -> MappingLeaf:
+def _unflatten(keys: tuple[str, ...], values: Sequence[Any]) -> MappingLeaf:
     return MappingLeaf(dict(zip(keys, values, strict=True)))
 
 

--- a/src/lcm/params/processing.py
+++ b/src/lcm/params/processing.py
@@ -33,7 +33,6 @@ from jax import Array
 
 from lcm.dtypes import safe_to_float_dtype, safe_to_int_dtype
 from lcm.exceptions import InvalidNameError, InvalidParamsError
-from lcm.interfaces import InternalRegime
 from lcm.params.mapping_leaf import MappingLeaf
 from lcm.params.sequence_leaf import SequenceLeaf
 from lcm.typing import (
@@ -52,7 +51,7 @@ _NUM_PARTS_FUNCTION_PARAM = 3
 def process_params(
     *,
     params: UserParams,
-    params_template: Mapping[RegimeName, RegimeParamsTemplate],
+    params_template: Mapping[RegimeName, Mapping[str, object]],
 ) -> InternalParams:
     """Process user-provided params into internal params.
 
@@ -298,7 +297,7 @@ def _find_candidates(
 
 
 def create_params_template(  # noqa: C901
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, Any],
 ) -> ParamsTemplate:
     """Create params_template from internal regimes and validate name uniqueness.
 
@@ -306,7 +305,9 @@ def create_params_template(  # noqa: C901
     are disjoint sets to enable unambiguous parameter propagation.
 
     Args:
-        internal_regimes: Mapping of regime names to InternalRegime instances.
+        internal_regimes: Mapping of regime names to `InternalRegime` instances
+            (or any object exposing a `regime_params_template` attribute —
+            internal helpers and test mocks both qualify).
 
     Returns:
         The parameter template.

--- a/src/lcm/params/processing.py
+++ b/src/lcm/params/processing.py
@@ -33,9 +33,11 @@ from jax import Array
 
 from lcm.dtypes import safe_to_float_dtype, safe_to_int_dtype
 from lcm.exceptions import InvalidNameError, InvalidParamsError
+from lcm.interfaces import InternalRegime
 from lcm.params.mapping_leaf import MappingLeaf
 from lcm.params.sequence_leaf import SequenceLeaf
 from lcm.typing import (
+    FunctionName,
     InternalParams,
     ParamsTemplate,
     RegimeName,
@@ -51,7 +53,7 @@ _NUM_PARTS_FUNCTION_PARAM = 3
 def process_params(
     *,
     params: UserParams,
-    params_template: Mapping[RegimeName, Mapping[str, object]],
+    params_template: Mapping[RegimeName, Mapping[FunctionName, object]],
 ) -> InternalParams:
     """Process user-provided params into internal params.
 
@@ -297,7 +299,7 @@ def _find_candidates(
 
 
 def create_params_template(  # noqa: C901
-    internal_regimes: Mapping[RegimeName, Any],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
 ) -> ParamsTemplate:
     """Create params_template from internal regimes and validate name uniqueness.
 
@@ -305,9 +307,7 @@ def create_params_template(  # noqa: C901
     are disjoint sets to enable unambiguous parameter propagation.
 
     Args:
-        internal_regimes: Mapping of regime names to `InternalRegime` instances
-            (or any object exposing a `regime_params_template` attribute —
-            internal helpers and test mocks both qualify).
+        internal_regimes: Mapping of regime names to InternalRegime instances.
 
     Returns:
         The parameter template.

--- a/src/lcm/params/processing.py
+++ b/src/lcm/params/processing.py
@@ -37,7 +37,6 @@ from lcm.interfaces import InternalRegime
 from lcm.params.mapping_leaf import MappingLeaf
 from lcm.params.sequence_leaf import SequenceLeaf
 from lcm.typing import (
-    FunctionName,
     InternalParams,
     ParamsTemplate,
     RegimeName,
@@ -53,7 +52,7 @@ _NUM_PARTS_FUNCTION_PARAM = 3
 def process_params(
     *,
     params: UserParams,
-    params_template: Mapping[RegimeName, Mapping[FunctionName, object]],
+    params_template: ParamsTemplate,
 ) -> InternalParams:
     """Process user-provided params into internal params.
 

--- a/src/lcm/params/processing.py
+++ b/src/lcm/params/processing.py
@@ -298,7 +298,7 @@ def _find_candidates(
 
 
 def create_params_template(  # noqa: C901
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
 ) -> ParamsTemplate:
     """Create params_template from internal regimes and validate name uniqueness.
 
@@ -306,7 +306,8 @@ def create_params_template(  # noqa: C901
     are disjoint sets to enable unambiguous parameter propagation.
 
     Args:
-        internal_regimes: Mapping of regime names to InternalRegime instances.
+        internal_regimes: Immutable mapping of regime names to InternalRegime
+            instances.
 
     Returns:
         The parameter template.

--- a/src/lcm/params/processing.py
+++ b/src/lcm/params/processing.py
@@ -52,7 +52,7 @@ _NUM_PARTS_FUNCTION_PARAM = 3
 def process_params(
     *,
     params: UserParams,
-    params_template: ParamsTemplate,
+    params_template: Mapping[RegimeName, RegimeParamsTemplate],
 ) -> InternalParams:
     """Process user-provided params into internal params.
 
@@ -298,7 +298,7 @@ def _find_candidates(
 
 
 def create_params_template(  # noqa: C901
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
 ) -> ParamsTemplate:
     """Create params_template from internal regimes and validate name uniqueness.
 

--- a/src/lcm/params/regime_template.py
+++ b/src/lcm/params/regime_template.py
@@ -1,4 +1,5 @@
 from types import MappingProxyType
+from typing import Any
 
 import dags.tree as dt
 from dags.tree import tree_path_from_qname
@@ -6,7 +7,6 @@ from dags.tree import tree_path_from_qname
 from lcm.exceptions import InvalidNameError
 from lcm.grids import IrregSpacedGrid
 from lcm.interfaces import SolveSimulateFunctionPair
-from lcm.regime import Regime
 from lcm.regime_building.validation import collect_state_transitions
 from lcm.shocks import _ShockGrid
 from lcm.typing import (
@@ -17,7 +17,7 @@ from lcm.typing import (
 )
 
 
-def create_regime_params_template(regime: Regime) -> RegimeParamsTemplate:
+def create_regime_params_template(regime: Any) -> RegimeParamsTemplate:  # noqa: ANN401
     """Create parameter template from a regime specification.
 
     Discover parameters from function signatures via `dags.tree`. Parameters
@@ -33,7 +33,10 @@ def create_regime_params_template(regime: Regime) -> RegimeParamsTemplate:
     pseudo-function keys matching the state or action name.
 
     Args:
-        regime: The regime as provided by the user.
+        regime: A `Regime` instance, or any object with the same
+            `states` / `actions` / `functions` / `constraints` /
+            `transition` / `state_transitions` interface (e.g., test mocks
+            that bypass `Regime`'s constructor validation).
 
     Returns:
         The regime parameter template with type annotations as values.
@@ -84,7 +87,7 @@ def create_regime_params_template(regime: Regime) -> RegimeParamsTemplate:
 
 def _add_runtime_grid_params(
     function_params: dict[FunctionName, dict[str, str]],
-    regime: Regime,
+    regime: Any,  # noqa: ANN401
 ) -> None:
     """Add runtime-supplied state/action grid params to the template in place."""
     for state_name, grid in regime.states.items():
@@ -142,7 +145,7 @@ def _fail_if_runtime_grid_shadows_function(
 
 
 def _collect_all_functions_for_template(
-    regime: Regime,
+    regime: Any,  # noqa: ANN401
 ) -> dict[
     FunctionName | TransitionFunctionName, UserFunction | SolveSimulateFunctionPair
 ]:
@@ -165,7 +168,7 @@ def _collect_all_functions_for_template(
 
 def _validate_no_shadowing(
     function_params: dict[FunctionName, dict[str, str]],
-    regime: Regime,
+    regime: Any,  # noqa: ANN401
 ) -> None:
     """Raise if any discovered parameter shadows a state or action name."""
     state_action_names = set(regime.states) | set(regime.actions)

--- a/src/lcm/params/regime_template.py
+++ b/src/lcm/params/regime_template.py
@@ -1,5 +1,4 @@
 from types import MappingProxyType
-from typing import Any
 
 import dags.tree as dt
 from dags.tree import tree_path_from_qname
@@ -7,6 +6,7 @@ from dags.tree import tree_path_from_qname
 from lcm.exceptions import InvalidNameError
 from lcm.grids import IrregSpacedGrid
 from lcm.interfaces import SolveSimulateFunctionPair
+from lcm.regime import Regime
 from lcm.regime_building.validation import collect_state_transitions
 from lcm.shocks import _ShockGrid
 from lcm.typing import (
@@ -17,7 +17,7 @@ from lcm.typing import (
 )
 
 
-def create_regime_params_template(regime: Any) -> RegimeParamsTemplate:  # noqa: ANN401
+def create_regime_params_template(regime: Regime) -> RegimeParamsTemplate:
     """Create parameter template from a regime specification.
 
     Discover parameters from function signatures via `dags.tree`. Parameters
@@ -33,10 +33,7 @@ def create_regime_params_template(regime: Any) -> RegimeParamsTemplate:  # noqa:
     pseudo-function keys matching the state or action name.
 
     Args:
-        regime: A `Regime` instance, or any object with the same
-            `states` / `actions` / `functions` / `constraints` /
-            `transition` / `state_transitions` interface (e.g., test mocks
-            that bypass `Regime`'s constructor validation).
+        regime: The regime as provided by the user.
 
     Returns:
         The regime parameter template with type annotations as values.
@@ -87,7 +84,7 @@ def create_regime_params_template(regime: Any) -> RegimeParamsTemplate:  # noqa:
 
 def _add_runtime_grid_params(
     function_params: dict[FunctionName, dict[str, str]],
-    regime: Any,  # noqa: ANN401
+    regime: Regime,
 ) -> None:
     """Add runtime-supplied state/action grid params to the template in place."""
     for state_name, grid in regime.states.items():
@@ -145,7 +142,7 @@ def _fail_if_runtime_grid_shadows_function(
 
 
 def _collect_all_functions_for_template(
-    regime: Any,  # noqa: ANN401
+    regime: Regime,
 ) -> dict[
     FunctionName | TransitionFunctionName, UserFunction | SolveSimulateFunctionPair
 ]:
@@ -168,7 +165,7 @@ def _collect_all_functions_for_template(
 
 def _validate_no_shadowing(
     function_params: dict[FunctionName, dict[str, str]],
-    regime: Any,  # noqa: ANN401
+    regime: Regime,
 ) -> None:
     """Raise if any discovered parameter shadows a state or action name."""
     state_action_names = set(regime.states) | set(regime.actions)

--- a/src/lcm/params/sequence_leaf.py
+++ b/src/lcm/params/sequence_leaf.py
@@ -38,7 +38,7 @@ def _flatten(sl: SequenceLeaf) -> tuple[list[Any], None]:
     return list(sl.data), None
 
 
-def _unflatten(_aux: None, values: list[Any]) -> SequenceLeaf:
+def _unflatten(_aux: None, values: Sequence[Any]) -> SequenceLeaf:
     return SequenceLeaf(values)
 
 

--- a/src/lcm/persistence.py
+++ b/src/lcm/persistence.py
@@ -9,7 +9,7 @@ import platform
 import shutil
 import tempfile
 import textwrap
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -22,9 +22,9 @@ import numpy as np
 
 from lcm.typing import (
     FloatND,
+    IntND,
     PeriodToRegimeToVArr,
     RegimeName,
-    UserInitialConditions,
     UserParams,
 )
 
@@ -74,7 +74,7 @@ class SimulateSnapshot:
     params: UserParams | None
     """User parameters passed to simulate."""
 
-    initial_conditions: UserInitialConditions | None
+    initial_conditions: Mapping[str, FloatND | IntND] | None
     """Mapping of state names and "regime" to arrays."""
 
     period_to_regime_to_V_arr: PeriodToRegimeToVArr | None
@@ -206,7 +206,7 @@ def save_simulate_snapshot(
     *,
     model: Model,
     params: UserParams,
-    initial_conditions: UserInitialConditions,
+    initial_conditions: Mapping[str, FloatND | IntND],
     period_to_regime_to_V_arr: PeriodToRegimeToVArr,
     result: SimulationResult,
     log_path: Path,

--- a/src/lcm/persistence.py
+++ b/src/lcm/persistence.py
@@ -27,6 +27,18 @@ if TYPE_CHECKING:
     from lcm.model import Model
     from lcm.simulation.result import SimulationResult
 
+    # Type-checker view: full precision.
+    _ModelOrNone = Model | None
+    _SimulationResultOrNone = SimulationResult | None
+else:
+    # Runtime view used by beartype's annotation evaluator. `Model` and
+    # `SimulationResult` cannot be imported here (circular), so collapse
+    # to `Any`. The snapshot dataclasses are serialization carriers; the
+    # API surface that needs strict checking is the `save_*_snapshot`
+    # callers, which beartype still polices via their own parameters.
+    _ModelOrNone = Any
+    _SimulationResultOrNone = Any
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,7 +46,7 @@ logger = logging.getLogger(__name__)
 class SolveSnapshot:
     """Snapshot of a solve run for offline reconstruction."""
 
-    model: Model | None
+    model: _ModelOrNone
     """The Model instance."""
 
     params: UserParams | None
@@ -51,7 +63,7 @@ class SolveSnapshot:
 class SimulateSnapshot:
     """Snapshot of a simulate run for offline reconstruction."""
 
-    model: Model | None
+    model: _ModelOrNone
     """The Model instance."""
 
     params: UserParams | None
@@ -63,7 +75,7 @@ class SimulateSnapshot:
     period_to_regime_to_V_arr: PeriodToRegimeToVArr | None
     """Immutable mapping of periods to regime value function arrays."""
 
-    result: SimulationResult | None
+    result: _SimulationResultOrNone
     """SimulationResult object."""
 
     platform: str

--- a/src/lcm/persistence.py
+++ b/src/lcm/persistence.py
@@ -9,7 +9,7 @@ import platform
 import shutil
 import tempfile
 import textwrap
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
@@ -19,9 +19,14 @@ import cloudpickle
 import h5py
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
 
-from lcm.typing import FloatND, PeriodToRegimeToVArr, RegimeName, UserParams
+from lcm.typing import (
+    FloatND,
+    PeriodToRegimeToVArr,
+    RegimeName,
+    UserInitialConditions,
+    UserParams,
+)
 
 if TYPE_CHECKING:
     from lcm.model import Model
@@ -69,7 +74,7 @@ class SimulateSnapshot:
     params: UserParams | None
     """User parameters passed to simulate."""
 
-    initial_conditions: Mapping[str, Array] | None
+    initial_conditions: UserInitialConditions | None
     """Mapping of state names and "regime" to arrays."""
 
     period_to_regime_to_V_arr: PeriodToRegimeToVArr | None
@@ -201,7 +206,7 @@ def save_simulate_snapshot(
     *,
     model: Model,
     params: UserParams,
-    initial_conditions: Mapping[str, Array],
+    initial_conditions: UserInitialConditions,
     period_to_regime_to_V_arr: PeriodToRegimeToVArr,
     result: SimulationResult,
     log_path: Path,

--- a/src/lcm/regime_building/Q_and_F.py
+++ b/src/lcm/regime_building/Q_and_F.py
@@ -149,7 +149,7 @@ def get_Q_and_F(
             A tuple containing the arrays with state-action values and feasibilities.
 
         """
-        regime_transition_probs: MappingProxyType[str, Array] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
             compute_regime_transition_probs(**states_actions_params)
         )
         U_arr, F_arr = U_and_F(**states_actions_params)
@@ -309,15 +309,17 @@ def get_compute_intermediates(
         args=arg_names_of_compute_intermediates,
         return_annotation=(
             "tuple[FloatND, FloatND, FloatND, FloatND, "
-            "MappingProxyType[RegimeName, Array]]"
+            "MappingProxyType[RegimeName, FloatND]]"
         ),
     )
     def compute_intermediates(
         next_regime_to_V_arr: FloatND,
         **states_actions_params: Array,
-    ) -> tuple[FloatND, FloatND, FloatND, FloatND, MappingProxyType[RegimeName, Array]]:
+    ) -> tuple[
+        FloatND, FloatND, FloatND, FloatND, MappingProxyType[RegimeName, FloatND]
+    ]:
         """Compute all Q_and_F intermediates."""
-        regime_transition_probs: MappingProxyType[str, Array] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
             compute_regime_transition_probs(**states_actions_params)
         )
         U_arr, F_arr = U_and_F(**states_actions_params)

--- a/src/lcm/regime_building/Q_and_F.py
+++ b/src/lcm/regime_building/Q_and_F.py
@@ -4,7 +4,6 @@ from typing import Any, cast
 
 import jax.numpy as jnp
 from dags import concatenate_functions, with_signature
-from jax import Array
 
 from lcm.regime_building.h_dag import _get_build_H_kwargs
 from lcm.regime_building.next_state import (
@@ -18,6 +17,7 @@ from lcm.typing import (
     FloatND,
     FunctionsMapping,
     InternalUserFunction,
+    IntND,
     QAndFFunction,
     RegimeName,
     RegimeTransitionFunction,
@@ -136,7 +136,7 @@ def get_Q_and_F(
     )
     def Q_and_F(
         next_regime_to_V_arr: FloatND,
-        **states_actions_params: Array,
+        **states_actions_params: FloatND | IntND | BoolND,
     ) -> tuple[FloatND, BoolND]:
         """Calculate the state-action value and feasibility for a non-terminal period.
 
@@ -314,7 +314,7 @@ def get_compute_intermediates(
     )
     def compute_intermediates(
         next_regime_to_V_arr: FloatND,
-        **states_actions_params: Array,
+        **states_actions_params: FloatND | IntND | BoolND,
     ) -> tuple[
         FloatND, FloatND, FloatND, FloatND, MappingProxyType[RegimeName, FloatND]
     ]:
@@ -395,7 +395,7 @@ def get_Q_and_F_terminal(
     )
     def Q_and_F(
         next_regime_to_V_arr: FloatND,  # noqa: ARG001
-        **states_actions_params: Array,
+        **states_actions_params: FloatND | IntND | BoolND,
     ) -> tuple[FloatND, BoolND]:
         """Calculate the state-action values and feasibilities for a terminal period.
 

--- a/src/lcm/regime_building/Q_and_F.py
+++ b/src/lcm/regime_building/Q_and_F.py
@@ -149,7 +149,7 @@ def get_Q_and_F(
             A tuple containing the arrays with state-action values and feasibilities.
 
         """
-        regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
             compute_regime_transition_probs(**states_actions_params)
         )
         U_arr, F_arr = U_and_F(**states_actions_params)
@@ -319,7 +319,7 @@ def get_compute_intermediates(
         FloatND, FloatND, FloatND, FloatND, MappingProxyType[RegimeName, FloatND]
     ]:
         """Compute all Q_and_F intermediates."""
-        regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
             compute_regime_transition_probs(**states_actions_params)
         )
         U_arr, F_arr = U_and_F(**states_actions_params)

--- a/src/lcm/regime_building/Q_and_F.py
+++ b/src/lcm/regime_building/Q_and_F.py
@@ -149,7 +149,7 @@ def get_Q_and_F(
             A tuple containing the arrays with state-action values and feasibilities.
 
         """
-        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (
             compute_regime_transition_probs(**states_actions_params)
         )
         U_arr, F_arr = U_and_F(**states_actions_params)
@@ -319,7 +319,7 @@ def get_compute_intermediates(
         FloatND, FloatND, FloatND, FloatND, MappingProxyType[RegimeName, FloatND]
     ]:
         """Compute all Q_and_F intermediates."""
-        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (
             compute_regime_transition_probs(**states_actions_params)
         )
         U_arr, F_arr = U_and_F(**states_actions_params)

--- a/src/lcm/regime_building/V.py
+++ b/src/lcm/regime_building/V.py
@@ -5,14 +5,13 @@ from types import MappingProxyType
 import jax.numpy as jnp
 from dags import concatenate_functions, with_signature
 from dags.tree import qname_from_tree_path
-from jax import Array
 
 from lcm.grids import ContinuousGrid, DiscreteGrid, IrregSpacedGrid
 from lcm.grids.coordinates import get_irreg_coordinate
 from lcm.regime import Regime
 from lcm.regime_building.ndimage import map_coordinates
 from lcm.shocks import _ShockGrid
-from lcm.typing import FloatND, ScalarFloat, StateName
+from lcm.typing import FloatND, IntND, ScalarFloat, StateName
 from lcm.utils.functools import all_as_kwargs
 from lcm.variables import Variables, get_grids
 
@@ -173,8 +172,11 @@ def _get_lookup_function(
     """
     arg_names = [*axis_names, array_name]
 
-    @with_signature(args=dict.fromkeys(arg_names, "Array"), return_annotation="Array")
-    def lookup_wrapper(*args: Array, **kwargs: Array) -> FloatND:
+    @with_signature(
+        args=dict.fromkeys(arg_names, "FloatND | IntND"),
+        return_annotation="FloatND",
+    )
+    def lookup_wrapper(*args: FloatND | IntND, **kwargs: FloatND | IntND) -> FloatND:
         kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=arg_names)
         positions = tuple(kwargs[var] for var in axis_names)
         return kwargs[array_name][positions]
@@ -210,9 +212,9 @@ def _get_coordinate_finder(
             arg_names = [in_name, points_param]
 
             @with_signature(
-                args=dict.fromkeys(arg_names, "Array"), return_annotation="Array"
+                args=dict.fromkeys(arg_names, "FloatND"), return_annotation="FloatND"
             )
-            def find_irreg_coordinate(*args: Array, **kwargs: Array) -> FloatND:
+            def find_irreg_coordinate(*args: FloatND, **kwargs: FloatND) -> FloatND:
                 kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=arg_names)
                 return get_irreg_coordinate(
                     value=kwargs[in_name], points=kwargs[points_param]
@@ -224,17 +226,19 @@ def _get_coordinate_finder(
         points_jax = grid.to_jax()
 
         @with_signature(
-            args=dict.fromkeys([in_name], "Array"), return_annotation="Array"
+            args=dict.fromkeys([in_name], "FloatND"), return_annotation="FloatND"
         )
-        def find_irreg_coordinate(*args: Array, **kwargs: Array) -> FloatND:
+        def find_irreg_coordinate(*args: FloatND, **kwargs: FloatND) -> FloatND:
             kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=[in_name])
             return get_irreg_coordinate(value=kwargs[in_name], points=points_jax)
 
         return find_irreg_coordinate
 
     # All other grid types (LinSpaced, LogSpaced, Piecewise*, ShockGrid)
-    @with_signature(args=dict.fromkeys([in_name], "Array"), return_annotation="Array")
-    def find_coordinate(*args: Array, **kwargs: Array) -> FloatND:
+    @with_signature(
+        args=dict.fromkeys([in_name], "FloatND"), return_annotation="FloatND"
+    )
+    def find_coordinate(*args: FloatND, **kwargs: FloatND) -> FloatND:
         kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=[in_name])
         return grid.get_coordinate(kwargs[in_name])
 
@@ -260,8 +264,10 @@ def _get_interpolator(
     """
     arg_names = [name_of_values_on_grid, *axis_names]
 
-    @with_signature(args=dict.fromkeys(arg_names, "Array"), return_annotation="Array")
-    def interpolate(*args: Array, **kwargs: Array) -> FloatND:
+    @with_signature(
+        args=dict.fromkeys(arg_names, "FloatND"), return_annotation="FloatND"
+    )
+    def interpolate(*args: FloatND, **kwargs: FloatND) -> FloatND:
         kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=arg_names)
         coordinates = jnp.array([kwargs[var] for var in axis_names])
         return map_coordinates(

--- a/src/lcm/regime_building/V.py
+++ b/src/lcm/regime_building/V.py
@@ -159,7 +159,7 @@ def _get_lookup_function(
     *,
     array_name: str,
     axis_names: list[str],
-) -> Callable[..., Array]:
+) -> Callable[..., FloatND]:
     """Create a function that emulates indexing into an array via named axes.
 
     Args:
@@ -174,7 +174,7 @@ def _get_lookup_function(
     arg_names = [*axis_names, array_name]
 
     @with_signature(args=dict.fromkeys(arg_names, "Array"), return_annotation="Array")
-    def lookup_wrapper(*args: Array, **kwargs: Array) -> Array:
+    def lookup_wrapper(*args: Array, **kwargs: Array) -> FloatND:
         kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=arg_names)
         positions = tuple(kwargs[var] for var in axis_names)
         return kwargs[array_name][positions]
@@ -186,7 +186,7 @@ def _get_coordinate_finder(
     *,
     in_name: str,
     grid: ContinuousGrid,
-) -> Callable[..., Array]:
+) -> Callable[..., FloatND]:
     """Create a function that translates a value into coordinates on a grid.
 
     The resulting coordinates can be used to do linear interpolation via
@@ -212,7 +212,7 @@ def _get_coordinate_finder(
             @with_signature(
                 args=dict.fromkeys(arg_names, "Array"), return_annotation="Array"
             )
-            def find_irreg_coordinate(*args: Array, **kwargs: Array) -> Array:
+            def find_irreg_coordinate(*args: Array, **kwargs: Array) -> FloatND:
                 kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=arg_names)
                 return get_irreg_coordinate(
                     value=kwargs[in_name], points=kwargs[points_param]
@@ -226,7 +226,7 @@ def _get_coordinate_finder(
         @with_signature(
             args=dict.fromkeys([in_name], "Array"), return_annotation="Array"
         )
-        def find_irreg_coordinate(*args: Array, **kwargs: Array) -> Array:
+        def find_irreg_coordinate(*args: Array, **kwargs: Array) -> FloatND:
             kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=[in_name])
             return get_irreg_coordinate(value=kwargs[in_name], points=points_jax)
 
@@ -234,7 +234,7 @@ def _get_coordinate_finder(
 
     # All other grid types (LinSpaced, LogSpaced, Piecewise*, ShockGrid)
     @with_signature(args=dict.fromkeys([in_name], "Array"), return_annotation="Array")
-    def find_coordinate(*args: Array, **kwargs: Array) -> Array:
+    def find_coordinate(*args: Array, **kwargs: Array) -> FloatND:
         kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=[in_name])
         return grid.get_coordinate(kwargs[in_name])
 
@@ -245,7 +245,7 @@ def _get_interpolator(
     *,
     name_of_values_on_grid: str,
     axis_names: list[str],
-) -> Callable[..., Array]:
+) -> Callable[..., FloatND]:
     """Create a function interpolator via named axes.
 
     Args:
@@ -261,7 +261,7 @@ def _get_interpolator(
     arg_names = [name_of_values_on_grid, *axis_names]
 
     @with_signature(args=dict.fromkeys(arg_names, "Array"), return_annotation="Array")
-    def interpolate(*args: Array, **kwargs: Array) -> Array:
+    def interpolate(*args: Array, **kwargs: Array) -> FloatND:
         kwargs = all_as_kwargs(args=args, kwargs=kwargs, arg_names=arg_names)
         coordinates = jnp.array([kwargs[var] for var in axis_names])
         return map_coordinates(

--- a/src/lcm/regime_building/argmax.py
+++ b/src/lcm/regime_building/argmax.py
@@ -1,14 +1,14 @@
 import jax.numpy as jnp
 
-from lcm.typing import BoolND, IntND, RealND
+from lcm.typing import BoolND, FloatND, IntND
 
 
 def argmax_and_max(
-    a: RealND,
+    a: FloatND | IntND,
     axis: int | tuple[int, ...] | None = None,
     initial: float | None = None,
     where: BoolND | None = None,
-) -> tuple[IntND, RealND]:
+) -> tuple[IntND, FloatND | IntND]:
     """Compute the argmax of an n-dim array along axis.
 
     If multiple maxima exist, the first index will be selected.
@@ -69,7 +69,9 @@ def argmax_and_max(
     return _argmax, _max.reshape(_argmax.shape)
 
 
-def _move_axes_to_back(a: RealND | BoolND, axes: tuple[int, ...]) -> RealND | BoolND:
+def _move_axes_to_back(
+    a: FloatND | IntND | BoolND, axes: tuple[int, ...]
+) -> FloatND | IntND | BoolND:
     """Move specified axes to the back of the array.
 
     Args:
@@ -84,7 +86,9 @@ def _move_axes_to_back(a: RealND | BoolND, axes: tuple[int, ...]) -> RealND | Bo
     return a.transpose((*front_axes, *axes))
 
 
-def _flatten_last_n_axes(a: RealND | BoolND, n: int) -> RealND | BoolND:
+def _flatten_last_n_axes(
+    a: FloatND | IntND | BoolND, n: int
+) -> FloatND | IntND | BoolND:
     """Flatten the last n axes of a to 1 dimension.
 
     Args:

--- a/src/lcm/regime_building/argmax.py
+++ b/src/lcm/regime_building/argmax.py
@@ -1,15 +1,14 @@
 import jax.numpy as jnp
-from jax import Array
 
-from lcm.typing import BoolND, IntND
+from lcm.typing import BoolND, FloatND, IntND
 
 
 def argmax_and_max(
-    a: Array,
+    a: FloatND,
     axis: int | tuple[int, ...] | None = None,
     initial: float | None = None,
     where: BoolND | None = None,
-) -> tuple[IntND, Array]:
+) -> tuple[IntND, FloatND]:
     """Compute the argmax of an n-dim array along axis.
 
     If multiple maxima exist, the first index will be selected.
@@ -70,7 +69,7 @@ def argmax_and_max(
     return _argmax, _max.reshape(_argmax.shape)
 
 
-def _move_axes_to_back(a: Array, axes: tuple[int, ...]) -> Array:
+def _move_axes_to_back(a: FloatND | BoolND, axes: tuple[int, ...]) -> FloatND | BoolND:
     """Move specified axes to the back of the array.
 
     Args:
@@ -85,7 +84,7 @@ def _move_axes_to_back(a: Array, axes: tuple[int, ...]) -> Array:
     return a.transpose((*front_axes, *axes))
 
 
-def _flatten_last_n_axes(a: Array, n: int) -> Array:
+def _flatten_last_n_axes(a: FloatND | BoolND, n: int) -> FloatND | BoolND:
     """Flatten the last n axes of a to 1 dimension.
 
     Args:

--- a/src/lcm/regime_building/argmax.py
+++ b/src/lcm/regime_building/argmax.py
@@ -1,14 +1,14 @@
 import jax.numpy as jnp
 from jax import Array
 
-from lcm.typing import IntND
+from lcm.typing import BoolND, IntND
 
 
 def argmax_and_max(
     a: Array,
     axis: int | tuple[int, ...] | None = None,
     initial: float | None = None,
-    where: Array | None = None,
+    where: BoolND | None = None,
 ) -> tuple[IntND, Array]:
     """Compute the argmax of an n-dim array along axis.
 

--- a/src/lcm/regime_building/argmax.py
+++ b/src/lcm/regime_building/argmax.py
@@ -1,14 +1,14 @@
 import jax.numpy as jnp
 
-from lcm.typing import BoolND, FloatND, IntND
+from lcm.typing import BoolND, IntND, RealND
 
 
 def argmax_and_max(
-    a: FloatND,
+    a: RealND,
     axis: int | tuple[int, ...] | None = None,
     initial: float | None = None,
     where: BoolND | None = None,
-) -> tuple[IntND, FloatND]:
+) -> tuple[IntND, RealND]:
     """Compute the argmax of an n-dim array along axis.
 
     If multiple maxima exist, the first index will be selected.
@@ -69,7 +69,7 @@ def argmax_and_max(
     return _argmax, _max.reshape(_argmax.shape)
 
 
-def _move_axes_to_back(a: FloatND | BoolND, axes: tuple[int, ...]) -> FloatND | BoolND:
+def _move_axes_to_back(a: RealND | BoolND, axes: tuple[int, ...]) -> RealND | BoolND:
     """Move specified axes to the back of the array.
 
     Args:
@@ -84,7 +84,7 @@ def _move_axes_to_back(a: FloatND | BoolND, axes: tuple[int, ...]) -> FloatND | 
     return a.transpose((*front_axes, *axes))
 
 
-def _flatten_last_n_axes(a: FloatND | BoolND, n: int) -> FloatND | BoolND:
+def _flatten_last_n_axes(a: RealND | BoolND, n: int) -> RealND | BoolND:
     """Flatten the last n axes of a to 1 dimension.
 
     Args:

--- a/src/lcm/regime_building/diagnostics.py
+++ b/src/lcm/regime_building/diagnostics.py
@@ -24,6 +24,7 @@ from lcm.regime_building.Q_and_F import get_complete_targets, get_compute_interm
 from lcm.regime_building.V import VInterpolationInfo
 from lcm.typing import (
     ActionName,
+    FloatND,
     FunctionsMapping,
     RegimeName,
     RegimeTransitionFunction,
@@ -171,7 +172,7 @@ def _wrap_with_reduction(
         # contribute to numerators. Infeasible cells are zeroed out because
         # the solver masks them before the max, so a NaN there never
         # propagates to V_arr — reporting it would conflate causes.
-        nan_arrays: dict[str, Array] = {
+        nan_arrays: dict[str, FloatND] = {
             "U_nan": jnp.isnan(U_arr).astype(float) * F_float,
             "E_nan": jnp.isnan(E_next_V).astype(float) * F_float,
             "Q_nan": jnp.isnan(Q_arr).astype(float) * F_float,

--- a/src/lcm/regime_building/diagnostics.py
+++ b/src/lcm/regime_building/diagnostics.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
-from jax import Array
 
 from lcm.ages import AgeGrid
 from lcm.grids import Grid
@@ -24,8 +23,10 @@ from lcm.regime_building.Q_and_F import get_complete_targets, get_compute_interm
 from lcm.regime_building.V import VInterpolationInfo
 from lcm.typing import (
     ActionName,
+    BoolND,
     FloatND,
     FunctionsMapping,
+    IntND,
     RegimeName,
     RegimeTransitionFunction,
     StateName,
@@ -165,7 +166,9 @@ def _wrap_with_reduction(
 
     """
 
-    def reduced(**kwargs: Array) -> dict[str, Any]:
+    def reduced(
+        **kwargs: MappingProxyType[RegimeName, FloatND] | FloatND | IntND | BoolND,
+    ) -> dict[str, Any]:
         U_arr, F_arr, E_next_V, Q_arr, regime_probs = func(**kwargs)
         F_float = F_arr.astype(float)
         # NaN-count arrays are masked by feasibility: only feasible cells

--- a/src/lcm/regime_building/max_Q_over_a.py
+++ b/src/lcm/regime_building/max_Q_over_a.py
@@ -4,7 +4,6 @@ from types import MappingProxyType
 
 import jax.numpy as jnp
 from dags import with_signature
-from jax import Array
 
 from lcm.regime_building.argmax import argmax_and_max
 from lcm.typing import (
@@ -80,7 +79,7 @@ def get_max_Q_over_a(
     )
     def max_Q_over_a(
         next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
-        **states_actions_params: Array,
+        **states_actions_params: FloatND | IntND | BoolND,
     ) -> FloatND:
         Q_arr, F_arr = Q_and_F(
             next_regime_to_V_arr=next_regime_to_V_arr,
@@ -153,7 +152,7 @@ def get_argmax_and_max_Q_over_a(
     )
     def argmax_and_max_Q_over_a(
         next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
-        **states_actions_params: Array,
+        **states_actions_params: FloatND | IntND | BoolND,
     ) -> tuple[IntND, FloatND]:
         Q_arr, F_arr = Q_and_F(
             next_regime_to_V_arr=next_regime_to_V_arr,

--- a/src/lcm/regime_building/ndimage.py
+++ b/src/lcm/regime_building/ndimage.py
@@ -21,14 +21,14 @@ from collections.abc import Sequence
 import jax.numpy as jnp
 from jax import jit, lax
 
-from lcm.typing import FloatND, IntND
+from lcm.typing import IntND, RealND
 
 
 @jit
 def map_coordinates(
-    input: FloatND | IntND,  # noqa: A002
-    coordinates: Sequence[FloatND],
-) -> FloatND | IntND:
+    input: RealND,  # noqa: A002
+    coordinates: Sequence[RealND] | RealND,
+) -> RealND:
     """Map the input array to new coordinates using linear interpolation.
 
     Modified from JAX implementation of `scipy.ndimage.map_coordinates`.
@@ -73,8 +73,8 @@ def map_coordinates(
 
 
 def _compute_indices_and_weights(
-    coordinate: FloatND, input_size: int
-) -> list[tuple[IntND, FloatND]]:
+    coordinate: RealND, input_size: int
+) -> list[tuple[IntND, RealND]]:
     """Compute indices and weights for linear interpolation."""
     lower_index = jnp.clip(jnp.floor(coordinate), 0, input_size - 2).astype(jnp.int32)
     upper_weight = coordinate - lower_index
@@ -82,15 +82,15 @@ def _compute_indices_and_weights(
     return [(lower_index, lower_weight), (lower_index + 1, upper_weight)]
 
 
-def _multiply_all(arrs: Sequence[FloatND]) -> FloatND:
+def _multiply_all(arrs: Sequence[RealND]) -> RealND:
     """Multiply all arrays in the sequence."""
     return functools.reduce(operator.mul, arrs)
 
 
-def _sum_all(arrs: Sequence[FloatND]) -> FloatND:
+def _sum_all(arrs: Sequence[RealND]) -> RealND:
     """Sum all arrays in the sequence."""
     return functools.reduce(operator.add, arrs)
 
 
-def _round_half_away_from_zero(a: FloatND | IntND) -> FloatND | IntND:
+def _round_half_away_from_zero(a: RealND) -> RealND:
     return a if jnp.issubdtype(a.dtype, jnp.integer) else lax.round(a)

--- a/src/lcm/regime_building/ndimage.py
+++ b/src/lcm/regime_building/ndimage.py
@@ -19,14 +19,16 @@ import operator
 from collections.abc import Sequence
 
 import jax.numpy as jnp
-from jax import Array, jit, lax
+from jax import jit, lax
+
+from lcm.typing import FloatND, IntND
 
 
 @jit
 def map_coordinates(
-    input: Array,  # noqa: A002
-    coordinates: Sequence[Array],
-) -> Array:
+    input: FloatND | IntND,  # noqa: A002
+    coordinates: Sequence[FloatND],
+) -> FloatND | IntND:
     """Map the input array to new coordinates using linear interpolation.
 
     Modified from JAX implementation of `scipy.ndimage.map_coordinates`.
@@ -71,8 +73,8 @@ def map_coordinates(
 
 
 def _compute_indices_and_weights(
-    coordinate: Array, input_size: int
-) -> list[tuple[Array, Array]]:
+    coordinate: FloatND, input_size: int
+) -> list[tuple[IntND, FloatND]]:
     """Compute indices and weights for linear interpolation."""
     lower_index = jnp.clip(jnp.floor(coordinate), 0, input_size - 2).astype(jnp.int32)
     upper_weight = coordinate - lower_index
@@ -80,15 +82,15 @@ def _compute_indices_and_weights(
     return [(lower_index, lower_weight), (lower_index + 1, upper_weight)]
 
 
-def _multiply_all(arrs: Sequence[Array]) -> Array:
+def _multiply_all(arrs: Sequence[FloatND]) -> FloatND:
     """Multiply all arrays in the sequence."""
     return functools.reduce(operator.mul, arrs)
 
 
-def _sum_all(arrs: Sequence[Array]) -> Array:
+def _sum_all(arrs: Sequence[FloatND]) -> FloatND:
     """Sum all arrays in the sequence."""
     return functools.reduce(operator.add, arrs)
 
 
-def _round_half_away_from_zero(a: Array) -> Array:
+def _round_half_away_from_zero(a: FloatND | IntND) -> FloatND | IntND:
     return a if jnp.issubdtype(a.dtype, jnp.integer) else lax.round(a)

--- a/src/lcm/regime_building/ndimage.py
+++ b/src/lcm/regime_building/ndimage.py
@@ -21,14 +21,14 @@ from collections.abc import Sequence
 import jax.numpy as jnp
 from jax import jit, lax
 
-from lcm.typing import IntND, RealND
+from lcm.typing import FloatND, IntND
 
 
 @jit
 def map_coordinates(
-    input: RealND,  # noqa: A002
-    coordinates: Sequence[RealND] | RealND,
-) -> RealND:
+    input: FloatND | IntND,  # noqa: A002
+    coordinates: Sequence[FloatND | IntND] | FloatND | IntND,
+) -> FloatND | IntND:
     """Map the input array to new coordinates using linear interpolation.
 
     Modified from JAX implementation of `scipy.ndimage.map_coordinates`.
@@ -73,8 +73,8 @@ def map_coordinates(
 
 
 def _compute_indices_and_weights(
-    coordinate: RealND, input_size: int
-) -> list[tuple[IntND, RealND]]:
+    coordinate: FloatND | IntND, input_size: int
+) -> list[tuple[IntND, FloatND | IntND]]:
     """Compute indices and weights for linear interpolation."""
     lower_index = jnp.clip(jnp.floor(coordinate), 0, input_size - 2).astype(jnp.int32)
     upper_weight = coordinate - lower_index
@@ -82,15 +82,15 @@ def _compute_indices_and_weights(
     return [(lower_index, lower_weight), (lower_index + 1, upper_weight)]
 
 
-def _multiply_all(arrs: Sequence[RealND]) -> RealND:
+def _multiply_all(arrs: Sequence[FloatND | IntND]) -> FloatND | IntND:
     """Multiply all arrays in the sequence."""
     return functools.reduce(operator.mul, arrs)
 
 
-def _sum_all(arrs: Sequence[RealND]) -> RealND:
+def _sum_all(arrs: Sequence[FloatND | IntND]) -> FloatND | IntND:
     """Sum all arrays in the sequence."""
     return functools.reduce(operator.add, arrs)
 
 
-def _round_half_away_from_zero(a: RealND) -> RealND:
+def _round_half_away_from_zero(a: FloatND | IntND) -> FloatND | IntND:
     return a if jnp.issubdtype(a.dtype, jnp.integer) else lax.round(a)

--- a/src/lcm/regime_building/next_state.py
+++ b/src/lcm/regime_building/next_state.py
@@ -239,7 +239,7 @@ def _create_discrete_stochastic_next_func(
     qname = qname_from_tree_path((target, next_state_name))
 
     @with_signature(
-        args={f"weight_{qname}": "FloatND", f"key_{qname}": "dict[str, KeyArray]"},
+        args={f"weight_{qname}": "FloatND", f"key_{qname}": "PRNGKeyND"},
         return_annotation="DiscreteState",
     )
     def next_stochastic_state(**kwargs: FloatND) -> DiscreteState:
@@ -295,7 +295,7 @@ def _create_ar1_next_func(
         qname_from_tree_path((state_name, p)): p for p in grid.params_to_pass_at_runtime
     }
     args: dict[str, str] = {
-        f"key_{qname}": "dict[str, KeyArray]",
+        f"key_{qname}": "PRNGKeyND",
         state_name: "ContinuousState",
         **dict.fromkeys(runtime_param_names, "float"),
     }
@@ -328,7 +328,7 @@ def _create_iid_next_func(
         qname_from_tree_path((state_name, p)): p for p in grid.params_to_pass_at_runtime
     }
     args: dict[str, str] = {
-        f"key_{qname}": "dict[str, KeyArray]",
+        f"key_{qname}": "PRNGKeyND",
         **dict.fromkeys(runtime_param_names, "float"),
     }
     _draw_shock = grid.draw_shock

--- a/src/lcm/regime_building/next_state.py
+++ b/src/lcm/regime_building/next_state.py
@@ -10,6 +10,7 @@ from jax import Array
 
 from lcm.grids import Grid
 from lcm.shocks import _ShockGrid
+from lcm.shocks._base import _params_to_jax
 from lcm.shocks.ar1 import _ShockGridAR1
 from lcm.shocks.iid import _ShockGridIID
 from lcm.typing import (
@@ -300,11 +301,13 @@ def _create_ar1_next_func(
 
     @with_signature(args=args, return_annotation="ContinuousState")
     def next_stochastic_state(**kwargs: FloatND) -> ContinuousState:
-        params = MappingProxyType(
-            {
-                **fixed_params,
-                **{raw: kwargs[qn] for qn, raw in runtime_param_names.items()},
-            }
+        params = _params_to_jax(
+            MappingProxyType(
+                {
+                    **fixed_params,
+                    **{raw: kwargs[qn] for qn, raw in runtime_param_names.items()},
+                }
+            )
         )
         return _draw_shock(
             params=params,
@@ -330,11 +333,13 @@ def _create_iid_next_func(
 
     @with_signature(args=args, return_annotation="ContinuousState")
     def next_stochastic_state(**kwargs: FloatND) -> ContinuousState:
-        params = MappingProxyType(
-            {
-                **fixed_params,
-                **{raw: kwargs[qn] for qn, raw in runtime_param_names.items()},
-            }
+        params = _params_to_jax(
+            MappingProxyType(
+                {
+                    **fixed_params,
+                    **{raw: kwargs[qn] for qn, raw in runtime_param_names.items()},
+                }
+            )
         )
         return _draw_shock(
             params=params,

--- a/src/lcm/regime_building/next_state.py
+++ b/src/lcm/regime_building/next_state.py
@@ -6,7 +6,6 @@ from types import MappingProxyType
 import jax
 from dags import concatenate_functions, with_signature
 from dags.tree import qname_from_tree_path
-from jax import Array
 
 from lcm.grids import Grid
 from lcm.shocks import _ShockGrid
@@ -18,6 +17,7 @@ from lcm.typing import (
     DiscreteState,
     FloatND,
     FunctionsMapping,
+    IntND,
     NextStateSimulationFunction,
     RegimeName,
     ShockName,
@@ -94,7 +94,7 @@ def get_next_state_function_for_simulation(
         Returns `{target_regime_name: {next_<state>: array}}`.
 
     """
-    per_target_funcs: dict[RegimeName, Callable[..., dict[str, Array]]] = {}
+    per_target_funcs: dict[RegimeName, Callable[..., dict[str, FloatND | IntND]]] = {}
     for target, target_transitions in transitions.items():
         extended = _extend_target_transitions_for_simulation(
             target=target,
@@ -126,7 +126,7 @@ def get_next_stochastic_weights_function(
     functions: FunctionsMapping,
     transitions: FunctionsMapping,
     stochastic_transition_names: frozenset[TransitionFunctionName],
-) -> Callable[..., dict[str, Array]]:
+) -> Callable[..., dict[str, FloatND | IntND]]:
     """Get function that computes the weights for the next stochastic states.
 
     Args:
@@ -156,11 +156,13 @@ def get_next_stochastic_weights_function(
 def _extend_target_transitions_for_simulation(
     *,
     target: RegimeName,
-    target_transitions: MappingProxyType[TransitionFunctionName, Callable[..., Array]],
+    target_transitions: MappingProxyType[
+        TransitionFunctionName, Callable[..., FloatND | IntND]
+    ],
     all_grids: MappingProxyType[RegimeName, MappingProxyType[StateOrActionName, Grid]],
     variables: Variables,
     stochastic_transition_names: frozenset[TransitionFunctionName],
-) -> dict[TransitionFunctionName, Callable[..., Array]]:
+) -> dict[TransitionFunctionName, Callable[..., FloatND | IntND]]:
     """Replace stochastic transitions for one target with realisation wrappers.
 
     Deterministic transitions are passed through unchanged. Stochastic transitions
@@ -186,7 +188,7 @@ def _extend_target_transitions_for_simulation(
 
     """
     shock_names: frozenset[ShockName] = frozenset(variables.shock_names)
-    extended: dict[TransitionFunctionName, Callable[..., Array]] = dict(
+    extended: dict[TransitionFunctionName, Callable[..., FloatND | IntND]] = dict(
         target_transitions
     )
     for next_state_name in target_transitions:
@@ -237,7 +239,7 @@ def _create_discrete_stochastic_next_func(
     qname = qname_from_tree_path((target, next_state_name))
 
     @with_signature(
-        args={f"weight_{qname}": "FloatND", f"key_{qname}": "dict[str, Array]"},
+        args={f"weight_{qname}": "FloatND", f"key_{qname}": "dict[str, KeyArray]"},
         return_annotation="DiscreteState",
     )
     def next_stochastic_state(**kwargs: FloatND) -> DiscreteState:
@@ -293,7 +295,7 @@ def _create_ar1_next_func(
         qname_from_tree_path((state_name, p)): p for p in grid.params_to_pass_at_runtime
     }
     args: dict[str, str] = {
-        f"key_{qname}": "dict[str, Array]",
+        f"key_{qname}": "dict[str, KeyArray]",
         state_name: "ContinuousState",
         **dict.fromkeys(runtime_param_names, "float"),
     }
@@ -326,7 +328,7 @@ def _create_iid_next_func(
         qname_from_tree_path((state_name, p)): p for p in grid.params_to_pass_at_runtime
     }
     args: dict[str, str] = {
-        f"key_{qname}": "dict[str, Array]",
+        f"key_{qname}": "dict[str, KeyArray]",
         **dict.fromkeys(runtime_param_names, "float"),
     }
     _draw_shock = grid.draw_shock

--- a/src/lcm/regime_building/processing.py
+++ b/src/lcm/regime_building/processing.py
@@ -9,7 +9,6 @@ import jax
 from dags import concatenate_functions, get_annotations, with_signature
 from dags.signature import rename_arguments
 from dags.tree import QNAME_DELIMITER, qname_from_tree_path, tree_path_from_qname
-from jax import Array
 from jax import numpy as jnp
 
 from lcm.ages import AgeGrid
@@ -50,6 +49,7 @@ from lcm.typing import (
     FunctionsMapping,
     Int1D,
     InternalUserFunction,
+    IntND,
     MaxQOverAFunction,
     NextStateSimulationFunction,
     QAndFFunction,
@@ -889,7 +889,7 @@ def _get_weights_func_for_shock(*, name: str, grid: _ShockGrid) -> UserFunction:
         args = {name: "ContinuousState", **dict.fromkeys(runtime_param_names, "float")}
 
         @with_signature(args=args, return_annotation="FloatND", enforce=False)
-        def weights_func_runtime(*a: Array, **kwargs: Array) -> Float1D:  # noqa: ARG001
+        def weights_func_runtime(*a: FloatND, **kwargs: FloatND) -> Float1D:  # noqa: ARG001
             shock_kw: dict[str, float] = {  # ty: ignore[invalid-assignment]
                 **fixed_params,
                 **{raw: kwargs[qn] for qn, raw in runtime_param_names.items()},
@@ -916,7 +916,7 @@ def _get_weights_func_for_shock(*, name: str, grid: _ShockGrid) -> UserFunction:
         return_annotation="FloatND",
         enforce=False,
     )
-    def weights_func(*args: Array, **kwargs: Array) -> Float1D:  # noqa: ARG001
+    def weights_func(*args: FloatND, **kwargs: FloatND) -> Float1D:  # noqa: ARG001
         coordinate = get_irreg_coordinate(value=kwargs[f"{name}"], points=gridpoints)
         return map_coordinates(
             input=transition_probs,
@@ -1259,7 +1259,8 @@ def _wrap_regime_transition_probs(
         regime_names_to_ids: Immutable mapping of regime names to integer indices.
 
     Returns:
-        A wrapped function that returns MappingProxyType[str, float|Array].
+        A wrapped function that returns an immutable mapping of regime
+        names to probability scalars.
 
     """
     # Get regime names in index order from regime_names_to_ids. Coerce
@@ -1279,8 +1280,8 @@ def _wrap_regime_transition_probs(
     )
     @functools.wraps(func)
     def wrapped(
-        *args: Array | int,
-        **kwargs: Array | int,
+        *args: FloatND | IntND | int,
+        **kwargs: FloatND | IntND | int,
     ) -> MappingProxyType[str, Any]:
         result = func(*args, **kwargs)
         # Convert array to dict using ordering by regime id
@@ -1318,8 +1319,8 @@ def _wrap_deterministic_regime_transition(
     @with_signature(args=annotations, return_annotation="FloatND")
     @functools.wraps(func)
     def wrapped(
-        *args: Array | int,
-        **kwargs: Array | int,
+        *args: FloatND | IntND | int,
+        **kwargs: FloatND | IntND | int,
     ) -> FloatND:
         regime_idx = func(*args, **kwargs)
         return jax.nn.one_hot(regime_idx, n_regimes)

--- a/src/lcm/regime_building/processing.py
+++ b/src/lcm/regime_building/processing.py
@@ -868,7 +868,7 @@ def _get_stochastic_next_function_for_shock(
 
     @with_signature(args={f"{name}": "ContinuousState"}, return_annotation="Int1D")
     def next_func(**kwargs: Any) -> Int1D:  # noqa: ARG001, ANN401
-        return jnp.arange(grid.shape[0])
+        return jnp.arange(grid.shape[0], dtype=jnp.int32)
 
     return next_func
 
@@ -902,7 +902,7 @@ def _get_weights_func_for_shock(*, name: str, grid: _ShockGrid) -> UserFunction:
                 input=transition_probs,
                 coordinates=[
                     jnp.full(n_points, fill_value=coord),
-                    jnp.arange(n_points),
+                    jnp.arange(n_points, dtype=jnp.int32),
                 ],
             )
 
@@ -922,7 +922,7 @@ def _get_weights_func_for_shock(*, name: str, grid: _ShockGrid) -> UserFunction:
             input=transition_probs,
             coordinates=[
                 jnp.full(grid.n_points, fill_value=coordinate),
-                jnp.arange(grid.n_points),
+                jnp.arange(grid.n_points, dtype=jnp.int32),
             ],
         )
 

--- a/src/lcm/regime_building/processing.py
+++ b/src/lcm/regime_building/processing.py
@@ -41,6 +41,7 @@ from lcm.regime_building.Q_and_F import (
 from lcm.regime_building.V import VInterpolationInfo, create_v_interpolation_info
 from lcm.regime_building.validation import collect_state_transitions
 from lcm.shocks import _ShockGrid
+from lcm.shocks._base import _params_to_jax
 from lcm.state_action_space import create_state_action_space
 from lcm.typing import (
     ArgmaxQOverAFunction,
@@ -892,8 +893,9 @@ def _get_weights_func_for_shock(*, name: str, grid: _ShockGrid) -> UserFunction:
                 **fixed_params,
                 **{raw: kwargs[qn] for qn, raw in runtime_param_names.items()},
             }
-            gridpoints = grid.compute_gridpoints(**shock_kw)
-            transition_probs = grid.compute_transition_probs(**shock_kw)
+            shock_kw_jax = _params_to_jax(MappingProxyType(shock_kw))
+            gridpoints = grid.compute_gridpoints(**shock_kw_jax)
+            transition_probs = grid.compute_transition_probs(**shock_kw_jax)
             coord = get_irreg_coordinate(value=kwargs[name], points=gridpoints)
             return map_coordinates(
                 input=transition_probs,

--- a/src/lcm/regime_building/processing.py
+++ b/src/lcm/regime_building/processing.py
@@ -46,6 +46,7 @@ from lcm.state_action_space import create_state_action_space
 from lcm.typing import (
     ArgmaxQOverAFunction,
     Float1D,
+    FloatND,
     FunctionsMapping,
     Int1D,
     InternalUserFunction,
@@ -1314,12 +1315,12 @@ def _wrap_deterministic_regime_transition(
     # Preserve original annotations but update return type
     annotations = {k: v for k, v in get_annotations(func).items() if k != "return"}
 
-    @with_signature(args=annotations, return_annotation="Array")
+    @with_signature(args=annotations, return_annotation="FloatND")
     @functools.wraps(func)
     def wrapped(
         *args: Array | int,
         **kwargs: Array | int,
-    ) -> Array:
+    ) -> FloatND:
         regime_idx = func(*args, **kwargs)
         return jax.nn.one_hot(regime_idx, n_regimes)
 

--- a/src/lcm/shocks/_base.py
+++ b/src/lcm/shocks/_base.py
@@ -1,7 +1,8 @@
 from abc import abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from types import MappingProxyType
-from typing import ClassVar, overload
+from typing import Any, ClassVar, overload
 
 import jax.numpy as jnp
 import numpy as np
@@ -13,11 +14,35 @@ from lcm.grids import coordinates as grid_coordinates
 from lcm.typing import Float1D, FloatND, IntND, ScalarFloat
 
 
+def _params_to_jax(
+    params: Mapping[str, Any],
+) -> MappingProxyType[str, FloatND | IntND]:
+    """Cast Python `int` / `float` shock params to JAX scalars.
+
+    `self.params` on a shock grid mixes dataclass-default literals (Python
+    `int` / `float`) with runtime-substituted values (already JAX scalars).
+    The downstream `compute_gridpoints` / `compute_transition_probs` and
+    `draw_shock` slots take `FloatND | IntND`-valued mappings, so the
+    boundary cast happens here rather than widening every kwarg signature
+    to admit Python scalars.
+
+    """
+    out: dict[str, FloatND | IntND] = {}
+    for name, value in params.items():
+        if isinstance(value, bool | int):
+            out[name] = jnp.int32(value)
+        elif isinstance(value, float):
+            out[name] = jnp.asarray(value)
+        else:
+            out[name] = value
+    return MappingProxyType(out)
+
+
 def _gauss_hermite_normal(
     *,
     n_points: int,
-    mu: float | ScalarFloat | Float1D,
-    sigma: float | ScalarFloat | Float1D,
+    mu: ScalarFloat | Float1D,
+    sigma: ScalarFloat | Float1D,
 ) -> tuple[Float1D, Float1D]:
     """Compute Gauss-Hermite quadrature nodes and weights for $N(\\mu, \\sigma^2)$.
 
@@ -84,11 +109,11 @@ class _ShockGrid(ContinuousGrid):
         return not self.params_to_pass_at_runtime
 
     @abstractmethod
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         """Compute discretized gridpoints for the shock distribution."""
 
     @abstractmethod
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
         """Compute transition probability matrix for the shock distribution."""
 
     def get_gridpoints(self) -> Float1D:
@@ -100,7 +125,7 @@ class _ShockGrid(ContinuousGrid):
         """
         if not self.is_fully_specified:
             return jnp.full(self.n_points, jnp.nan)
-        return self.compute_gridpoints(**self.params)
+        return self.compute_gridpoints(**_params_to_jax(self.params))
 
     def get_transition_probs(self) -> FloatND:
         """Get the transition probabilities at the gridpoints.
@@ -111,19 +136,17 @@ class _ShockGrid(ContinuousGrid):
         """
         if not self.is_fully_specified:
             return jnp.full((self.n_points, self.n_points), jnp.nan)
-        return self.compute_transition_probs(**self.params)
+        return self.compute_transition_probs(**_params_to_jax(self.params))
 
     def to_jax(self) -> Float1D:
         """Convert the grid to a Jax array."""
         return self.get_gridpoints()
 
     @overload
-    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(
-        self, value: float | ScalarFloat | FloatND
-    ) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if not self.is_fully_specified:
             raise GridInitializationError(
@@ -154,11 +177,11 @@ def _validate_gauss_hermite_grid(
 def _mixture_cdf(
     *,
     x: FloatND,
-    p1: float | FloatND,
-    mu1: float | FloatND,
-    sigma1: float | FloatND,
-    mu2: float | FloatND,
-    sigma2: float | FloatND,
+    p1: ScalarFloat | FloatND,
+    mu1: ScalarFloat | FloatND,
+    sigma1: ScalarFloat | FloatND,
+    mu2: ScalarFloat | FloatND,
+    sigma2: ScalarFloat | FloatND,
 ) -> FloatND:
     """Evaluate the CDF of a two-component normal mixture.
 

--- a/src/lcm/shocks/_base.py
+++ b/src/lcm/shocks/_base.py
@@ -10,7 +10,7 @@ from jax.scipy.stats.norm import cdf
 from lcm.exceptions import GridInitializationError
 from lcm.grids import ContinuousGrid
 from lcm.grids import coordinates as grid_coordinates
-from lcm.typing import Float1D, FloatND, ScalarFloat
+from lcm.typing import Float1D, FloatND, IntND, ScalarFloat
 
 
 def _gauss_hermite_normal(
@@ -84,11 +84,11 @@ class _ShockGrid(ContinuousGrid):
         return not self.params_to_pass_at_runtime
 
     @abstractmethod
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         """Compute discretized gridpoints for the shock distribution."""
 
     @abstractmethod
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
         """Compute transition probability matrix for the shock distribution."""
 
     def get_gridpoints(self) -> Float1D:
@@ -118,10 +118,12 @@ class _ShockGrid(ContinuousGrid):
         return self.get_gridpoints()
 
     @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
+    def get_coordinate(self, value: float | ScalarFloat) -> ScalarFloat: ...
     @overload
     def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(
+        self, value: float | ScalarFloat | FloatND
+    ) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if not self.is_fully_specified:
             raise GridInitializationError(

--- a/src/lcm/shocks/_base.py
+++ b/src/lcm/shocks/_base.py
@@ -1,8 +1,7 @@
 from abc import abstractmethod
-from collections.abc import Mapping
 from dataclasses import dataclass, fields
 from types import MappingProxyType
-from typing import Any, ClassVar, overload
+from typing import Any, ClassVar
 
 import jax.numpy as jnp
 import numpy as np
@@ -11,11 +10,11 @@ from jax.scipy.stats.norm import cdf
 from lcm.exceptions import GridInitializationError
 from lcm.grids import ContinuousGrid
 from lcm.grids import coordinates as grid_coordinates
-from lcm.typing import Float1D, FloatND, IntND, ScalarFloat
+from lcm.typing import Float1D, FloatND, IntND, ScalarFloat, ScalarInt
 
 
 def _params_to_jax(
-    params: Mapping[str, Any],
+    params: MappingProxyType[str, Any],
 ) -> MappingProxyType[str, FloatND | IntND]:
     """Cast Python `int` / `float` shock params to JAX scalars.
 
@@ -41,8 +40,8 @@ def _params_to_jax(
 def _gauss_hermite_normal(
     *,
     n_points: int,
-    mu: ScalarFloat | Float1D,
-    sigma: ScalarFloat | Float1D,
+    mu: ScalarFloat,
+    sigma: ScalarFloat,
 ) -> tuple[Float1D, Float1D]:
     """Compute Gauss-Hermite quadrature nodes and weights for $N(\\mu, \\sigma^2)$.
 
@@ -109,11 +108,11 @@ class _ShockGrid(ContinuousGrid):
         return not self.params_to_pass_at_runtime
 
     @abstractmethod
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         """Compute discretized gridpoints for the shock distribution."""
 
     @abstractmethod
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:
         """Compute transition probability matrix for the shock distribution."""
 
     def get_gridpoints(self) -> Float1D:
@@ -142,11 +141,7 @@ class _ShockGrid(ContinuousGrid):
         """Convert the grid to a Jax array."""
         return self.get_gridpoints()
 
-    @overload
-    def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
-    @overload
-    def get_coordinate(self, value: FloatND) -> FloatND: ...
-    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
+    def get_coordinate(self, value: FloatND) -> FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if not self.is_fully_specified:
             raise GridInitializationError(
@@ -177,11 +172,11 @@ def _validate_gauss_hermite_grid(
 def _mixture_cdf(
     *,
     x: FloatND,
-    p1: ScalarFloat | FloatND,
-    mu1: ScalarFloat | FloatND,
-    sigma1: ScalarFloat | FloatND,
-    mu2: ScalarFloat | FloatND,
-    sigma2: ScalarFloat | FloatND,
+    p1: ScalarFloat,
+    mu1: ScalarFloat,
+    sigma1: ScalarFloat,
+    mu2: ScalarFloat,
+    sigma2: ScalarFloat,
 ) -> FloatND:
     """Evaluate the CDF of a two-component normal mixture.
 

--- a/src/lcm/shocks/_base.py
+++ b/src/lcm/shocks/_base.py
@@ -5,7 +5,6 @@ from typing import overload
 
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
 from jax.scipy.stats.norm import cdf
 
 from lcm.exceptions import GridInitializationError
@@ -76,11 +75,11 @@ class _ShockGrid(ContinuousGrid):
         return not self.params_to_pass_at_runtime
 
     @abstractmethod
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         """Compute discretized gridpoints for the shock distribution."""
 
     @abstractmethod
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
         """Compute transition probability matrix for the shock distribution."""
 
     def get_gridpoints(self) -> Float1D:
@@ -112,8 +111,8 @@ class _ShockGrid(ContinuousGrid):
     @overload
     def get_coordinate(self, value: ScalarFloat) -> ScalarFloat: ...
     @overload
-    def get_coordinate(self, value: Array) -> Array: ...
-    def get_coordinate(self, value: ScalarFloat | Array) -> ScalarFloat | Array:
+    def get_coordinate(self, value: FloatND) -> FloatND: ...
+    def get_coordinate(self, value: ScalarFloat | FloatND) -> ScalarFloat | FloatND:
         """Return the generalized coordinate of a value in the grid."""
         if not self.is_fully_specified:
             raise GridInitializationError(
@@ -144,11 +143,11 @@ def _validate_gauss_hermite_grid(
 def _mixture_cdf(
     *,
     x: FloatND,
-    p1: float,
-    mu1: float,
-    sigma1: float,
-    mu2: float,
-    sigma2: float,
+    p1: float | FloatND,
+    mu1: float | FloatND,
+    sigma1: float | FloatND,
+    mu2: float | FloatND,
+    sigma2: float | FloatND,
 ) -> FloatND:
     """Evaluate the CDF of a two-component normal mixture.
 

--- a/src/lcm/shocks/_base.py
+++ b/src/lcm/shocks/_base.py
@@ -15,7 +15,10 @@ from lcm.typing import Float1D, FloatND, ScalarFloat
 
 
 def _gauss_hermite_normal(
-    *, n_points: int, mu: float | Float1D, sigma: float | Float1D
+    *,
+    n_points: int,
+    mu: float | ScalarFloat | Float1D,
+    sigma: float | ScalarFloat | Float1D,
 ) -> tuple[Float1D, Float1D]:
     """Compute Gauss-Hermite quadrature nodes and weights for $N(\\mu, \\sigma^2)$.
 

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -24,7 +24,7 @@ class _ShockGridAR1(_ShockGrid):
     @abstractmethod
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat: ...
@@ -77,7 +77,7 @@ class Tauchen(_ShockGridAR1):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
@@ -90,14 +90,14 @@ class Tauchen(_ShockGridAR1):
         x = jnp.linspace(-x_max, x_max, n_points)
         return x + mu / (1 - rho)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
         n_points = self.n_points
         rho, sigma = kwargs["rho"], kwargs["sigma"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
 
         if self.gauss_hermite:
             nodes, _weights = _gauss_hermite_normal(
-                n_points=n_points, mu=0.0, sigma=std_y
+                n_points=n_points, mu=jnp.asarray(0.0), sigma=std_y
             )
         else:
             n_std = kwargs["n_std"]
@@ -119,7 +119,7 @@ class Tauchen(_ShockGridAR1):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
@@ -152,14 +152,14 @@ class Rouwenhorst(_ShockGridAR1):
     mu: float | int | None = None
     """Intercept (drift) of the AR(1) process."""
 
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         nu = jnp.sqrt((n_points - 1) / (1 - rho**2)) * sigma
         long_run_mean = mu / (1.0 - rho)
         return jnp.linspace(long_run_mean - nu, long_run_mean + nu, n_points)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
         n_points = self.n_points
         rho = kwargs["rho"]
         q = (rho + 1) / 2
@@ -188,7 +188,7 @@ class Rouwenhorst(_ShockGridAR1):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
@@ -242,17 +242,17 @@ class TauchenNormalMixture(_ShockGridAR1):
     @staticmethod
     def _innovation_variance(
         *,
-        p1: float | FloatND,
-        mu1: float | FloatND,
-        sigma1: float | FloatND,
-        mu2: float | FloatND,
-        sigma2: float | FloatND,
-    ) -> float | FloatND:
+        p1: ScalarFloat | FloatND,
+        mu1: ScalarFloat | FloatND,
+        sigma1: ScalarFloat | FloatND,
+        mu2: ScalarFloat | FloatND,
+        sigma2: ScalarFloat | FloatND,
+    ) -> ScalarFloat | FloatND:
         """Compute the variance of the mixture innovation."""
         mean_eps = p1 * mu1 + (1 - p1) * mu2
         return p1 * (sigma1**2 + mu1**2) + (1 - p1) * (sigma2**2 + mu2**2) - mean_eps**2
 
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]
@@ -268,7 +268,7 @@ class TauchenNormalMixture(_ShockGridAR1):
         x_max = n_std * std_y
         return jnp.linspace(long_run_mean - x_max, long_run_mean + x_max, n_points)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]
@@ -302,7 +302,7 @@ class TauchenNormalMixture(_ShockGridAR1):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -15,7 +15,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND
+from lcm.typing import Float1D, FloatND, ScalarFloat
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -27,8 +27,8 @@ class _ShockGridAR1(_ShockGrid):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-        current_value: Float1D,
-    ) -> Float1D: ...
+        current_value: ScalarFloat,
+    ) -> ScalarFloat: ...
 
 
 @beartype_init(GRID_CONF)
@@ -78,7 +78,7 @@ class Tauchen(_ShockGridAR1):
             exclude.add("n_std")
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
@@ -91,7 +91,7 @@ class Tauchen(_ShockGridAR1):
         x = jnp.linspace(-x_max, x_max, n_points)
         return x + mu / (1 - rho)
 
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
         n_points = self.n_points
         rho, sigma = kwargs["rho"], kwargs["sigma"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
@@ -122,8 +122,8 @@ class Tauchen(_ShockGridAR1):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-        current_value: Float1D,
-    ) -> Float1D:
+        current_value: ScalarFloat,
+    ) -> ScalarFloat:
         return (
             params["mu"]
             + params["rho"] * current_value
@@ -153,14 +153,14 @@ class Rouwenhorst(_ShockGridAR1):
     mu: float | int | None = None
     """Intercept (drift) of the AR(1) process."""
 
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         nu = jnp.sqrt((n_points - 1) / (1 - rho**2)) * sigma
         long_run_mean = mu / (1.0 - rho)
         return jnp.linspace(long_run_mean - nu, long_run_mean + nu, n_points)
 
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
         n_points = self.n_points
         rho = kwargs["rho"]
         q = (rho + 1) / 2
@@ -191,8 +191,8 @@ class Rouwenhorst(_ShockGridAR1):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-        current_value: Float1D,
-    ) -> Float1D:
+        current_value: ScalarFloat,
+    ) -> ScalarFloat:
         return (
             params["mu"]
             + params["rho"] * current_value
@@ -243,17 +243,17 @@ class TauchenNormalMixture(_ShockGridAR1):
     @staticmethod
     def _innovation_variance(
         *,
-        p1: float,
-        mu1: float,
-        sigma1: float,
-        mu2: float,
-        sigma2: float,
-    ) -> float:
+        p1: float | FloatND,
+        mu1: float | FloatND,
+        sigma1: float | FloatND,
+        mu2: float | FloatND,
+        sigma2: float | FloatND,
+    ) -> float | FloatND:
         """Compute the variance of the mixture innovation."""
         mean_eps = p1 * mu1 + (1 - p1) * mu2
         return p1 * (sigma1**2 + mu1**2) + (1 - p1) * (sigma2**2 + mu2**2) - mean_eps**2
 
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]
@@ -269,7 +269,7 @@ class TauchenNormalMixture(_ShockGridAR1):
         x_max = n_std * std_y
         return jnp.linspace(long_run_mean - x_max, long_run_mean + x_max, n_points)
 
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]
@@ -305,8 +305,8 @@ class TauchenNormalMixture(_ShockGridAR1):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-        current_value: Float1D,
-    ) -> Float1D:
+        current_value: ScalarFloat,
+    ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)
         component = jax.random.bernoulli(key1, params["p1"])
         normal = jax.random.normal(key2)

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -14,7 +14,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, IntND, KeyArray, ScalarFloat
+from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat, ScalarInt
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -24,7 +24,7 @@ class _ShockGridAR1(_ShockGrid):
     @abstractmethod
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat: ...
@@ -77,7 +77,7 @@ class Tauchen(_ShockGridAR1):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
@@ -90,7 +90,7 @@ class Tauchen(_ShockGridAR1):
         x = jnp.linspace(-x_max, x_max, n_points)
         return x + mu / (1 - rho)
 
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:
         n_points = self.n_points
         rho, sigma = kwargs["rho"], kwargs["sigma"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
@@ -119,7 +119,7 @@ class Tauchen(_ShockGridAR1):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
@@ -152,14 +152,14 @@ class Rouwenhorst(_ShockGridAR1):
     mu: float | int | None = None
     """Intercept (drift) of the AR(1) process."""
 
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         nu = jnp.sqrt((n_points - 1) / (1 - rho**2)) * sigma
         long_run_mean = mu / (1.0 - rho)
         return jnp.linspace(long_run_mean - nu, long_run_mean + nu, n_points)
 
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:
         n_points = self.n_points
         rho = kwargs["rho"]
         q = (rho + 1) / 2
@@ -188,7 +188,7 @@ class Rouwenhorst(_ShockGridAR1):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
@@ -242,17 +242,17 @@ class TauchenNormalMixture(_ShockGridAR1):
     @staticmethod
     def _innovation_variance(
         *,
-        p1: ScalarFloat | FloatND,
-        mu1: ScalarFloat | FloatND,
-        sigma1: ScalarFloat | FloatND,
-        mu2: ScalarFloat | FloatND,
-        sigma2: ScalarFloat | FloatND,
-    ) -> ScalarFloat | FloatND:
+        p1: ScalarFloat,
+        mu1: ScalarFloat,
+        sigma1: ScalarFloat,
+        mu2: ScalarFloat,
+        sigma2: ScalarFloat,
+    ) -> ScalarFloat:
         """Compute the variance of the mixture innovation."""
         mean_eps = p1 * mu1 + (1 - p1) * mu2
         return p1 * (sigma1**2 + mu1**2) + (1 - p1) * (sigma2**2 + mu2**2) - mean_eps**2
 
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]
@@ -268,7 +268,7 @@ class TauchenNormalMixture(_ShockGridAR1):
         x_max = n_std * std_y
         return jnp.linspace(long_run_mean - x_max, long_run_mean + x_max, n_points)
 
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]
@@ -302,7 +302,7 @@ class TauchenNormalMixture(_ShockGridAR1):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -14,7 +14,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat, ScalarInt
+from lcm.typing import Float1D, FloatND, PRNGKeyND, ScalarFloat, ScalarInt
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -25,7 +25,7 @@ class _ShockGridAR1(_ShockGrid):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
         current_value: ScalarFloat,
     ) -> ScalarFloat: ...
 
@@ -120,7 +120,7 @@ class Tauchen(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
         return (
@@ -189,7 +189,7 @@ class Rouwenhorst(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
         return (
@@ -303,7 +303,7 @@ class TauchenNormalMixture(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -7,7 +7,6 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.stats.norm import cdf
 
-from lcm._beartype_conf import GRID_CONF, beartype_init
 from lcm.shocks._base import (
     _gauss_hermite_normal,
     _mixture_cdf,
@@ -30,7 +29,6 @@ class _ShockGridAR1(_ShockGrid):
     ) -> ScalarFloat: ...
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class Tauchen(_ShockGridAR1):
     r"""AR(1) shock discretized via Tauchen (1986).
@@ -130,7 +128,6 @@ class Tauchen(_ShockGridAR1):
         )
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class Rouwenhorst(_ShockGridAR1):
     r"""AR(1) shock discretized via Rouwenhorst (1995).
@@ -199,7 +196,6 @@ class Rouwenhorst(_ShockGridAR1):
         )
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class TauchenNormalMixture(_ShockGridAR1):
     r"""AR(1) shock with mixture-of-normals innovations, discretized via Tauchen.

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -5,7 +5,6 @@ from types import MappingProxyType
 
 import jax
 import jax.numpy as jnp
-from jax import Array
 from jax.scipy.stats.norm import cdf
 
 from lcm._beartype_conf import GRID_CONF, beartype_init
@@ -15,7 +14,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, ScalarFloat
+from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -26,7 +25,7 @@ class _ShockGridAR1(_ShockGrid):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat: ...
 
@@ -121,7 +120,7 @@ class Tauchen(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
         return (
@@ -190,7 +189,7 @@ class Rouwenhorst(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
         return (
@@ -304,7 +303,7 @@ class TauchenNormalMixture(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
         current_value: ScalarFloat,
     ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -14,7 +14,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat
+from lcm.typing import Float1D, FloatND, IntND, KeyArray, ScalarFloat
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -77,7 +77,7 @@ class Tauchen(_ShockGridAR1):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
@@ -90,7 +90,7 @@ class Tauchen(_ShockGridAR1):
         x = jnp.linspace(-x_max, x_max, n_points)
         return x + mu / (1 - rho)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
         n_points = self.n_points
         rho, sigma = kwargs["rho"], kwargs["sigma"]
         std_y = jnp.sqrt(sigma**2 / (1 - rho**2))
@@ -152,14 +152,14 @@ class Rouwenhorst(_ShockGridAR1):
     mu: float | int | None = None
     """Intercept (drift) of the AR(1) process."""
 
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         n_points = self.n_points
         rho, sigma, mu = kwargs["rho"], kwargs["sigma"], kwargs["mu"]
         nu = jnp.sqrt((n_points - 1) / (1 - rho**2)) * sigma
         long_run_mean = mu / (1.0 - rho)
         return jnp.linspace(long_run_mean - nu, long_run_mean + nu, n_points)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
         n_points = self.n_points
         rho = kwargs["rho"]
         q = (rho + 1) / 2
@@ -252,7 +252,7 @@ class TauchenNormalMixture(_ShockGridAR1):
         mean_eps = p1 * mu1 + (1 - p1) * mu2
         return p1 * (sigma1**2 + mu1**2) + (1 - p1) * (sigma2**2 + mu2**2) - mean_eps**2
 
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]
@@ -268,7 +268,7 @@ class TauchenNormalMixture(_ShockGridAR1):
         x_max = n_std * std_y
         return jnp.linspace(long_run_mean - x_max, long_run_mean + x_max, n_points)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
         n_points = self.n_points
         rho, mu = kwargs["rho"], kwargs["mu"]
         n_std = kwargs["n_std"]

--- a/src/lcm/shocks/ar1.py
+++ b/src/lcm/shocks/ar1.py
@@ -5,6 +5,7 @@ from types import MappingProxyType
 
 import jax
 import jax.numpy as jnp
+from jax import Array
 from jax.scipy.stats.norm import cdf
 
 from lcm._beartype_conf import GRID_CONF, beartype_init
@@ -25,7 +26,7 @@ class _ShockGridAR1(_ShockGrid):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
         current_value: Float1D,
     ) -> Float1D: ...
 
@@ -120,7 +121,7 @@ class Tauchen(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
         current_value: Float1D,
     ) -> Float1D:
         return (
@@ -189,7 +190,7 @@ class Rouwenhorst(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
         current_value: Float1D,
     ) -> Float1D:
         return (
@@ -303,7 +304,7 @@ class TauchenNormalMixture(_ShockGridAR1):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
         current_value: Float1D,
     ) -> Float1D:
         key1, key2 = jax.random.split(key)

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -13,7 +13,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, IntND, KeyArray, ScalarFloat
+from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat, ScalarInt
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -23,7 +23,7 @@ class _ShockGridIID(_ShockGrid):
     @abstractmethod
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
     ) -> ScalarFloat: ...
 
@@ -44,18 +44,18 @@ class Uniform(_ShockGridIID):
     stop: float | int | None = None
     """Upper bound of the uniform distribution."""
 
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         return jnp.linspace(
             start=kwargs["start"], stop=kwargs["stop"], num=self.n_points
         )
 
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:  # noqa: ARG002
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:  # noqa: ARG002
         n_points = self.n_points
         return jnp.full((n_points, n_points), fill_value=1 / n_points)
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
     ) -> ScalarFloat:
         return jax.random.uniform(
@@ -99,7 +99,7 @@ class Normal(_ShockGridIID):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -112,7 +112,7 @@ class Normal(_ShockGridIID):
         x_max = mu + n_std * sigma
         return jnp.linspace(start=x_min, stop=x_max, num=n_points)
 
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -132,7 +132,7 @@ class Normal(_ShockGridIID):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
     ) -> ScalarFloat:
         return params["mu"] + params["sigma"] * jax.random.normal(key=key)
@@ -167,7 +167,7 @@ class LogNormal(_ShockGridIID):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -178,7 +178,7 @@ class LogNormal(_ShockGridIID):
         n_std = kwargs["n_std"]
         return jnp.exp(jnp.linspace(mu - n_std * sigma, mu + n_std * sigma, n_points))
 
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -198,7 +198,7 @@ class LogNormal(_ShockGridIID):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
     ) -> ScalarFloat:
         return jnp.exp(params["mu"] + params["sigma"] * jax.random.normal(key=key))
@@ -238,7 +238,7 @@ class NormalMixture(_ShockGridIID):
     sigma2: float | int | None = None
     """Standard deviation of the second mixture component."""
 
-    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: ScalarFloat | ScalarInt) -> Float1D:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]
@@ -253,7 +253,7 @@ class NormalMixture(_ShockGridIID):
             mean_eps - n_std * std_eps, mean_eps + n_std * std_eps, n_points
         )
 
-    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: ScalarFloat | ScalarInt) -> FloatND:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]
@@ -283,7 +283,7 @@ class NormalMixture(_ShockGridIID):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, FloatND | IntND],
+        params: MappingProxyType[str, ScalarFloat | ScalarInt],
         key: KeyArray,
     ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -4,6 +4,7 @@ from types import MappingProxyType
 
 import jax
 import jax.numpy as jnp
+from jax import Array
 from jax.scipy.stats.norm import cdf
 
 from lcm._beartype_conf import GRID_CONF, beartype_init
@@ -24,7 +25,7 @@ class _ShockGridIID(_ShockGrid):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
     ) -> Float1D: ...
 
 
@@ -56,7 +57,7 @@ class Uniform(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
     ) -> Float1D:
         return jax.random.uniform(
             key=key, minval=params["start"], maxval=params["stop"]
@@ -133,7 +134,7 @@ class Normal(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
     ) -> Float1D:
         return params["mu"] + params["sigma"] * jax.random.normal(key=key)
 
@@ -199,7 +200,7 @@ class LogNormal(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
     ) -> Float1D:
         return jnp.exp(params["mu"] + params["sigma"] * jax.random.normal(key=key))
 
@@ -284,7 +285,7 @@ class NormalMixture(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: FloatND,
+        key: Array,
     ) -> Float1D:
         key1, key2 = jax.random.split(key)
         component = jax.random.bernoulli(key1, params["p1"])

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -14,7 +14,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND
+from lcm.typing import Float1D, FloatND, ScalarFloat
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -26,7 +26,7 @@ class _ShockGridIID(_ShockGrid):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-    ) -> Float1D: ...
+    ) -> ScalarFloat: ...
 
 
 @beartype_init(GRID_CONF)
@@ -45,12 +45,12 @@ class Uniform(_ShockGridIID):
     stop: float | int | None = None
     """Upper bound of the uniform distribution."""
 
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         return jnp.linspace(
             start=kwargs["start"], stop=kwargs["stop"], num=self.n_points
         )
 
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:  # noqa: ARG002
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:  # noqa: ARG002
         n_points = self.n_points
         return jnp.full((n_points, n_points), fill_value=1 / n_points)
 
@@ -58,7 +58,7 @@ class Uniform(_ShockGridIID):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-    ) -> Float1D:
+    ) -> ScalarFloat:
         return jax.random.uniform(
             key=key, minval=params["start"], maxval=params["stop"]
         )
@@ -100,7 +100,7 @@ class Normal(_ShockGridIID):
             exclude.add("n_std")
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -113,7 +113,7 @@ class Normal(_ShockGridIID):
         x_max = mu + n_std * sigma
         return jnp.linspace(start=x_min, stop=x_max, num=n_points)
 
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -135,7 +135,7 @@ class Normal(_ShockGridIID):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-    ) -> Float1D:
+    ) -> ScalarFloat:
         return params["mu"] + params["sigma"] * jax.random.normal(key=key)
 
 
@@ -168,7 +168,7 @@ class LogNormal(_ShockGridIID):
             exclude.add("n_std")
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -179,7 +179,7 @@ class LogNormal(_ShockGridIID):
         n_std = kwargs["n_std"]
         return jnp.exp(jnp.linspace(mu - n_std * sigma, mu + n_std * sigma, n_points))
 
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -201,7 +201,7 @@ class LogNormal(_ShockGridIID):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-    ) -> Float1D:
+    ) -> ScalarFloat:
         return jnp.exp(params["mu"] + params["sigma"] * jax.random.normal(key=key))
 
 
@@ -239,7 +239,7 @@ class NormalMixture(_ShockGridIID):
     sigma2: float | int | None = None
     """Standard deviation of the second mixture component."""
 
-    def compute_gridpoints(self, **kwargs: float) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]
@@ -254,7 +254,7 @@ class NormalMixture(_ShockGridIID):
             mean_eps - n_std * std_eps, mean_eps + n_std * std_eps, n_points
         )
 
-    def compute_transition_probs(self, **kwargs: float) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]
@@ -286,7 +286,7 @@ class NormalMixture(_ShockGridIID):
         self,
         params: MappingProxyType[str, float | FloatND],
         key: Array,
-    ) -> Float1D:
+    ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)
         component = jax.random.bernoulli(key1, params["p1"])
         normal = jax.random.normal(key2)

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -13,7 +13,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat
+from lcm.typing import Float1D, FloatND, IntND, KeyArray, ScalarFloat
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -44,12 +44,12 @@ class Uniform(_ShockGridIID):
     stop: float | int | None = None
     """Upper bound of the uniform distribution."""
 
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         return jnp.linspace(
             start=kwargs["start"], stop=kwargs["stop"], num=self.n_points
         )
 
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:  # noqa: ARG002
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:  # noqa: ARG002
         n_points = self.n_points
         return jnp.full((n_points, n_points), fill_value=1 / n_points)
 
@@ -99,7 +99,7 @@ class Normal(_ShockGridIID):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -112,7 +112,7 @@ class Normal(_ShockGridIID):
         x_max = mu + n_std * sigma
         return jnp.linspace(start=x_min, stop=x_max, num=n_points)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -167,7 +167,7 @@ class LogNormal(_ShockGridIID):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -178,7 +178,7 @@ class LogNormal(_ShockGridIID):
         n_std = kwargs["n_std"]
         return jnp.exp(jnp.linspace(mu - n_std * sigma, mu + n_std * sigma, n_points))
 
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -238,7 +238,7 @@ class NormalMixture(_ShockGridIID):
     sigma2: float | int | None = None
     """Standard deviation of the second mixture component."""
 
-    def compute_gridpoints(self, **kwargs: float | FloatND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]
@@ -253,7 +253,7 @@ class NormalMixture(_ShockGridIID):
             mean_eps - n_std * std_eps, mean_eps + n_std * std_eps, n_points
         )
 
-    def compute_transition_probs(self, **kwargs: float | FloatND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -23,7 +23,7 @@ class _ShockGridIID(_ShockGrid):
     @abstractmethod
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
     ) -> ScalarFloat: ...
 
@@ -44,18 +44,18 @@ class Uniform(_ShockGridIID):
     stop: float | int | None = None
     """Upper bound of the uniform distribution."""
 
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         return jnp.linspace(
             start=kwargs["start"], stop=kwargs["stop"], num=self.n_points
         )
 
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:  # noqa: ARG002
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:  # noqa: ARG002
         n_points = self.n_points
         return jnp.full((n_points, n_points), fill_value=1 / n_points)
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
     ) -> ScalarFloat:
         return jax.random.uniform(
@@ -99,7 +99,7 @@ class Normal(_ShockGridIID):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -112,7 +112,7 @@ class Normal(_ShockGridIID):
         x_max = mu + n_std * sigma
         return jnp.linspace(start=x_min, stop=x_max, num=n_points)
 
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -132,7 +132,7 @@ class Normal(_ShockGridIID):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
     ) -> ScalarFloat:
         return params["mu"] + params["sigma"] * jax.random.normal(key=key)
@@ -167,7 +167,7 @@ class LogNormal(_ShockGridIID):
             exclude = exclude | {"n_std"}
         return tuple(f.name for f in fields(self) if f.name not in exclude)
 
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -178,7 +178,7 @@ class LogNormal(_ShockGridIID):
         n_std = kwargs["n_std"]
         return jnp.exp(jnp.linspace(mu - n_std * sigma, mu + n_std * sigma, n_points))
 
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
         n_points = self.n_points
         mu, sigma = kwargs["mu"], kwargs["sigma"]
         if self.gauss_hermite:
@@ -198,7 +198,7 @@ class LogNormal(_ShockGridIID):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
     ) -> ScalarFloat:
         return jnp.exp(params["mu"] + params["sigma"] * jax.random.normal(key=key))
@@ -238,7 +238,7 @@ class NormalMixture(_ShockGridIID):
     sigma2: float | int | None = None
     """Standard deviation of the second mixture component."""
 
-    def compute_gridpoints(self, **kwargs: float | FloatND | IntND) -> Float1D:
+    def compute_gridpoints(self, **kwargs: FloatND | IntND) -> Float1D:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]
@@ -253,7 +253,7 @@ class NormalMixture(_ShockGridIID):
             mean_eps - n_std * std_eps, mean_eps + n_std * std_eps, n_points
         )
 
-    def compute_transition_probs(self, **kwargs: float | FloatND | IntND) -> FloatND:
+    def compute_transition_probs(self, **kwargs: FloatND | IntND) -> FloatND:
         n_points = self.n_points
         n_std = kwargs["n_std"]
         p1, mu1, sigma1 = kwargs["p1"], kwargs["mu1"], kwargs["sigma1"]
@@ -283,7 +283,7 @@ class NormalMixture(_ShockGridIID):
 
     def draw_shock(
         self,
-        params: MappingProxyType[str, float | FloatND],
+        params: MappingProxyType[str, FloatND | IntND],
         key: KeyArray,
     ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -4,7 +4,6 @@ from types import MappingProxyType
 
 import jax
 import jax.numpy as jnp
-from jax import Array
 from jax.scipy.stats.norm import cdf
 
 from lcm._beartype_conf import GRID_CONF, beartype_init
@@ -14,7 +13,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, ScalarFloat
+from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -25,7 +24,7 @@ class _ShockGridIID(_ShockGrid):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
     ) -> ScalarFloat: ...
 
 
@@ -57,7 +56,7 @@ class Uniform(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
     ) -> ScalarFloat:
         return jax.random.uniform(
             key=key, minval=params["start"], maxval=params["stop"]
@@ -134,7 +133,7 @@ class Normal(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
     ) -> ScalarFloat:
         return params["mu"] + params["sigma"] * jax.random.normal(key=key)
 
@@ -200,7 +199,7 @@ class LogNormal(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
     ) -> ScalarFloat:
         return jnp.exp(params["mu"] + params["sigma"] * jax.random.normal(key=key))
 
@@ -285,7 +284,7 @@ class NormalMixture(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, float | FloatND],
-        key: Array,
+        key: KeyArray,
     ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)
         component = jax.random.bernoulli(key1, params["p1"])

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -6,7 +6,6 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.stats.norm import cdf
 
-from lcm._beartype_conf import GRID_CONF, beartype_init
 from lcm.shocks._base import (
     _gauss_hermite_normal,
     _mixture_cdf,
@@ -28,7 +27,6 @@ class _ShockGridIID(_ShockGrid):
     ) -> ScalarFloat: ...
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class Uniform(_ShockGridIID):
     r"""Discretized iid uniform shock: $U(\text{start}, \text{stop})$.
@@ -63,7 +61,6 @@ class Uniform(_ShockGridIID):
         )
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class Normal(_ShockGridIID):
     r"""Discretized iid normal shock: $N(\mu_\varepsilon, \sigma_\varepsilon^2)$.
@@ -138,7 +135,6 @@ class Normal(_ShockGridIID):
         return params["mu"] + params["sigma"] * jax.random.normal(key=key)
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class LogNormal(_ShockGridIID):
     r"""Discretized iid log-normal shock: $\ln X \sim N(\mu, \sigma^2)$."""
@@ -204,7 +200,6 @@ class LogNormal(_ShockGridIID):
         return jnp.exp(params["mu"] + params["sigma"] * jax.random.normal(key=key))
 
 
-@beartype_init(GRID_CONF)
 @dataclass(frozen=True, kw_only=True)
 class NormalMixture(_ShockGridIID):
     r"""Discretized IID normal-mixture shock.

--- a/src/lcm/shocks/iid.py
+++ b/src/lcm/shocks/iid.py
@@ -13,7 +13,7 @@ from lcm.shocks._base import (
     _ShockGrid,
     _validate_gauss_hermite_grid,
 )
-from lcm.typing import Float1D, FloatND, KeyArray, ScalarFloat, ScalarInt
+from lcm.typing import Float1D, FloatND, PRNGKeyND, ScalarFloat, ScalarInt
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -24,7 +24,7 @@ class _ShockGridIID(_ShockGrid):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
     ) -> ScalarFloat: ...
 
 
@@ -56,7 +56,7 @@ class Uniform(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
     ) -> ScalarFloat:
         return jax.random.uniform(
             key=key, minval=params["start"], maxval=params["stop"]
@@ -133,7 +133,7 @@ class Normal(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
     ) -> ScalarFloat:
         return params["mu"] + params["sigma"] * jax.random.normal(key=key)
 
@@ -199,7 +199,7 @@ class LogNormal(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
     ) -> ScalarFloat:
         return jnp.exp(params["mu"] + params["sigma"] * jax.random.normal(key=key))
 
@@ -284,7 +284,7 @@ class NormalMixture(_ShockGridIID):
     def draw_shock(
         self,
         params: MappingProxyType[str, ScalarFloat | ScalarInt],
-        key: KeyArray,
+        key: PRNGKeyND,
     ) -> ScalarFloat:
         key1, key2 = jax.random.split(key)
         component = jax.random.bernoulli(key1, params["p1"])

--- a/src/lcm/simulation/compile.py
+++ b/src/lcm/simulation/compile.py
@@ -21,7 +21,6 @@ from types import MappingProxyType
 import jax
 import jax.numpy as jnp
 from dags.tree import qname_from_tree_path
-from jax import Array
 
 from lcm.ages import AgeGrid
 from lcm.interfaces import InternalRegime
@@ -32,7 +31,9 @@ from lcm.solution.solve_brute import (
 )
 from lcm.typing import (
     FlatRegimeParams,
+    FloatND,
     InternalParams,
+    IntND,
     RegimeName,
 )
 from lcm.utils.logging import format_duration
@@ -340,7 +341,7 @@ def _build_argmax_args(
     ages: AgeGrid,
     period: int,
     n_subjects: int,
-    next_regime_to_V_arr: MappingProxyType[RegimeName, Array],
+    next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
 ) -> dict[str, object]:
     base = internal_regime.state_action_space(regime_params=regime_params)
     subject_states = _subject_shape_arrays(base.states, n_subjects=n_subjects)
@@ -419,10 +420,10 @@ def _build_crtp_args(
 
 
 def _subject_shape_arrays(
-    base_arrays: Mapping[str, Array],
+    base_arrays: Mapping[str, FloatND | IntND],
     *,
     n_subjects: int,
-) -> dict[str, Array]:
+) -> dict[str, FloatND | IntND]:
     """Return zeros of shape `(n_subjects,)` mirroring each base array's dtype.
 
     With `build_initial_states` casting discrete states to the grid dtype,

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -27,7 +27,9 @@ from lcm.interfaces import InternalRegime
 from lcm.regime_building.Q_and_F import _get_feasibility
 from lcm.typing import (
     ActionName,
+    BoolND,
     FlatRegimeParams,
+    Int1D,
     InternalParams,
     RegimeIdsToNames,
     RegimeName,
@@ -240,7 +242,7 @@ def _format_missing_states_message(missing: set[str], required: set[str]) -> str
 def _collect_state_name_errors(
     *,
     initial_states: Mapping[StateName, Array],
-    regime_id_arr: Array,
+    regime_id_arr: Int1D,
     regime_ids_to_names: RegimeIdsToNames,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     valid_regime_names: set[RegimeName],
@@ -298,7 +300,7 @@ def _collect_state_name_errors(
 def _collect_structural_errors(
     *,
     initial_states: Mapping[StateName, Array],
-    regime_id_arr: Array,
+    regime_id_arr: Int1D,
     regime_ids_to_names: RegimeIdsToNames,
     regime_names_to_ids: RegimeNamesToIds,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
@@ -398,7 +400,7 @@ def _collect_structural_errors(
 def _collect_feasibility_errors(
     *,
     initial_states: Mapping[StateName, Array],
-    regime_id_arr: Array,
+    regime_id_arr: Int1D,
     regime_names_to_ids: RegimeNamesToIds,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     internal_params: InternalParams,
@@ -450,7 +452,7 @@ def _validate_discrete_state_values(
     *,
     initial_states: Mapping[StateName, Array],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
-    regime_id_arr: Array,
+    regime_id_arr: Int1D,
     regime_names_to_ids: RegimeNamesToIds,
 ) -> None:
     """Validate that discrete state values are valid codes.
@@ -512,12 +514,12 @@ _BYTES_PER_ACTION_ELEMENT = 4
 
 def _batched_feasibility_check(
     *,
-    feasibility_func: Callable[..., Array],
+    feasibility_func: Callable[..., BoolND],
     subject_states: Mapping[StateName, Array],
     action_kwargs: Mapping[str, Array],
     filtered_params: Mapping[str, object],
     flat_actions: Mapping[ActionName, Array],
-) -> Array:
+) -> BoolND:
     """Check feasibility for all subjects, batching to avoid OOM.
 
     Vmaps over action combos individually (like solve/simulate do) so each
@@ -542,10 +544,10 @@ def _batched_feasibility_check(
         def _is_combo_feasible(
             action_kw: dict[str, Array],
             subject_kw: dict[str, Array],
-        ) -> Array:
+        ) -> BoolND:
             return feasibility_func(**action_kw, **subject_kw, **filtered_params)
 
-        def _is_any_action_feasible(per_subject_kwargs: dict[str, Array]) -> Array:
+        def _is_any_action_feasible(per_subject_kwargs: dict[str, Array]) -> BoolND:
             per_combo = jax.vmap(_is_combo_feasible, in_axes=(0, None))(
                 action_kwargs,
                 per_subject_kwargs,
@@ -554,7 +556,7 @@ def _batched_feasibility_check(
 
     else:
 
-        def _is_any_action_feasible(per_subject_kwargs: dict[str, Array]) -> Array:
+        def _is_any_action_feasible(per_subject_kwargs: dict[str, Array]) -> BoolND:
             return jnp.any(feasibility_func(**per_subject_kwargs, **filtered_params))
 
     vmapped_check = jax.vmap(_is_any_action_feasible)
@@ -569,7 +571,7 @@ def _batched_feasibility_check(
     if n_subjects <= batch_size:
         return vmapped_check(subject_states)
 
-    results: list[Array] = []
+    results: list[BoolND] = []
     for start in range(0, n_subjects, batch_size):
         end = min(start + batch_size, n_subjects)
         batch = {k: v[start:end] for k, v in subject_states.items()}
@@ -672,7 +674,7 @@ def _check_regime_feasibility(  # noqa: C901
         # No per-subject varying states: feasibility is identical for all subjects.
         if action_kwargs:
 
-            def _check_combo(action_kw: dict[str, Array]) -> Array:
+            def _check_combo(action_kw: dict[str, Array]) -> BoolND:
                 return feasibility_func(**action_kw, **filtered_params)  # ty: ignore[invalid-argument-type]
 
             result = jax.vmap(_check_combo)(action_kwargs)
@@ -704,14 +706,14 @@ def _check_regime_feasibility(  # noqa: C901
 
 def _admits_any_action(
     *,
-    feasibility_func: Callable[..., Array],
+    feasibility_func: Callable[..., BoolND],
     action_kwargs: Mapping[str, Array],
     params: Mapping[str, object],
 ) -> bool:
     """Return True iff the feasibility function admits ≥ 1 action under params."""
     if action_kwargs:
 
-        def _check_combo(action_kw: dict[str, Array]) -> Array:
+        def _check_combo(action_kw: dict[str, Array]) -> BoolND:
             return feasibility_func(**action_kw, **params)
 
         per_combo = jax.vmap(_check_combo)(action_kwargs)
@@ -725,7 +727,7 @@ def _per_constraint_feasibility(
     subject_states: Mapping[StateName, Array],
     regime_params: Mapping[str, object],
     flat_actions: Mapping[ActionName, Array],
-    idx_arr: Array,
+    idx_arr: Int1D,
     infeasible_indices: Sequence[int],
 ) -> dict[str, np.ndarray]:
     """Per-constraint feasibility for the infeasible subjects.

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -7,7 +7,7 @@ Consolidates initial condition construction (`build_initial_states`) and validat
 
 from collections.abc import Callable, Mapping, Sequence
 from types import MappingProxyType
-from typing import Never, cast
+from typing import NoReturn, cast
 
 import jax
 import numpy as np
@@ -769,7 +769,7 @@ def _raise_feasibility_type_error(
     regime_name: RegimeName,
     internal_regime: InternalRegime,
     subject_states: dict[StateName, Array],
-) -> Never:
+) -> NoReturn:
     """Re-raise a TypeError from feasibility checking with diagnostic context.
 
     Args:

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -37,7 +37,6 @@ from lcm.typing import (
     RegimeNamesToIds,
     StateName,
     StatesPerRegime,
-    UserInitialConditions,
 )
 from lcm.utils.containers import invert_regime_ids
 from lcm.utils.functools import get_union_of_args
@@ -50,7 +49,7 @@ MISSING_CAT_CODE = jnp.iinfo(jnp.int32).min
 
 def build_initial_states(
     *,
-    initial_states: UserInitialConditions,
+    initial_states: Mapping[str, FloatND | IntND],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
 ) -> StatesPerRegime:
     """Build the regime-keyed state carrier from user-provided initial states.
@@ -127,7 +126,7 @@ def build_initial_states(
 
 def validate_initial_conditions(
     *,
-    initial_conditions: UserInitialConditions,
+    initial_conditions: Mapping[str, FloatND | IntND],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     regime_names_to_ids: RegimeNamesToIds,
     internal_params: InternalParams,
@@ -245,7 +244,7 @@ def _format_missing_states_message(missing: set[str], required: set[str]) -> str
 
 def _collect_state_name_errors(
     *,
-    initial_states: UserInitialConditions,
+    initial_states: Mapping[str, FloatND | IntND],
     regime_id_arr: Int1D,
     regime_ids_to_names: RegimeIdsToNames,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
@@ -303,7 +302,7 @@ def _collect_state_name_errors(
 
 def _collect_structural_errors(
     *,
-    initial_states: UserInitialConditions,
+    initial_states: Mapping[str, FloatND | IntND],
     regime_id_arr: Int1D,
     regime_ids_to_names: RegimeIdsToNames,
     regime_names_to_ids: RegimeNamesToIds,
@@ -403,7 +402,7 @@ def _collect_structural_errors(
 
 def _collect_feasibility_errors(
     *,
-    initial_states: UserInitialConditions,
+    initial_states: Mapping[str, FloatND | IntND],
     regime_id_arr: Int1D,
     regime_names_to_ids: RegimeNamesToIds,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
@@ -454,7 +453,7 @@ def _collect_feasibility_errors(
 
 def _validate_discrete_state_values(
     *,
-    initial_states: UserInitialConditions,
+    initial_states: Mapping[str, FloatND | IntND],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     regime_id_arr: Int1D,
     regime_names_to_ids: RegimeNamesToIds,
@@ -519,7 +518,7 @@ _BYTES_PER_ACTION_ELEMENT = 4
 def _batched_feasibility_check(
     *,
     feasibility_func: Callable[..., BoolND],
-    subject_states: UserInitialConditions,
+    subject_states: Mapping[str, FloatND | IntND],
     action_kwargs: Mapping[str, FloatND | IntND],
     filtered_params: Mapping[str, object],
     flat_actions: Mapping[ActionName, FloatND | IntND],
@@ -591,7 +590,7 @@ def _check_regime_feasibility(  # noqa: C901
     *,
     internal_regime: InternalRegime,
     regime_name: RegimeName,
-    initial_states: UserInitialConditions,
+    initial_states: Mapping[str, FloatND | IntND],
     subject_indices: list[int],
     regime_params: Mapping[str, object],
     ages: AgeGrid,
@@ -732,7 +731,7 @@ def _admits_any_action(
 def _per_constraint_feasibility(
     *,
     internal_regime: InternalRegime,
-    subject_states: UserInitialConditions,
+    subject_states: Mapping[str, FloatND | IntND],
     regime_params: Mapping[str, object],
     flat_actions: Mapping[ActionName, FloatND | IntND],
     idx_arr: Int1D,
@@ -845,7 +844,7 @@ def _format_infeasibility_message(
     infeasible_indices: Sequence[int],
     internal_regime: InternalRegime,
     regime_name: RegimeName,
-    initial_states: UserInitialConditions,
+    initial_states: Mapping[str, FloatND | IntND],
     state_names: Sequence[str],
     per_constraint_admits_any: Mapping[str, np.ndarray],
 ) -> str:

--- a/src/lcm/simulation/initial_conditions.py
+++ b/src/lcm/simulation/initial_conditions.py
@@ -12,7 +12,6 @@ from typing import NoReturn, cast
 import jax
 import numpy as np
 import pandas as pd
-from jax import Array
 from jax import numpy as jnp
 
 from lcm.ages import PSEUDO_STATE_NAMES, AgeGrid
@@ -29,13 +28,16 @@ from lcm.typing import (
     ActionName,
     BoolND,
     FlatRegimeParams,
+    FloatND,
     Int1D,
     InternalParams,
+    IntND,
     RegimeIdsToNames,
     RegimeName,
     RegimeNamesToIds,
     StateName,
     StatesPerRegime,
+    UserInitialConditions,
 )
 from lcm.utils.containers import invert_regime_ids
 from lcm.utils.functools import get_union_of_args
@@ -48,7 +50,7 @@ MISSING_CAT_CODE = jnp.iinfo(jnp.int32).min
 
 def build_initial_states(
     *,
-    initial_states: Mapping[StateName, Array],
+    initial_states: UserInitialConditions,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
 ) -> StatesPerRegime:
     """Build the regime-keyed state carrier from user-provided initial states.
@@ -68,10 +70,12 @@ def build_initial_states(
 
     """
     n_subjects = len(next(iter(initial_states.values())))
-    states_per_regime: dict[RegimeName, MappingProxyType[StateName, Array]] = {}
+    states_per_regime: dict[
+        RegimeName, MappingProxyType[StateName, FloatND | IntND]
+    ] = {}
 
     for regime_name, internal_regime in internal_regimes.items():
-        regime_states: dict[StateName, Array] = {}
+        regime_states: dict[StateName, FloatND | IntND] = {}
         # Logic for distribution of subjects over devices
         distributed = any(grid.distributed for grid in internal_regime.grids.values())
         devices = jax.devices()
@@ -123,7 +127,7 @@ def build_initial_states(
 
 def validate_initial_conditions(
     *,
-    initial_conditions: Mapping[str, Array],
+    initial_conditions: UserInitialConditions,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     regime_names_to_ids: RegimeNamesToIds,
     internal_params: InternalParams,
@@ -241,7 +245,7 @@ def _format_missing_states_message(missing: set[str], required: set[str]) -> str
 
 def _collect_state_name_errors(
     *,
-    initial_states: Mapping[StateName, Array],
+    initial_states: UserInitialConditions,
     regime_id_arr: Int1D,
     regime_ids_to_names: RegimeIdsToNames,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
@@ -299,7 +303,7 @@ def _collect_state_name_errors(
 
 def _collect_structural_errors(
     *,
-    initial_states: Mapping[StateName, Array],
+    initial_states: UserInitialConditions,
     regime_id_arr: Int1D,
     regime_ids_to_names: RegimeIdsToNames,
     regime_names_to_ids: RegimeNamesToIds,
@@ -399,7 +403,7 @@ def _collect_structural_errors(
 
 def _collect_feasibility_errors(
     *,
-    initial_states: Mapping[StateName, Array],
+    initial_states: UserInitialConditions,
     regime_id_arr: Int1D,
     regime_names_to_ids: RegimeNamesToIds,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
@@ -450,7 +454,7 @@ def _collect_feasibility_errors(
 
 def _validate_discrete_state_values(
     *,
-    initial_states: Mapping[StateName, Array],
+    initial_states: UserInitialConditions,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     regime_id_arr: Int1D,
     regime_names_to_ids: RegimeNamesToIds,
@@ -515,10 +519,10 @@ _BYTES_PER_ACTION_ELEMENT = 4
 def _batched_feasibility_check(
     *,
     feasibility_func: Callable[..., BoolND],
-    subject_states: Mapping[StateName, Array],
-    action_kwargs: Mapping[str, Array],
+    subject_states: UserInitialConditions,
+    action_kwargs: Mapping[str, FloatND | IntND],
     filtered_params: Mapping[str, object],
-    flat_actions: Mapping[ActionName, Array],
+    flat_actions: Mapping[ActionName, FloatND | IntND],
 ) -> BoolND:
     """Check feasibility for all subjects, batching to avoid OOM.
 
@@ -542,12 +546,14 @@ def _batched_feasibility_check(
     if action_kwargs:
 
         def _is_combo_feasible(
-            action_kw: dict[str, Array],
-            subject_kw: dict[str, Array],
+            action_kw: dict[str, FloatND | IntND],
+            subject_kw: dict[str, FloatND | IntND],
         ) -> BoolND:
             return feasibility_func(**action_kw, **subject_kw, **filtered_params)
 
-        def _is_any_action_feasible(per_subject_kwargs: dict[str, Array]) -> BoolND:
+        def _is_any_action_feasible(
+            per_subject_kwargs: dict[str, FloatND | IntND],
+        ) -> BoolND:
             per_combo = jax.vmap(_is_combo_feasible, in_axes=(0, None))(
                 action_kwargs,
                 per_subject_kwargs,
@@ -556,7 +562,9 @@ def _batched_feasibility_check(
 
     else:
 
-        def _is_any_action_feasible(per_subject_kwargs: dict[str, Array]) -> BoolND:
+        def _is_any_action_feasible(
+            per_subject_kwargs: dict[str, FloatND | IntND],
+        ) -> BoolND:
             return jnp.any(feasibility_func(**per_subject_kwargs, **filtered_params))
 
     vmapped_check = jax.vmap(_is_any_action_feasible)
@@ -583,7 +591,7 @@ def _check_regime_feasibility(  # noqa: C901
     *,
     internal_regime: InternalRegime,
     regime_name: RegimeName,
-    initial_states: Mapping[StateName, Array],
+    initial_states: UserInitialConditions,
     subject_indices: list[int],
     regime_params: Mapping[str, object],
     ages: AgeGrid,
@@ -619,7 +627,7 @@ def _check_regime_feasibility(  # noqa: C901
     state_action_space = internal_regime.state_action_space(
         regime_params=cast("FlatRegimeParams", MappingProxyType(dict(regime_params))),
     )
-    action_grids: dict[str, Array] = {
+    action_grids: dict[str, FloatND | IntND] = {
         **state_action_space.discrete_actions,
         **state_action_space.continuous_actions,
     }
@@ -635,7 +643,7 @@ def _check_regime_feasibility(  # noqa: C901
 
     # Build per-subject state arrays
     idx_arr = jnp.array(subject_indices)
-    subject_states: dict[StateName, Array] = {}
+    subject_states: dict[StateName, FloatND | IntND] = {}
     for sn in state_names:
         if sn in accepted:
             subject_states[sn] = initial_states[sn][idx_arr]
@@ -648,7 +656,7 @@ def _check_regime_feasibility(  # noqa: C901
         )
 
     # Split actions and params — actions are vmapped over, params are not
-    action_kwargs: dict[str, Array] = {
+    action_kwargs: dict[str, FloatND | IntND] = {
         k: v for k, v in flat_actions.items() if k in accepted
     }
 
@@ -674,7 +682,7 @@ def _check_regime_feasibility(  # noqa: C901
         # No per-subject varying states: feasibility is identical for all subjects.
         if action_kwargs:
 
-            def _check_combo(action_kw: dict[str, Array]) -> BoolND:
+            def _check_combo(action_kw: dict[str, FloatND | IntND]) -> BoolND:
                 return feasibility_func(**action_kw, **filtered_params)  # ty: ignore[invalid-argument-type]
 
             result = jax.vmap(_check_combo)(action_kwargs)
@@ -707,13 +715,13 @@ def _check_regime_feasibility(  # noqa: C901
 def _admits_any_action(
     *,
     feasibility_func: Callable[..., BoolND],
-    action_kwargs: Mapping[str, Array],
+    action_kwargs: Mapping[str, FloatND | IntND],
     params: Mapping[str, object],
 ) -> bool:
     """Return True iff the feasibility function admits ≥ 1 action under params."""
     if action_kwargs:
 
-        def _check_combo(action_kw: dict[str, Array]) -> BoolND:
+        def _check_combo(action_kw: dict[str, FloatND | IntND]) -> BoolND:
             return feasibility_func(**action_kw, **params)
 
         per_combo = jax.vmap(_check_combo)(action_kwargs)
@@ -724,9 +732,9 @@ def _admits_any_action(
 def _per_constraint_feasibility(
     *,
     internal_regime: InternalRegime,
-    subject_states: Mapping[StateName, Array],
+    subject_states: UserInitialConditions,
     regime_params: Mapping[str, object],
-    flat_actions: Mapping[ActionName, Array],
+    flat_actions: Mapping[ActionName, FloatND | IntND],
     idx_arr: Int1D,
     infeasible_indices: Sequence[int],
 ) -> dict[str, np.ndarray]:
@@ -791,7 +799,7 @@ def _raise_feasibility_type_error(
     exc: TypeError,
     regime_name: RegimeName,
     internal_regime: InternalRegime,
-    subject_states: dict[StateName, Array],
+    subject_states: dict[StateName, FloatND | IntND],
 ) -> NoReturn:
     """Re-raise a TypeError from feasibility checking with diagnostic context.
 
@@ -837,7 +845,7 @@ def _format_infeasibility_message(
     infeasible_indices: Sequence[int],
     internal_regime: InternalRegime,
     regime_name: RegimeName,
-    initial_states: Mapping[StateName, Array],
+    initial_states: UserInitialConditions,
     state_names: Sequence[str],
     per_constraint_admits_any: Mapping[str, np.ndarray],
 ) -> str:
@@ -904,8 +912,8 @@ def _format_infeasibility_message(
 def _build_flat_action_grid(
     *,
     action_names: list[ActionName],
-    grids: MappingProxyType[str, Array],
-) -> dict[str, Array]:
+    grids: MappingProxyType[str, FloatND | IntND],
+) -> dict[str, FloatND | IntND]:
     """Build a flat array of all action combinations from action grids.
 
     Args:

--- a/src/lcm/simulation/random.py
+++ b/src/lcm/simulation/random.py
@@ -2,12 +2,12 @@ import os
 
 import jax
 
-from lcm.typing import KeyArray
+from lcm.typing import PRNGKeyND
 
 
 def generate_simulation_keys(
-    *, key: KeyArray, names: list[str], n_initial_states: int
-) -> tuple[KeyArray, dict[str, KeyArray]]:
+    *, key: PRNGKeyND, names: list[str], n_initial_states: int
+) -> tuple[PRNGKeyND, dict[str, PRNGKeyND]]:
     """Generate pseudo-random number generator keys (PRNG keys) for simulation.
 
     PRNG keys in JAX are immutable objects used to control random number generation.

--- a/src/lcm/simulation/random.py
+++ b/src/lcm/simulation/random.py
@@ -1,12 +1,13 @@
 import os
 
 import jax
-from jax import Array
+
+from lcm.typing import KeyArray
 
 
 def generate_simulation_keys(
-    *, key: Array, names: list[str], n_initial_states: int
-) -> tuple[Array, dict[str, Array]]:
+    *, key: KeyArray, names: list[str], n_initial_states: int
+) -> tuple[KeyArray, dict[str, KeyArray]]:
     """Generate pseudo-random number generator keys (PRNG keys) for simulation.
 
     PRNG keys in JAX are immutable objects used to control random number generation.

--- a/src/lcm/simulation/result.py
+++ b/src/lcm/simulation/result.py
@@ -12,7 +12,6 @@ import cloudpickle
 import jax.numpy as jnp
 import pandas as pd
 from dags import concatenate_functions
-from jax import Array
 
 from lcm.ages import AgeGrid
 from lcm.exceptions import InvalidAdditionalTargetsError
@@ -23,9 +22,11 @@ from lcm.regime import Regime
 from lcm.regime_building.processing import compute_merged_discrete_categories
 from lcm.typing import (
     ActionName,
+    BoolND,
     FlatRegimeParams,
     FloatND,
     InternalParams,
+    IntND,
     RegimeName,
     RegimeNamesToIds,
     StateName,
@@ -490,7 +491,9 @@ def _process_regime(
     ]
 
     # Concatenate and filter to in-regime subjects
-    data: dict[str, Array | Sequence[str]] = _concatenate_and_filter(period_dicts)  # ty: ignore[invalid-assignment]
+    data: dict[str, FloatND | IntND | BoolND | Sequence[str]] = _concatenate_and_filter(
+        period_dicts
+    )  # ty: ignore[invalid-assignment]
 
     # Add age column (computed from period using ages grid)
     data["age"] = ages.values[data["period"]]  # noqa: PD011
@@ -521,9 +524,9 @@ def _extract_period_data(
     period: int,
     regime_states: tuple[str, ...],
     regime_actions: tuple[str, ...],
-) -> dict[str, Array]:
+) -> dict[str, FloatND | IntND | BoolND]:
     """Extract data from a single period's simulation results."""
-    data: dict[str, Array] = {
+    data: dict[str, FloatND | IntND | BoolND] = {
         "subject_id": jnp.arange(len(result.in_regime)),
         "period": jnp.full_like(result.in_regime, period, dtype=jnp.int32),
         "_in_regime": result.in_regime,
@@ -541,7 +544,9 @@ def _extract_period_data(
     return data
 
 
-def _concatenate_and_filter(period_dicts: list[dict[str, Array]]) -> dict[str, Array]:
+def _concatenate_and_filter(
+    period_dicts: list[dict[str, FloatND | IntND | BoolND]],
+) -> dict[str, FloatND | IntND | BoolND]:
     """Concatenate period data and filter to in-regime subjects."""
     keys = [k for k in period_dicts[0] if k != "_in_regime"]
 
@@ -745,11 +750,11 @@ def _codes_to_categorical(
 
 def _compute_targets(
     *,
-    data: dict[str, Array | Sequence[str]],
+    data: dict[str, FloatND | IntND | BoolND | Sequence[str]],
     targets: list[str],
     internal_regime: InternalRegime,
     regime_params: FlatRegimeParams,
-) -> dict[str, Array]:
+) -> dict[str, FloatND | IntND | BoolND]:
     """Compute additional targets for a regime."""
     functions_pool = _build_functions_pool(internal_regime)
     target_func = _create_target_function(

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -25,10 +25,12 @@ from lcm.simulation.transitions import (
     create_regime_state_action_space,
 )
 from lcm.typing import (
+    Float1D,
     FloatND,
     Int1D,
     InternalParams,
     IntND,
+    KeyArray,
     RegimeName,
     RegimeNamesToIds,
     ScalarFloat,
@@ -215,8 +217,8 @@ def _simulate_regime_in_period(
     internal_params: InternalParams,
     regime_names_to_ids: RegimeNamesToIds,
     active_regimes_next_period: tuple[RegimeName, ...],
-    key: Array,
-) -> tuple[PeriodRegimeSimulationData, StatesPerRegime, Int1D, Array]:
+    key: KeyArray,
+) -> tuple[PeriodRegimeSimulationData, StatesPerRegime, Int1D, KeyArray]:
     """Simulate one regime for one period.
 
     This function processes all subjects in a given regime for a single period,
@@ -369,7 +371,7 @@ vmapped_unravel_index = vmap(jnp.unravel_index, in_axes=(0, None))
 
 def _compute_starting_periods(
     *,
-    initial_ages: Array,
+    initial_ages: Float1D,
     ages: AgeGrid,
 ) -> Int1D:
     """Convert per-subject initial ages to starting period indices.

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -36,7 +36,6 @@ from lcm.typing import (
     ScalarFloat,
     ScalarInt,
     StatesPerRegime,
-    UserInitialConditions,
 )
 from lcm.utils.containers import invert_regime_ids
 from lcm.utils.error_handling import validate_V
@@ -52,7 +51,7 @@ from lcm.utils.logging import (
 def simulate(
     *,
     internal_params: InternalParams,
-    initial_conditions: UserInitialConditions,
+    initial_conditions: Mapping[str, FloatND | IntND],
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     regime_names_to_ids: RegimeNamesToIds,
     logger: logging.Logger,

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -30,7 +30,7 @@ from lcm.typing import (
     Int1D,
     InternalParams,
     IntND,
-    KeyArray,
+    PRNGKeyND,
     RegimeName,
     RegimeNamesToIds,
     ScalarFloat,
@@ -217,8 +217,8 @@ def _simulate_regime_in_period(
     internal_params: InternalParams,
     regime_names_to_ids: RegimeNamesToIds,
     active_regimes_next_period: tuple[RegimeName, ...],
-    key: KeyArray,
-) -> tuple[PeriodRegimeSimulationData, StatesPerRegime, Int1D, KeyArray]:
+    key: PRNGKeyND,
+) -> tuple[PeriodRegimeSimulationData, StatesPerRegime, Int1D, PRNGKeyND]:
     """Simulate one regime for one period.
 
     This function processes all subjects in a given regime for a single period,

--- a/src/lcm/simulation/simulate.py
+++ b/src/lcm/simulation/simulate.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 import jax
 import jax.numpy as jnp
 import pandas as pd
-from jax import Array, vmap
+from jax import vmap
 
 from lcm.ages import AgeGrid
 from lcm.interfaces import (
@@ -36,6 +36,7 @@ from lcm.typing import (
     ScalarFloat,
     ScalarInt,
     StatesPerRegime,
+    UserInitialConditions,
 )
 from lcm.utils.containers import invert_regime_ids
 from lcm.utils.error_handling import validate_V
@@ -51,7 +52,7 @@ from lcm.utils.logging import (
 def simulate(
     *,
     internal_params: InternalParams,
-    initial_conditions: Mapping[str, Array],
+    initial_conditions: UserInitialConditions,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     regime_names_to_ids: RegimeNamesToIds,
     logger: logging.Logger,
@@ -337,8 +338,8 @@ def _simulate_regime_in_period(
 def _lookup_values_from_indices(
     *,
     flat_indices: IntND,
-    grids: MappingProxyType[str, Array],
-) -> MappingProxyType[str, Array]:
+    grids: MappingProxyType[str, FloatND | IntND],
+) -> MappingProxyType[str, FloatND | IntND]:
     """Retrieve values from indices.
 
     Args:

--- a/src/lcm/simulation/transitions.py
+++ b/src/lcm/simulation/transitions.py
@@ -10,8 +10,8 @@ from types import MappingProxyType
 
 import jax
 from dags.tree import qname_from_tree_path
-from jax import Array, vmap
 from jax import numpy as jnp
+from jax import vmap
 
 from lcm.interfaces import InternalRegime, StateActionSpace
 from lcm.simulation.random import generate_simulation_keys
@@ -23,6 +23,7 @@ from lcm.typing import (
     Float1D,
     FloatND,
     Int1D,
+    IntND,
     KeyArray,
     RegimeName,
     RegimeNamesToIds,
@@ -72,7 +73,7 @@ def create_regime_state_action_space(
 def calculate_next_states(
     *,
     internal_regime: InternalRegime,
-    optimal_actions: MappingProxyType[ActionName, Array],
+    optimal_actions: MappingProxyType[ActionName, FloatND | IntND],
     period: int,
     age: ScalarInt | ScalarFloat,
     regime_params: FlatRegimeParams,
@@ -162,7 +163,7 @@ def calculate_next_regime_membership(
     *,
     internal_regime: InternalRegime,
     state_action_space: StateActionSpace,
-    optimal_actions: MappingProxyType[ActionName, Array],
+    optimal_actions: MappingProxyType[ActionName, FloatND | IntND],
     period: int,
     age: ScalarInt | ScalarFloat,
     regime_params: FlatRegimeParams,
@@ -301,7 +302,7 @@ def _advance_states_for_subjects(
         Updated carrier with next-period values written in for selected subjects.
 
     """
-    updated: dict[RegimeName, dict[StateName, Array]] = {
+    updated: dict[RegimeName, dict[StateName, FloatND | IntND]] = {
         regime_name: dict(regime_states)
         for regime_name, regime_states in states_per_regime.items()
     }

--- a/src/lcm/simulation/transitions.py
+++ b/src/lcm/simulation/transitions.py
@@ -24,7 +24,7 @@ from lcm.typing import (
     FloatND,
     Int1D,
     IntND,
-    KeyArray,
+    PRNGKeyND,
     RegimeName,
     RegimeNamesToIds,
     RegimeStates,
@@ -79,7 +79,7 @@ def calculate_next_states(
     regime_params: FlatRegimeParams,
     states_per_regime: StatesPerRegime,
     state_action_space: StateActionSpace,
-    key: KeyArray,
+    key: PRNGKeyND,
     subjects_in_regime: Bool1D,
 ) -> StatesPerRegime:
     """Calculate next period states for subjects in a regime.
@@ -170,7 +170,7 @@ def calculate_next_regime_membership(
     regime_names_to_ids: RegimeNamesToIds,
     new_subject_regime_ids: Int1D,
     active_regimes_next_period: tuple[RegimeName, ...],
-    key: KeyArray,
+    key: PRNGKeyND,
     subjects_in_regime: Bool1D,
 ) -> Int1D:
     """Calculate next period regime membership for subjects in a regime.
@@ -200,7 +200,7 @@ def calculate_next_regime_membership(
     """
     # Compute regime transition probabilities
     # ---------------------------------------------------------------------------------
-    regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
+    regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
         internal_regime.simulate_functions.compute_regime_transition_probs(  # ty: ignore[call-non-callable]
             **state_action_space.states,
             **optimal_actions,
@@ -236,7 +236,7 @@ def draw_key_from_dict(
     *,
     d: MappingProxyType[RegimeName, Float1D],
     regime_names_to_ids: RegimeNamesToIds,
-    keys: KeyArray,
+    keys: PRNGKeyND,
 ) -> Int1D:
     """Draw a random key from a dictionary of arrays.
 
@@ -260,7 +260,7 @@ def draw_key_from_dict(
     )
 
     def random_id(
-        key: KeyArray,
+        key: PRNGKeyND,
         p: Float1D,
     ) -> Int1D:
         return jax.random.choice(

--- a/src/lcm/simulation/transitions.py
+++ b/src/lcm/simulation/transitions.py
@@ -200,7 +200,7 @@ def calculate_next_regime_membership(
     """
     # Compute regime transition probabilities
     # ---------------------------------------------------------------------------------
-    regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
+    regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (
         internal_regime.simulate_functions.compute_regime_transition_probs(  # ty: ignore[call-non-callable]
             **state_action_space.states,
             **optimal_actions,

--- a/src/lcm/simulation/transitions.py
+++ b/src/lcm/simulation/transitions.py
@@ -20,7 +20,10 @@ from lcm.typing import (
     ActionName,
     Bool1D,
     FlatRegimeParams,
+    Float1D,
+    FloatND,
     Int1D,
+    KeyArray,
     RegimeName,
     RegimeNamesToIds,
     RegimeStates,
@@ -75,7 +78,7 @@ def calculate_next_states(
     regime_params: FlatRegimeParams,
     states_per_regime: StatesPerRegime,
     state_action_space: StateActionSpace,
-    key: Array,
+    key: KeyArray,
     subjects_in_regime: Bool1D,
 ) -> StatesPerRegime:
     """Calculate next period states for subjects in a regime.
@@ -166,7 +169,7 @@ def calculate_next_regime_membership(
     regime_names_to_ids: RegimeNamesToIds,
     new_subject_regime_ids: Int1D,
     active_regimes_next_period: tuple[RegimeName, ...],
-    key: Array,
+    key: KeyArray,
     subjects_in_regime: Bool1D,
 ) -> Int1D:
     """Calculate next period regime membership for subjects in a regime.
@@ -196,7 +199,7 @@ def calculate_next_regime_membership(
     """
     # Compute regime transition probabilities
     # ---------------------------------------------------------------------------------
-    regime_transition_probs: MappingProxyType[str, Array] = (  # ty: ignore[invalid-assignment]
+    regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
         internal_regime.simulate_functions.compute_regime_transition_probs(  # ty: ignore[call-non-callable]
             **state_action_space.states,
             **optimal_actions,
@@ -230,9 +233,9 @@ def calculate_next_regime_membership(
 
 def draw_key_from_dict(
     *,
-    d: MappingProxyType[RegimeName, Array],
+    d: MappingProxyType[RegimeName, Float1D],
     regime_names_to_ids: RegimeNamesToIds,
-    keys: Array,
+    keys: KeyArray,
 ) -> Int1D:
     """Draw a random key from a dictionary of arrays.
 
@@ -256,8 +259,8 @@ def draw_key_from_dict(
     )
 
     def random_id(
-        key: Array,
-        p: Array,
+        key: KeyArray,
+        p: Float1D,
     ) -> Int1D:
         return jax.random.choice(
             key,

--- a/src/lcm/solution/solve_brute.py
+++ b/src/lcm/solution/solve_brute.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import os
 import time
-from collections.abc import Callable, Hashable, Mapping
+from collections.abc import Callable, Hashable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -25,7 +25,7 @@ def solve(
     *,
     internal_params: InternalParams,
     ages: AgeGrid,
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     logger: logging.Logger,
     enable_jit: bool,
     max_compilation_workers: int | None = None,
@@ -235,7 +235,7 @@ def solve(
 
 def _compile_all_functions(
     *,
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     internal_params: InternalParams,
     ages: AgeGrid,
     next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
@@ -400,7 +400,7 @@ class _RegimeVTopology:
 
 def _get_regime_V_shapes_and_shardings(
     *,
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     internal_params: InternalParams,
 ) -> dict[RegimeName, _RegimeVTopology]:
     """Compute V-array shapes and shardings for every regime.
@@ -469,7 +469,7 @@ def _emit_post_loop_diagnostics(
     logger: logging.Logger,
     diagnostic_rows: list[_DiagnosticRow],
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     internal_params: InternalParams,
     running_any_nan: FloatND,
     running_any_inf: FloatND,
@@ -511,7 +511,7 @@ def _raise_first_nan_row(
     *,
     diagnostic_rows: list[_DiagnosticRow],
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     internal_params: InternalParams,
 ) -> None:
     """Find the first NaN-bearing (regime, period) and raise.
@@ -535,7 +535,7 @@ def _raise_at(
     *,
     row: _DiagnosticRow,
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     internal_params: InternalParams,
 ) -> None:
     """Run the enriched NaN diagnostic on a single offending row and raise."""
@@ -577,7 +577,7 @@ def _raise_at(
 def _reconstruct_next_regime_to_V_arr(
     *,
     period: int,
-    internal_regimes: Mapping[RegimeName, InternalRegime],
+    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
     internal_params: InternalParams,
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
 ) -> MappingProxyType[RegimeName, FloatND]:

--- a/src/lcm/solution/solve_brute.py
+++ b/src/lcm/solution/solve_brute.py
@@ -436,7 +436,7 @@ def _get_regime_V_shapes_and_shardings(
     return topology
 
 
-def _build_zero_V_arr(*, topology: _RegimeVTopology) -> jax.Array:
+def _build_zero_V_arr(*, topology: _RegimeVTopology) -> FloatND:
     """Build the zero V-array template for a regime, sharded where requested."""
     zeros = jnp.zeros(topology.shape)
     if topology.sharding is None:

--- a/src/lcm/solution/solve_brute.py
+++ b/src/lcm/solution/solve_brute.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import os
 import time
-from collections.abc import Callable, Hashable
+from collections.abc import Callable, Hashable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -25,7 +25,7 @@ def solve(
     *,
     internal_params: InternalParams,
     ages: AgeGrid,
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
     logger: logging.Logger,
     enable_jit: bool,
     max_compilation_workers: int | None = None,
@@ -234,7 +234,7 @@ def solve(
 
 def _compile_all_functions(
     *,
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
     internal_params: InternalParams,
     ages: AgeGrid,
     next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
@@ -388,7 +388,7 @@ def _func_dedup_key(*, func: Callable) -> Hashable:
 
 def _get_regime_V_shapes(
     *,
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
     internal_params: InternalParams,
 ) -> dict[RegimeName, tuple[int, ...]]:
     """Compute value function array shapes for all regimes.
@@ -438,7 +438,7 @@ def _emit_post_loop_diagnostics(
     logger: logging.Logger,
     diagnostic_rows: list[_DiagnosticRow],
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
     internal_params: InternalParams,
     running_any_nan: FloatND,
     running_any_inf: FloatND,
@@ -480,7 +480,7 @@ def _raise_first_nan_row(
     *,
     diagnostic_rows: list[_DiagnosticRow],
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
     internal_params: InternalParams,
 ) -> None:
     """Find the first NaN-bearing (regime, period) and raise.
@@ -504,7 +504,7 @@ def _raise_at(
     *,
     row: _DiagnosticRow,
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
     internal_params: InternalParams,
 ) -> None:
     """Run the enriched NaN diagnostic on a single offending row and raise."""
@@ -546,7 +546,7 @@ def _raise_at(
 def _reconstruct_next_regime_to_V_arr(
     *,
     period: int,
-    internal_regimes: MappingProxyType[RegimeName, InternalRegime],
+    internal_regimes: Mapping[RegimeName, InternalRegime],
     internal_params: InternalParams,
     solution: MappingProxyType[int, MappingProxyType[RegimeName, FloatND]],
 ) -> MappingProxyType[RegimeName, FloatND]:

--- a/src/lcm/state_action_space.py
+++ b/src/lcm/state_action_space.py
@@ -1,11 +1,10 @@
 from types import MappingProxyType
 
 import jax.numpy as jnp
-from jax import Array
 
 from lcm.grids import Grid, IrregSpacedGrid
 from lcm.interfaces import StateActionSpace
-from lcm.typing import StateName, StateOrActionName
+from lcm.typing import FloatND, IntND, StateName, StateOrActionName
 from lcm.variables import Variables
 
 
@@ -13,7 +12,7 @@ def create_state_action_space(
     *,
     variables: Variables,
     grids: MappingProxyType[StateOrActionName, Grid],
-    states: dict[StateName, Array] | None = None,
+    states: dict[StateName, FloatND | IntND] | None = None,
 ) -> StateActionSpace:
     """Create a state-action-space.
 
@@ -58,7 +57,7 @@ def create_state_action_space(
     )
 
 
-def _grid_to_jax_or_placeholder(grid: Grid) -> Array:
+def _grid_to_jax_or_placeholder(grid: Grid) -> FloatND | IntND:
     """Return the grid's points, or a NaN placeholder for runtime-supplied grids.
 
     `IrregSpacedGrid.to_jax()` raises when its points haven't been supplied — that
@@ -74,7 +73,9 @@ def _grid_to_jax_or_placeholder(grid: Grid) -> Array:
 
 
 def _validate_all_states_present(
-    *, provided_states: dict[StateName, Array], required_state_names: set[StateName]
+    *,
+    provided_states: dict[StateName, FloatND | IntND],
+    required_state_names: set[StateName],
 ) -> None:
     """Check that all states are present in the provided states."""
     provided_state_names = set(provided_states)

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -29,9 +29,9 @@ type ScalarFloat = Float[Scalar, ""]
 type ScalarBool = Bool[Scalar, ""]
 
 # JAX PRNG keys (jax.random) have dtype `key<fry>` and are not float-typed,
-# so they don't match `FloatND`. `KeyArray` keeps the perimeter check on shock
+# so they don't match `FloatND`. `PRNGKeyND` keeps the perimeter check on shock
 # samplers explicit about what kind of array they expect.
-type KeyArray = Array
+type PRNGKeyND = Array
 
 type Period = ScalarInt
 type Age = ScalarInt | ScalarFloat

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -5,7 +5,7 @@ from typing import Any, Protocol, runtime_checkable
 import numpy as np
 import pandas as pd
 from jax import Array
-from jaxtyping import Bool, Float, Int32, Scalar
+from jaxtyping import Bool, Float, Int, Int32, Scalar
 
 from lcm.params import MappingLeaf
 from lcm.params.sequence_leaf import SequenceLeaf
@@ -55,8 +55,21 @@ type RegimeStates = MappingProxyType[StateName, Array]
 type StatesPerRegime = MappingProxyType[RegimeName, RegimeStates]
 
 
+# User-supplied param leaf, checked by beartype at the `process_params`
+# boundary. The int slot is dtype-generic `Int[Array, "..."]` rather than
+# `IntND` (int32-only): users legitimately pass int64 arrays, which the
+# boundary downcasts. `FloatND`/`BoolND` are already dtype-generic.
 type _ParamsLeaf = (
-    bool | int | float | Array | np.ndarray | pd.Series | MappingLeaf | SequenceLeaf
+    bool
+    | int
+    | float
+    | FloatND
+    | Int[Array, "..."]
+    | BoolND
+    | np.ndarray
+    | pd.Series
+    | MappingLeaf
+    | SequenceLeaf
 )
 type UserParams = Mapping[
     str,
@@ -172,9 +185,9 @@ class MaxQOverAFunction(Protocol):
 
     def __call__(
         self,
-        next_regime_to_V_arr: MappingProxyType[RegimeName, Array],
+        next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
         **kwargs: Any,  # noqa: ANN401
-    ) -> Array: ...
+    ) -> FloatND: ...
 
 
 @runtime_checkable
@@ -190,9 +203,9 @@ class ArgmaxQOverAFunction(Protocol):
 
     def __call__(
         self,
-        next_regime_to_V_arr: MappingProxyType[RegimeName, Array],
+        next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
         **kwargs: Any,  # noqa: ANN401
-    ) -> tuple[Array, Array]: ...
+    ) -> tuple[IntND, FloatND]: ...
 
 
 @runtime_checkable

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -51,8 +51,14 @@ type TransitionFunctionsMapping = MappingProxyType[
     RegimeName, MappingProxyType[TransitionFunctionName, InternalUserFunction]
 ]
 
-type RegimeStates = MappingProxyType[StateName, Array]
+type RegimeStates = MappingProxyType[StateName, FloatND | IntND]
 type StatesPerRegime = MappingProxyType[RegimeName, RegimeStates]
+
+# User-supplied initial conditions / states, checked by beartype at the
+# `Model.simulate` boundary. The int slot is dtype-generic `Int[Array, "..."]`
+# rather than `IntND` (int32-only): users pass int64 arrays, which
+# `build_initial_states` downcasts. Parallels `_ParamsLeaf`.
+type UserInitialConditions = Mapping[str, FloatND | Int[Array, "..."]]
 
 
 # User-supplied param leaf, checked by beartype at the `process_params`
@@ -78,8 +84,8 @@ type UserParams = Mapping[
 
 # Internal regime parameters: A flat mapping with function-qualified names.
 # Keys are always function-qualified (e.g., "utility__risk_aversion",
-# "H__discount_factor"). Values are scalars or arrays.
-type FlatRegimeParams = MappingProxyType[str, Array]
+# "H__discount_factor"). Values are canonical-dtype scalars or arrays.
+type FlatRegimeParams = MappingProxyType[str, FloatND | IntND | BoolND]
 type InternalParams = MappingProxyType[RegimeName, FlatRegimeParams]
 
 # Immutable templates, used internally
@@ -115,9 +121,9 @@ class InternalUserFunction(Protocol):
 
     def __call__(
         self,
-        *args: Array | float,
-        **kwargs: Array | float,
-    ) -> Array: ...
+        *args: FloatND | IntND | BoolND | float,
+        **kwargs: FloatND | IntND | BoolND | float,
+    ) -> FloatND | IntND | BoolND: ...
 
 
 @runtime_checkable
@@ -132,8 +138,8 @@ class RegimeTransitionFunction(Protocol):
 
     def __call__(
         self,
-        *args: Array | float,
-        **kwargs: Array | float,
+        *args: FloatND | IntND | BoolND | float,
+        **kwargs: FloatND | IntND | BoolND | float,
     ) -> Float1D: ...
 
 
@@ -149,8 +155,8 @@ class VmappedRegimeTransitionFunction(Protocol):
 
     def __call__(
         self,
-        *args: Array | float,
-        **kwargs: Array | float,
+        *args: FloatND | IntND | BoolND | float,
+        **kwargs: FloatND | IntND | BoolND | float,
     ) -> FloatND: ...
 
 
@@ -216,7 +222,7 @@ class StochasticNextFunction(Protocol):
 
     """
 
-    def __call__(self, **kwargs: Array) -> Array: ...
+    def __call__(self, **kwargs: FloatND | IntND) -> FloatND | IntND: ...
 
 
 @runtime_checkable
@@ -230,7 +236,7 @@ class NextStateSimulationFunction(Protocol):
 
     def __call__(
         self,
-        **kwargs: Array | Period | Age,
+        **kwargs: FloatND | IntND | Period | Age,
     ) -> MappingProxyType[
         RegimeName, MappingProxyType[str, DiscreteState | ContinuousState]
     ]: ...

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any, Protocol, runtime_checkable
 
+import numpy as np
 import pandas as pd
 from jax import Array
 from jaxtyping import Bool, Float, Int32, Scalar
@@ -54,7 +55,9 @@ type RegimeStates = MappingProxyType[StateName, Array]
 type StatesPerRegime = MappingProxyType[RegimeName, RegimeStates]
 
 
-type _ParamsLeaf = bool | int | float | Array | pd.Series | MappingLeaf | SequenceLeaf
+type _ParamsLeaf = (
+    bool | int | float | Array | np.ndarray | pd.Series | MappingLeaf | SequenceLeaf
+)
 type UserParams = Mapping[
     str,
     _ParamsLeaf | Mapping[str, _ParamsLeaf | Mapping[str, _ParamsLeaf]],

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -27,6 +27,11 @@ type ScalarInt = Int32[Scalar, ""]
 type ScalarFloat = Float[Scalar, ""]
 type ScalarBool = Bool[Scalar, ""]
 
+# JAX PRNG keys (jax.random) have dtype `key<fry>` and are not float-typed,
+# so they don't match `FloatND`. `KeyArray` keeps the perimeter check on shock
+# samplers explicit about what kind of array they expect.
+type KeyArray = Array
+
 type Period = ScalarInt
 type Age = ScalarInt | ScalarFloat
 type RegimeName = str

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -5,7 +5,7 @@ from typing import Any, Protocol, runtime_checkable
 import numpy as np
 import pandas as pd
 from jax import Array
-from jaxtyping import Bool, Float, Int, Int32, Scalar
+from jaxtyping import Bool, Float, Int32, Real, Scalar
 
 from lcm.params import MappingLeaf
 from lcm.params.sequence_leaf import SequenceLeaf
@@ -18,6 +18,12 @@ type DiscreteAction = Int32[Array, "..."]
 type FloatND = Float[Array, "..."]
 type IntND = Int32[Array, "..."]
 type BoolND = Bool[Array, "..."]
+
+# Dtype-generic real array (any-width float or int, no complex/bool). For
+# low-level numeric primitives (`ndimage`, `argmax`) that operate *below*
+# pylcm's canonical-dtype invariant — they are exercised across dtypes
+# (e.g. int64) and so cannot pin the int side to `IntND` (int32-only).
+type RealND = Real[Array, "..."]
 
 type Float1D = Float[Array, "_"]  # noqa: F821
 type Int1D = Int32[Array, "_"]  # noqa: F821
@@ -54,23 +60,13 @@ type TransitionFunctionsMapping = MappingProxyType[
 type RegimeStates = MappingProxyType[StateName, FloatND | IntND]
 type StatesPerRegime = MappingProxyType[RegimeName, RegimeStates]
 
-# User-supplied initial conditions / states, checked by beartype at the
-# `Model.simulate` boundary. The int slot is dtype-generic `Int[Array, "..."]`
-# rather than `IntND` (int32-only): users pass int64 arrays, which
-# `build_initial_states` downcasts. Parallels `_ParamsLeaf`.
-type UserInitialConditions = Mapping[str, FloatND | Int[Array, "..."]]
 
-
-# User-supplied param leaf, checked by beartype at the `process_params`
-# boundary. The int slot is dtype-generic `Int[Array, "..."]` rather than
-# `IntND` (int32-only): users legitimately pass int64 arrays, which the
-# boundary downcasts. `FloatND`/`BoolND` are already dtype-generic.
 type _ParamsLeaf = (
     bool
     | int
     | float
     | FloatND
-    | Int[Array, "..."]
+    | IntND
     | BoolND
     | np.ndarray
     | pd.Series

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -5,7 +5,7 @@ from typing import Any, Protocol, runtime_checkable
 import numpy as np
 import pandas as pd
 from jax import Array
-from jaxtyping import Bool, Float, Int32, Scalar
+from jaxtyping import Bool, Float, Int32, Key, Scalar
 
 from lcm.params import MappingLeaf
 from lcm.params.sequence_leaf import SequenceLeaf
@@ -28,10 +28,10 @@ type ScalarInt = Int32[Scalar, ""]
 type ScalarFloat = Float[Scalar, ""]
 type ScalarBool = Bool[Scalar, ""]
 
-# JAX PRNG keys (jax.random) have dtype `key<fry>` and are not float-typed,
-# so they don't match `FloatND`. `PRNGKeyND` keeps the perimeter check on shock
-# samplers explicit about what kind of array they expect.
-type PRNGKeyND = Array
+# JAX PRNG keys (`jax.random`) carry the dedicated `key<fry>` dtype, which
+# jaxtyping matches via `Key` — distinct from `FloatND`/`IntND`. Covers both a
+# single 0-d key and a batched 1-d array of keys.
+type PRNGKeyND = Key[Array, "..."]
 
 type Period = ScalarInt
 type Age = ScalarInt | ScalarFloat
@@ -118,9 +118,11 @@ class InternalUserFunction(Protocol):
 
 @runtime_checkable
 class RegimeTransitionFunction(Protocol):
-    """The regime transition function provided by the user.
+    """The processed regime transition function for the solve phase.
 
-    Returns an array of transition probabilities indexed by regime ID.
+    Wraps the user's `next_regime` function so its output is a mapping of
+    target regime name to a transition-probability array, rather than a
+    raw array indexed by regime id.
 
     Only used for type checking.
 
@@ -130,14 +132,16 @@ class RegimeTransitionFunction(Protocol):
         self,
         *args: FloatND | IntND | BoolND | float,
         **kwargs: FloatND | IntND | BoolND | float,
-    ) -> Float1D: ...
+    ) -> MappingProxyType[RegimeName, FloatND]: ...
 
 
 @runtime_checkable
 class VmappedRegimeTransitionFunction(Protocol):
-    """The vmapped regime transition function.
+    """The processed regime transition function for the simulate phase.
 
-    Returns a 2D array of transition probabilities with shape [n_regimes, n_subjects].
+    The `vmap`-over-subjects counterpart of `RegimeTransitionFunction`:
+    same mapping output, with each probability array carrying a leading
+    per-subject axis.
 
     Only used for type checking.
 
@@ -147,7 +151,7 @@ class VmappedRegimeTransitionFunction(Protocol):
         self,
         *args: FloatND | IntND | BoolND | float,
         **kwargs: FloatND | IntND | BoolND | float,
-    ) -> FloatND: ...
+    ) -> MappingProxyType[RegimeName, FloatND]: ...
 
 
 @runtime_checkable

--- a/src/lcm/typing.py
+++ b/src/lcm/typing.py
@@ -5,7 +5,7 @@ from typing import Any, Protocol, runtime_checkable
 import numpy as np
 import pandas as pd
 from jax import Array
-from jaxtyping import Bool, Float, Int32, Real, Scalar
+from jaxtyping import Bool, Float, Int32, Scalar
 
 from lcm.params import MappingLeaf
 from lcm.params.sequence_leaf import SequenceLeaf
@@ -18,12 +18,6 @@ type DiscreteAction = Int32[Array, "..."]
 type FloatND = Float[Array, "..."]
 type IntND = Int32[Array, "..."]
 type BoolND = Bool[Array, "..."]
-
-# Dtype-generic real array (any-width float or int, no complex/bool). For
-# low-level numeric primitives (`ndimage`, `argmax`) that operate *below*
-# pylcm's canonical-dtype invariant — they are exercised across dtypes
-# (e.g. int64) and so cannot pin the int side to `IntND` (int32-only).
-type RealND = Real[Array, "..."]
 
 type Float1D = Float[Array, "_"]  # noqa: F821
 type Int1D = Int32[Array, "_"]  # noqa: F821

--- a/src/lcm/utils/containers.py
+++ b/src/lcm/utils/containers.py
@@ -68,11 +68,11 @@ def find_duplicates(*containers: Iterable[T]) -> set[T]:
     return {v for v, count in counts.items() if count > 1}
 
 
-def get_field_names_and_values(dc: type) -> MappingProxyType[str, Any]:
+def get_field_names_and_values(dc: object) -> MappingProxyType[str, Any]:
     """Return the fields of a dataclass.
 
     Args:
-        dc: The dataclass to get the fields of.
+        dc: The dataclass class or instance to get the fields of.
 
     Returns:
         An immutable mapping with the field names as keys and the field values as
@@ -80,7 +80,10 @@ def get_field_names_and_values(dc: type) -> MappingProxyType[str, Any]:
 
     """
     return MappingProxyType(
-        {field.name: getattr(dc, field.name, None) for field in fields(dc)}
+        {
+            field.name: getattr(dc, field.name, None)
+            for field in fields(dc)  # ty: ignore[invalid-argument-type]
+        }
     )
 
 

--- a/src/lcm/utils/dispatchers.py
+++ b/src/lcm/utils/dispatchers.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 from jax import Array, vmap
 
 from lcm.exceptions import FunctionDispatchError
-from lcm.typing import ActionName, Float1D, FloatND, StateName
+from lcm.typing import ActionName, FloatND, StateName
 from lcm.utils.containers import find_duplicates
 from lcm.utils.functools import allow_args, allow_only_kwargs
 
@@ -246,7 +246,7 @@ def _base_productmap_batched(
                 "is POSITIONAL_ONLY."
             )
 
-    def batched_vmap(**kwargs: FloatND) -> FloatND:
+    def batched_vmap(**kwargs: Array) -> Array:
         non_array_kwargs = {
             key: val for key, val in kwargs.items() if key not in product_axes
         }
@@ -259,8 +259,8 @@ def _base_productmap_batched(
             loop_func: FunctionWithArrayReturn, axis: str
         ) -> FunctionWithArrayReturn:
             def func_mapped_over_one_more_axis(
-                *already_mapped_args: Float1D, **already_mapped_kwargs: Float1D
-            ) -> FloatND:
+                *already_mapped_args: Array, **already_mapped_kwargs: Array
+            ) -> Array:
                 return jax.lax.map(
                     lambda axis_i: loop_func(
                         *already_mapped_args, **{axis: axis_i}, **already_mapped_kwargs

--- a/src/lcm/utils/dispatchers.py
+++ b/src/lcm/utils/dispatchers.py
@@ -6,10 +6,10 @@ from typing import Literal, TypeVar, cast
 
 import jax
 import jax.numpy as jnp
-from jax import Array, vmap
+from jax import vmap
 
 from lcm.exceptions import FunctionDispatchError
-from lcm.typing import ActionName, FloatND, StateName
+from lcm.typing import ActionName, BoolND, FloatND, IntND, StateName
 from lcm.utils.containers import find_duplicates
 from lcm.utils.functools import allow_args, allow_only_kwargs
 
@@ -17,10 +17,12 @@ FunctionWithArrayReturn = TypeVar(
     "FunctionWithArrayReturn",
     bound=Callable[
         ...,
-        Array
-        | tuple[Array, Array]
-        | MappingProxyType[str, Array]
-        | MappingProxyType[str, MappingProxyType[str, Array]],
+        FloatND
+        | IntND
+        | BoolND
+        | tuple[FloatND | IntND | BoolND, FloatND | IntND | BoolND]
+        | MappingProxyType[str, FloatND | IntND]
+        | MappingProxyType[str, MappingProxyType[str, FloatND | IntND]],
     ],
 )
 
@@ -246,7 +248,7 @@ def _base_productmap_batched(
                 "is POSITIONAL_ONLY."
             )
 
-    def batched_vmap(**kwargs: Array) -> Array:
+    def batched_vmap(**kwargs: FloatND | IntND | BoolND) -> FloatND:
         non_array_kwargs = {
             key: val for key, val in kwargs.items() if key not in product_axes
         }
@@ -259,8 +261,9 @@ def _base_productmap_batched(
             loop_func: FunctionWithArrayReturn, axis: str
         ) -> FunctionWithArrayReturn:
             def func_mapped_over_one_more_axis(
-                *already_mapped_args: Array, **already_mapped_kwargs: Array
-            ) -> Array:
+                *already_mapped_args: FloatND | IntND | BoolND,
+                **already_mapped_kwargs: FloatND | IntND | BoolND,
+            ) -> FloatND | IntND | BoolND:
                 return jax.lax.map(
                     lambda axis_i: loop_func(
                         *already_mapped_args, **{axis: axis_i}, **already_mapped_kwargs

--- a/src/lcm/utils/error_handling.py
+++ b/src/lcm/utils/error_handling.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 def validate_V(
     *,
-    V_arr: Array,
+    V_arr: FloatND,
     age: float | ScalarInt | ScalarFloat,
     regime_name: RegimeName | None = None,
     partial_solution: object = None,
@@ -284,7 +284,7 @@ def _format_diagnostic_summary(summary: dict[str, Any]) -> str:
 
 def validate_regime_transition_probs(
     *,
-    regime_transition_probs: MappingProxyType[str, Array],
+    regime_transition_probs: MappingProxyType[str, FloatND],
     active_regimes_next_period: tuple[RegimeName, ...],
     regime_name: RegimeName,
     age: float | ScalarInt | ScalarFloat,
@@ -352,7 +352,7 @@ def validate_regime_transition_probs(
 
 def _format_sum_violation(
     *,
-    sum_all: Array,
+    sum_all: FloatND,
     state_action_values: MappingProxyType[str, Array] | None = None,
 ) -> str:
     """Format a human-readable description of probability sum violations.
@@ -499,18 +499,18 @@ def _validate_regime_transition_single(
             _func: object = regime_transition_func,
             _period: int = period,
             _age: ScalarInt | ScalarFloat = ages.values[period],  # noqa: PD011
-        ) -> MappingProxyType[str, Array]:
+        ) -> MappingProxyType[str, FloatND]:
             kwargs = dict(zip(_names, args, strict=True))
             return _func(  # ty: ignore[call-non-callable]
                 **kwargs, **_params, period=_period, age=_age
             )
 
-        regime_transition_probs: MappingProxyType[str, Array] = jax.vmap(_call)(
+        regime_transition_probs: MappingProxyType[str, FloatND] = jax.vmap(_call)(
             *flat_arrays
         )
         point = dict(zip(grid_var_names, flat_arrays, strict=True))
     else:
-        regime_transition_probs: MappingProxyType[str, Array] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
             regime_transition_func(  # ty: ignore[call-non-callable]
                 **filtered_params,
                 period=period,
@@ -540,7 +540,7 @@ def _validate_regime_transition_single(
 def _validate_no_reachable_incomplete_targets(
     *,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
-    regime_transition_probs: MappingProxyType[str, Array],
+    regime_transition_probs: MappingProxyType[str, FloatND],
     active_regimes_next_period: tuple[RegimeName, ...],
     regime_name: RegimeName,
     age: float | ScalarInt | ScalarFloat,

--- a/src/lcm/utils/error_handling.py
+++ b/src/lcm/utils/error_handling.py
@@ -284,7 +284,7 @@ def _format_diagnostic_summary(summary: dict[str, Any]) -> str:
 
 def validate_regime_transition_probs(
     *,
-    regime_transition_probs: MappingProxyType[str, FloatND],
+    regime_transition_probs: MappingProxyType[RegimeName, FloatND],
     active_regimes_next_period: tuple[RegimeName, ...],
     regime_name: RegimeName,
     age: float | ScalarInt | ScalarFloat,
@@ -499,18 +499,18 @@ def _validate_regime_transition_single(
             _func: object = regime_transition_func,
             _period: int = period,
             _age: ScalarInt | ScalarFloat = ages.values[period],  # noqa: PD011
-        ) -> MappingProxyType[str, FloatND]:
+        ) -> MappingProxyType[RegimeName, FloatND]:
             kwargs = dict(zip(_names, args, strict=True))
             return _func(  # ty: ignore[call-non-callable]
                 **kwargs, **_params, period=_period, age=_age
             )
 
-        regime_transition_probs: MappingProxyType[str, FloatND] = jax.vmap(_call)(
-            *flat_arrays
-        )
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = jax.vmap(
+            _call
+        )(*flat_arrays)
         point = dict(zip(grid_var_names, flat_arrays, strict=True))
     else:
-        regime_transition_probs: MappingProxyType[str, FloatND] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
             regime_transition_func(  # ty: ignore[call-non-callable]
                 **filtered_params,
                 period=period,
@@ -540,7 +540,7 @@ def _validate_regime_transition_single(
 def _validate_no_reachable_incomplete_targets(
     *,
     internal_regimes: MappingProxyType[RegimeName, InternalRegime],
-    regime_transition_probs: MappingProxyType[str, FloatND],
+    regime_transition_probs: MappingProxyType[RegimeName, FloatND],
     active_regimes_next_period: tuple[RegimeName, ...],
     regime_name: RegimeName,
     age: float | ScalarInt | ScalarFloat,

--- a/src/lcm/utils/error_handling.py
+++ b/src/lcm/utils/error_handling.py
@@ -510,7 +510,7 @@ def _validate_regime_transition_single(
         )(*flat_arrays)
         point = dict(zip(grid_var_names, flat_arrays, strict=True))
     else:
-        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (  # ty: ignore[invalid-assignment]
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (
             regime_transition_func(  # ty: ignore[call-non-callable]
                 **filtered_params,
                 period=period,

--- a/src/lcm/utils/error_handling.py
+++ b/src/lcm/utils/error_handling.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, overload
 import jax
 import jax.numpy as jnp
 import pandas as pd
-from jax import Array
 
 from lcm.ages import AgeGrid
 from lcm.exceptions import (
@@ -23,6 +22,7 @@ from lcm.typing import (
     FlatRegimeParams,
     FloatND,
     InternalParams,
+    IntND,
     RegimeName,
     ScalarFloat,
     ScalarInt,
@@ -289,7 +289,7 @@ def validate_regime_transition_probs(
     regime_name: RegimeName,
     age: float | ScalarInt | ScalarFloat,
     next_age: float | ScalarInt | ScalarFloat,
-    state_action_values: MappingProxyType[str, Array] | None = None,
+    state_action_values: MappingProxyType[str, FloatND | IntND] | None = None,
 ) -> None:
     """Validate regime transition probabilities.
 
@@ -353,7 +353,7 @@ def validate_regime_transition_probs(
 def _format_sum_violation(
     *,
     sum_all: FloatND,
-    state_action_values: MappingProxyType[str, Array] | None = None,
+    state_action_values: MappingProxyType[str, FloatND | IntND] | None = None,
 ) -> str:
     """Format a human-readable description of probability sum violations.
 
@@ -480,7 +480,7 @@ def _validate_regime_transition_single(
     filtered_params = {k: v for k, v in regime_params.items() if k in accepted_params}
 
     # Collect only grid variables the transition function accepts
-    grids: dict[str, Array] = {
+    grids: dict[str, FloatND | IntND] = {
         k: v for k, v in state_action_space.states.items() if k in accepted_params
     } | {k: v for k, v in state_action_space.actions.items() if k in accepted_params}
 
@@ -493,7 +493,7 @@ def _validate_regime_transition_single(
         flat_arrays = [m.ravel() for m in mesh]
 
         def _call(
-            *args: Array,
+            *args: FloatND | IntND,
             _names: list[str] = grid_var_names,
             _params: dict = filtered_params,
             _func: object = regime_transition_func,
@@ -517,7 +517,7 @@ def _validate_regime_transition_single(
                 age=ages.values[period],  # noqa: PD011
             )
         )
-        point: dict[str, Array] = {}
+        point: dict[str, FloatND | IntND] = {}
 
     validate_regime_transition_probs(
         regime_transition_probs=regime_transition_probs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,25 @@
-from collections.abc import Iterator
-from dataclasses import make_dataclass
+# Beartype claw must instrument `lcm.grids`, `lcm.shocks`, and `lcm.params`
+# before any submodule of those packages is imported. The registrations below
+# install an import hook on `sys.meta_path` that transforms each matching
+# module's AST at first import. Subsequent imports in this file must come
+# after the registration, hence the `# noqa: E402` markers on them.
 
-import jax.numpy as jnp
-import pytest
-from jax import config as jax_config
+from beartype.claw import beartype_package
 
-from lcm.typing import ScalarInt
+from lcm._beartype_conf import GRID_CONF, PARAMS_CONF
+
+beartype_package("lcm.grids", conf=GRID_CONF)
+beartype_package("lcm.shocks", conf=GRID_CONF)
+beartype_package("lcm.params", conf=PARAMS_CONF)
+
+from collections.abc import Iterator  # noqa: E402
+from dataclasses import make_dataclass  # noqa: E402
+
+import jax.numpy as jnp  # noqa: E402
+import pytest  # noqa: E402
+from jax import config as jax_config  # noqa: E402
+
+from lcm.typing import ScalarInt  # noqa: E402
 
 # Module-level precision settings (updated by pytest_configure based on --precision)
 X64_ENABLED: bool = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,11 @@
-# Beartype claw must instrument `lcm.grids`, `lcm.shocks`, and `lcm.params`
-# before any submodule of those packages is imported. The registrations below
-# install an import hook on `sys.meta_path` that transforms each matching
-# module's AST at first import. Subsequent imports in this file must come
-# after the registration, hence the `# noqa: E402` markers on them.
+from collections.abc import Iterator
+from dataclasses import make_dataclass
 
-from beartype.claw import beartype_package
+import jax.numpy as jnp
+import pytest
+from jax import config as jax_config
 
-from lcm._beartype_conf import GRID_CONF, PARAMS_CONF
-
-beartype_package("lcm.grids", conf=GRID_CONF)
-beartype_package("lcm.shocks", conf=GRID_CONF)
-beartype_package("lcm.params", conf=PARAMS_CONF)
-
-from collections.abc import Iterator  # noqa: E402
-from dataclasses import make_dataclass  # noqa: E402
-
-import jax.numpy as jnp  # noqa: E402
-import pytest  # noqa: E402
-from jax import config as jax_config  # noqa: E402
-
-from lcm.typing import ScalarInt  # noqa: E402
+from lcm.typing import ScalarInt
 
 # Module-level precision settings (updated by pytest_configure based on --precision)
 X64_ENABLED: bool = True

--- a/tests/regime_building/test_create_regime_params_template.py
+++ b/tests/regime_building/test_create_regime_params_template.py
@@ -19,7 +19,7 @@ def test_create_params_without_shocks(binary_category_class):
         transition=lambda: 0,
         functions={"utility": lambda a, b, c: None},  # noqa: ARG005
     )
-    got = create_regime_params_template(regime)  # ty: ignore[invalid-argument-type]
+    got = create_regime_params_template(regime)
     assert got == ensure_containers_are_immutable(
         {
             "H": {"discount_factor": "float"},
@@ -45,7 +45,7 @@ def test_create_params_with_custom_H_no_extra_params():
         },
         functions={"utility": lambda a, b, c: None, "H": custom_H},  # noqa: ARG005
     )
-    got = create_regime_params_template(regime)  # ty: ignore[invalid-argument-type]
+    got = create_regime_params_template(regime)
     assert got == ensure_containers_are_immutable(
         {"H": {}, "utility": {"c": "no_annotation_found"}}
     )
@@ -67,7 +67,7 @@ def test_default_H_with_state_named_discount_factor_is_allowed():
         functions={"utility": lambda a, discount_factor: None},  # noqa: ARG005
         transition=lambda discount_factor: discount_factor,
     )
-    got = create_regime_params_template(regime)  # ty: ignore[invalid-argument-type]
+    got = create_regime_params_template(regime)
     assert got == ensure_containers_are_immutable(
         {
             "H": {},
@@ -95,7 +95,7 @@ def test_custom_H_shadowing_state_is_allowed():
         states={"wealth": None},
         functions={"utility": lambda a, wealth: None, "H": custom_H},  # noqa: ARG005
     )
-    got = create_regime_params_template(regime)  # ty: ignore[invalid-argument-type]
+    got = create_regime_params_template(regime)
     assert got == ensure_containers_are_immutable({"H": {}, "utility": {}})
 
 
@@ -124,7 +124,7 @@ def test_solve_simulate_pair_template_contains_union_of_params() -> None:
             "H": SolveSimulateFunctionPair(solve=exponential_h, simulate=beta_delta_h),
         },
     )
-    got = create_regime_params_template(regime)  # ty: ignore[invalid-argument-type]
+    got = create_regime_params_template(regime)
     assert set(got["H"]) == {"discount_factor", "beta", "delta"}
 
 
@@ -141,7 +141,7 @@ def test_regular_function_taking_state_as_argument_no_error(binary_category_clas
         transition=lambda: 0,
         functions={"utility": lambda a, wealth, risk_aversion: None},  # noqa: ARG005
     )
-    got = create_regime_params_template(regime)  # ty: ignore[invalid-argument-type]
+    got = create_regime_params_template(regime)
     assert got == ensure_containers_are_immutable(
         {
             "H": {"discount_factor": "float"},
@@ -180,7 +180,7 @@ def test_state_transition_consuming_other_next_state_is_not_a_param(
         transition=lambda: 0,
         functions={"utility": lambda a, wealth, aime: None},  # noqa: ARG005
     )
-    got = create_regime_params_template(regime)  # ty: ignore[invalid-argument-type]
+    got = create_regime_params_template(regime)
     assert got == ensure_containers_are_immutable(
         {
             "H": {"discount_factor": "float"},

--- a/tests/regime_building/test_process_params.py
+++ b/tests/regime_building/test_process_params.py
@@ -5,6 +5,7 @@ from types import MappingProxyType
 import pytest
 
 from lcm.exceptions import InvalidNameError, InvalidParamsError
+from lcm.interfaces import InternalRegime
 from lcm.params.processing import (
     create_params_template,
     process_params,
@@ -164,16 +165,22 @@ def test_ambiguous_model_regime_level(params_template):
         process_params(params=params, params_template=params_template)
 
 
-class MockRegime:
-    """Mock regime with regime_params_template for testing create_params_template."""
+class MockRegime(InternalRegime):
+    """Mock InternalRegime exposing only `regime_params_template`.
+
+    Inherits from `InternalRegime` so `isinstance(x, InternalRegime)`
+    holds at `create_params_template`'s beartype-checked perimeter, but
+    bypasses `InternalRegime.__init__` to keep test fixtures minimal —
+    `create_params_template` only reads `regime_params_template`.
+
+    """
 
     def __init__(self, regime_params_template: dict) -> None:
-        self._regime_params_template = regime_params_template
-
-    @property
-    def regime_params_template(self) -> MappingProxyType:
-        """Return regime_params_template as MappingProxyType."""
-        return MappingProxyType(self._regime_params_template)
+        object.__setattr__(
+            self,
+            "regime_params_template",
+            MappingProxyType(regime_params_template),
+        )
 
 
 def test_function_params_no_qname_separator():

--- a/tests/regime_building/test_process_params.py
+++ b/tests/regime_building/test_process_params.py
@@ -184,7 +184,7 @@ def test_function_params_no_qname_separator():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)  # ty: ignore[invalid-argument-type]
+        create_params_template(internal_regimes)
 
 
 def test_regime_name_no_qname_separator():
@@ -195,7 +195,7 @@ def test_regime_name_no_qname_separator():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)  # ty: ignore[invalid-argument-type]
+        create_params_template(internal_regimes)
 
 
 def test_function_name_no_qname_separator():
@@ -206,7 +206,7 @@ def test_function_name_no_qname_separator():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)  # ty: ignore[invalid-argument-type]
+        create_params_template(internal_regimes)
 
 
 def test_regime_function_names_disjoint():
@@ -218,7 +218,7 @@ def test_regime_function_names_disjoint():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)  # ty: ignore[invalid-argument-type]
+        create_params_template(internal_regimes)
 
 
 def test_regime_argument_names_disjoint():
@@ -230,7 +230,7 @@ def test_regime_argument_names_disjoint():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)  # ty: ignore[invalid-argument-type]
+        create_params_template(internal_regimes)
 
 
 def test_missing_parameter_raises_error(params_template):
@@ -303,7 +303,7 @@ def test_passing_same_params_to_regimes_with_different_templates():
     # InvalidParamsError is raised because dead__cons_util__*, dead__utility__*,
     # etc. are not in the template
     with pytest.raises(InvalidParamsError, match="Unknown keys"):
-        process_params(params=params, params_template=params_template)  # ty: ignore[invalid-argument-type]
+        process_params(params=params, params_template=params_template)
 
 
 def test_shock_params_via_regular_params():
@@ -332,6 +332,6 @@ def test_shock_params_via_regular_params():
         },
     }
 
-    result = process_params(params=params, params_template=params_template)  # ty: ignore[invalid-argument-type]
+    result = process_params(params=params, params_template=params_template)
     assert result["working_life"]["adjustment_cost__start"] == 0
     assert result["working_life"]["adjustment_cost__stop"] == 1

--- a/tests/regime_building/test_process_params.py
+++ b/tests/regime_building/test_process_params.py
@@ -1,6 +1,7 @@
 """Tests for process_params function."""
 
 from types import MappingProxyType
+from typing import cast
 
 import pytest
 
@@ -10,6 +11,13 @@ from lcm.params.processing import (
     create_params_template,
     process_params,
 )
+from lcm.typing import ParamsTemplate
+from lcm.utils.containers import ensure_containers_are_immutable
+
+
+def _as_template(plain: dict) -> ParamsTemplate:
+    """Deep-freeze a plain nested dict into a `ParamsTemplate` for tests."""
+    return cast("ParamsTemplate", ensure_containers_are_immutable(plain))
 
 
 def _expected_flat_keys(params_template, regime):
@@ -23,16 +31,18 @@ def _expected_flat_keys(params_template, regime):
 @pytest.fixture
 def params_template():
     """Fixture providing a params_template with two regimes and two functions each."""
-    return {
-        "regime_0": {
-            "fun_0": {"arg_0": float, "arg_1": float},
-            "fun_1": {"arg_0": float, "arg_1": 1.0},
-        },
-        "regime_1": {
-            "fun_0": {"arg_0": float, "arg_1": float},
-            "fun_1": {"arg_0": float, "arg_1": 1.0},
-        },
-    }
+    return _as_template(
+        {
+            "regime_0": {
+                "fun_0": {"arg_0": "float", "arg_1": "float"},
+                "fun_1": {"arg_0": "float", "arg_1": "float"},
+            },
+            "regime_1": {
+                "fun_0": {"arg_0": "float", "arg_1": "float"},
+                "fun_1": {"arg_0": "float", "arg_1": "float"},
+            },
+        }
+    )
 
 
 def test_params_at_function_level(params_template):
@@ -191,7 +201,7 @@ def test_function_params_no_qname_separator():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)
+        create_params_template(MappingProxyType(internal_regimes))
 
 
 def test_regime_name_no_qname_separator():
@@ -202,7 +212,7 @@ def test_regime_name_no_qname_separator():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)
+        create_params_template(MappingProxyType(internal_regimes))
 
 
 def test_function_name_no_qname_separator():
@@ -213,7 +223,7 @@ def test_function_name_no_qname_separator():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)
+        create_params_template(MappingProxyType(internal_regimes))
 
 
 def test_regime_function_names_disjoint():
@@ -225,7 +235,7 @@ def test_regime_function_names_disjoint():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)
+        create_params_template(MappingProxyType(internal_regimes))
 
 
 def test_regime_argument_names_disjoint():
@@ -237,7 +247,7 @@ def test_regime_argument_names_disjoint():
         ),
     }
     with pytest.raises(InvalidNameError):
-        create_params_template(internal_regimes)
+        create_params_template(MappingProxyType(internal_regimes))
 
 
 def test_missing_parameter_raises_error(params_template):
@@ -278,19 +288,21 @@ def test_passing_same_params_to_regimes_with_different_templates():
     """
     # Template for a non-terminal regime with functions that have parameters
     alive_template = {
-        "discount_factor": float,
-        "utility": {"beta_mean": float, "beta_std": float},
-        "cons_util": {"sigma": float, "bb": float, "kappa": float},
-        "next_health": {"probs_array": float},
+        "H": {"discount_factor": "float"},
+        "utility": {"beta_mean": "float", "beta_std": "float"},
+        "cons_util": {"sigma": "float", "bb": "float", "kappa": "float"},
+        "next_health": {"probs_array": "float"},
     }
 
     # Template for a terminal regime - empty (no H, no transitions)
-    dead_template: dict[str, type] = {}
+    dead_template: dict[str, dict[str, str]] = {}
 
-    params_template = {
-        "alive": alive_template,
-        "dead": dead_template,
-    }
+    params_template = _as_template(
+        {
+            "alive": alive_template,
+            "dead": dead_template,
+        }
+    )
 
     # User's shared params dict - has all parameters for the alive regime
     shared_params = {
@@ -320,13 +332,15 @@ def test_shock_params_via_regular_params():
     state name (e.g., "adjustment_cost"), so users can pass them via regular params.
     """
     # Template includes ShockGrid params under the state name
-    params_template = {
-        "working_life": {
-            "discount_factor": float,
-            "utility": {"param": float},
-            "adjustment_cost": {"start": float, "stop": float},
-        },
-    }
+    params_template = _as_template(
+        {
+            "working_life": {
+                "H": {"discount_factor": "float"},
+                "utility": {"param": "float"},
+                "adjustment_cost": {"start": "float", "stop": "float"},
+            },
+        }
+    )
 
     params = {
         "working_life": {

--- a/tests/regime_building/test_regime_processing.py
+++ b/tests/regime_building/test_regime_processing.py
@@ -37,7 +37,7 @@ def test_variables_from_regime_tags_kind_and_topology(binary_category_class):
         functions={"utility": utility},
     )
 
-    got = Variables.from_regime(regime_mock)  # ty: ignore[invalid-argument-type]
+    got = Variables.from_regime(regime_mock)
 
     assert isinstance(got, Variables)
     assert set(got) == {"a", "c"}
@@ -60,7 +60,7 @@ def test_get_grids(binary_category_class):
         functions={"utility": lambda _c: None},
     )
 
-    got = get_grids(regime_mock)  # ty: ignore[invalid-argument-type]
+    got = get_grids(regime_mock)
     assert isinstance(got["a"], DiscreteGrid)
     assert got["a"].categories == ("cat0", "cat1")
     assert got["a"].codes == (0, 1)
@@ -95,7 +95,7 @@ def test_get_grids_reorder(binary_category_class):
         functions={"utility": lambda _c: None},
     )
 
-    got = get_grids(regime_mock)  # ty: ignore[invalid-argument-type]
+    got = get_grids(regime_mock)
     assert list(got.keys()) == ["c", "b", "e", "d", "f", "a"]
 
 

--- a/tests/regime_mock.py
+++ b/tests/regime_mock.py
@@ -1,41 +1,67 @@
-from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Literal, cast
 
 from lcm.grids import Grid
 from lcm.interfaces import SolveSimulateFunctionPair
-from lcm.regime import _default_H
+from lcm.regime import Regime, _default_H
 from lcm.regime_building.validation import collect_state_transitions
 from lcm.typing import UserFunction
 
 
-@dataclass
-class RegimeMock:
+class RegimeMock(Regime):
     """A regime mock for testing the params_template creation functions.
 
-    This dataclass has the same attributes as the Regime dataclass, but does not perform
-    any checks, which helps us test the params_template creation functions in isolation.
+    Inherits from `Regime` so `isinstance(x, Regime)` holds at the
+    beartype-checked perimeter of `create_regime_params_template` and
+    friends, but bypasses `Regime.__init__`'s validation by writing
+    fields directly via `object.__setattr__`. Tests use this to supply
+    partial / loosely-typed configurations that the real `Regime`
+    constructor would reject.
 
     """
 
-    n_periods: int | None = None
-    actions: dict[str, Grid | None] | None = None
-    states: dict[str, Grid | None] | None = None
-    state_transitions: dict[str, UserFunction | None] = field(default_factory=dict)
-    constraints: dict[str, UserFunction] = field(default_factory=dict)
-    transition: UserFunction | None = None
-    functions: dict[str, UserFunction] = field(default_factory=dict)
+    def __init__(
+        self,
+        *,
+        n_periods: int | None = None,
+        actions: dict[str, Grid | None] | None = None,
+        states: dict[str, Grid | None] | None = None,
+        state_transitions: dict[str, UserFunction | None] | None = None,
+        constraints: dict[str, UserFunction] | None = None,
+        transition: UserFunction | None = None,
+        functions: dict[str, UserFunction] | None = None,
+    ) -> None:
+        object.__setattr__(self, "n_periods", n_periods)
+        object.__setattr__(self, "actions", actions if actions is not None else {})
+        object.__setattr__(self, "states", states if states is not None else {})
+        object.__setattr__(
+            self,
+            "state_transitions",
+            state_transitions if state_transitions is not None else {},
+        )
+        object.__setattr__(
+            self, "constraints", constraints if constraints is not None else {}
+        )
+        object.__setattr__(self, "transition", transition)
+        object.__setattr__(
+            self, "functions", functions if functions is not None else {}
+        )
+        # Match Regime's defaults for fields RegimeMock callers don't touch
+        object.__setattr__(self, "active", lambda _age: True)
+        object.__setattr__(self, "derived_categoricals", MappingProxyType({}))
+        object.__setattr__(self, "description", "")
+        # `Regime.__post_init__` injects the default `H` for non-terminal
+        # regimes; mirror that here.
+        if not self.terminal and "H" not in self.functions:
+            object.__setattr__(self, "functions", {**self.functions, "H": _default_H})
 
     @property
     def terminal(self) -> bool:
         return self.transition is None
 
-    def __post_init__(self) -> None:
-        if not self.terminal and "H" not in self.functions:
-            self.functions = {**self.functions, "H": _default_H}
-
     def get_all_functions(
         self, phase: Literal["solve", "simulate"] = "solve"
-    ) -> dict[str, UserFunction]:
+    ) -> MappingProxyType[str, UserFunction]:
         """Get all regime functions including utility, constraints, and transitions."""
         result: dict[str, UserFunction] = {}
         for name, func in self.functions.items():
@@ -54,4 +80,4 @@ class RegimeMock:
             )
         if self.transition:
             result["next_regime"] = self.transition
-        return result
+        return MappingProxyType(result)

--- a/tests/simulation/test_simulate.py
+++ b/tests/simulation/test_simulate.py
@@ -199,7 +199,7 @@ def test_simulate_with_only_discrete_actions():
     result = model.simulate(
         params=params,
         initial_conditions={
-            "wealth": jnp.array([0, 2]),
+            "wealth": jnp.array([0.0, 2.0]),
             "age": jnp.array([50.0, 50.0]),
             "regime": jnp.array([DiscreteRegimeId.working_life] * 2),
         },

--- a/tests/test_argmax.py
+++ b/tests/test_argmax.py
@@ -13,7 +13,7 @@ jitted_argmax = jit(argmax_and_max, static_argnums=[1, 2])
 
 
 def test_argmax_1d_with_mask():
-    a = jnp.arange(10)
+    a = jnp.arange(10, dtype=jnp.int32)
     mask = jnp.array([1, 0, 0, 1, 1, 0, 0, 0, 0, 0], dtype=bool)
     _argmax, _max = jitted_argmax(a, where=mask, initial=-1)
     assert _argmax == 4
@@ -21,7 +21,7 @@ def test_argmax_1d_with_mask():
 
 
 def test_argmax_2d_with_mask():
-    a = jnp.arange(10).reshape(2, 5)
+    a = jnp.arange(10, dtype=jnp.int32).reshape(2, 5)
     mask = jnp.array([1, 0, 0, 1, 1, 0, 0, 0, 0, 0], dtype=bool).reshape(a.shape)
 
     _argmax, _max = jitted_argmax(a, axis=None, where=mask, initial=-1)
@@ -38,14 +38,14 @@ def test_argmax_2d_with_mask():
 
 
 def test_argmax_1d_no_mask():
-    a = jnp.arange(10)
+    a = jnp.arange(10, dtype=jnp.int32)
     _argmax, _max = jitted_argmax(a)
     assert _argmax == 9
     assert _max == 9
 
 
 def test_argmax_2d_no_mask():
-    a = jnp.arange(10).reshape(2, 5)
+    a = jnp.arange(10, dtype=jnp.int32).reshape(2, 5)
 
     _argmax, _max = jitted_argmax(a, axis=None)
     assert _argmax == 9
@@ -65,7 +65,7 @@ def test_argmax_2d_no_mask():
 
 
 def test_argmax_3d_no_mask():
-    a = jnp.arange(24).reshape(2, 3, 4)
+    a = jnp.arange(24, dtype=jnp.int32).reshape(2, 3, 4)
 
     _argmax, _max = jitted_argmax(a, axis=None)
     assert _argmax == 23
@@ -107,37 +107,37 @@ def test_argmax_with_ties():
 
 
 def test_move_axes_to_back_1d():
-    a = jnp.arange(4)
+    a = jnp.arange(4, dtype=jnp.int32)
     got = _move_axes_to_back(a, axes=(0,))
     assert_array_equal(got, a)
 
 
 def test_move_axes_to_back_2d():
-    a = jnp.arange(4).reshape(2, 2)
+    a = jnp.arange(4, dtype=jnp.int32).reshape(2, 2)
     got = _move_axes_to_back(a, axes=(0,))
     assert_array_equal(got, a.transpose(1, 0))
 
 
 def test_move_axes_to_back_3d():
     # 2 dimensions in back
-    a = jnp.arange(8).reshape(2, 2, 2)
+    a = jnp.arange(8, dtype=jnp.int32).reshape(2, 2, 2)
     got = _move_axes_to_back(a, axes=(0, 1))
     assert_array_equal(got, a.transpose(2, 0, 1))
 
     # 2 dimensions in front
-    a = jnp.arange(8).reshape(2, 2, 2)
+    a = jnp.arange(8, dtype=jnp.int32).reshape(2, 2, 2)
     got = _move_axes_to_back(a, axes=(1,))
     assert_array_equal(got, a.transpose(0, 2, 1))
 
 
 def test_flatten_last_n_axes_1d():
-    a = jnp.arange(4)
+    a = jnp.arange(4, dtype=jnp.int32)
     got = _flatten_last_n_axes(a, n=1)
     assert_array_equal(got, a)
 
 
 def test_flatten_last_n_axes_2d():
-    a = jnp.arange(4).reshape(2, 2)
+    a = jnp.arange(4, dtype=jnp.int32).reshape(2, 2)
 
     got = _flatten_last_n_axes(a, n=1)
     assert_array_equal(got, a)
@@ -147,7 +147,7 @@ def test_flatten_last_n_axes_2d():
 
 
 def test_flatten_last_n_axes_3d():
-    a = jnp.arange(8).reshape(2, 2, 2)
+    a = jnp.arange(8, dtype=jnp.int32).reshape(2, 2, 2)
 
     got = _flatten_last_n_axes(a, n=1)
     assert_array_equal(got, a)

--- a/tests/test_fgp_discretization.py
+++ b/tests/test_fgp_discretization.py
@@ -287,7 +287,12 @@ def test_mixture_cdf_spot_check():
     """Spot-check mixture CDF against manual scipy-style computation."""
     x = jnp.array([0.0, 0.1, -0.1])
     got = _mixture_cdf(
-        x=x, p1=FGP_P1, mu1=FGP_MU1, sigma1=FGP_SIGMA1, mu2=FGP_MU2, sigma2=FGP_SIGMA2
+        x=x,
+        p1=jnp.asarray(FGP_P1),
+        mu1=jnp.asarray(FGP_MU1),
+        sigma1=jnp.asarray(FGP_SIGMA1),
+        mu2=jnp.asarray(FGP_MU2),
+        sigma2=jnp.asarray(FGP_SIGMA2),
     )
 
     expected = FGP_P1 * jax_cdf((x - FGP_MU1) / FGP_SIGMA1) + (1 - FGP_P1) * jax_cdf(

--- a/tests/test_float_dtype_invariants.py
+++ b/tests/test_float_dtype_invariants.py
@@ -100,8 +100,8 @@ def test_process_params_casts_float64_array_to_canonical_under_no_x64(
     }
 
     out = process_params(
-        params=user_params,  # ty: ignore[invalid-argument-type]
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params=user_params,
+        params_template=template,
     )
 
     schedule = out["regime_a"]["schedule"]
@@ -117,7 +117,7 @@ def test_process_params_casts_python_float_to_canonical(x64_disabled: None):
 
     out = process_params(
         params=user_params,
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params_template=template,
     )
 
     discount_factor = out["regime_a"]["discount_factor"]
@@ -134,8 +134,8 @@ def test_process_params_float_array_overflow_raises_with_qualified_name(
 
     with pytest.raises(OverflowError, match="schedule"):
         process_params(
-            params=user_params,  # ty: ignore[invalid-argument-type]
-            params_template=template,  # ty: ignore[invalid-argument-type]
+            params=user_params,
+            params_template=template,
         )
 
 
@@ -250,7 +250,7 @@ def test_process_params_casts_float_array_inside_mapping_leaf_to_canonical(
 
     out = process_params(
         params=user_params,
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params_template=template,
     )
 
     assert (
@@ -280,7 +280,7 @@ def test_process_params_casts_float_array_inside_sequence_leaf_to_canonical(
 
     out = process_params(
         params=user_params,
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params_template=template,
     )
 
     assert (

--- a/tests/test_float_dtype_invariants.py
+++ b/tests/test_float_dtype_invariants.py
@@ -1,7 +1,7 @@
 """Float dtypes follow `canonical_float_dtype()` across pylcm boundaries."""
 
 from collections.abc import Callable
-from types import MappingProxyType
+from typing import cast
 
 import jax.numpy as jnp
 import numpy as np
@@ -13,11 +13,19 @@ from lcm.params import MappingLeaf
 from lcm.params.processing import process_params
 from lcm.params.sequence_leaf import SequenceLeaf
 from lcm.simulation.initial_conditions import build_initial_states
+from lcm.typing import ParamsTemplate
+from lcm.utils.containers import ensure_containers_are_immutable
 from tests.test_models.deterministic.regression import (
     RegimeId,
     get_model,
     get_params,
 )
+
+
+def _as_template(plain: dict) -> ParamsTemplate:
+    """Deep-freeze a plain nested dict into a `ParamsTemplate` for tests."""
+    return cast("ParamsTemplate", ensure_containers_are_immutable(plain))
+
 
 # These tests deliberately pass `float64` inputs to verify the cast at
 # the barrier. Re-allow the JAX truncation warning that the
@@ -94,9 +102,9 @@ def test_process_params_casts_float64_array_to_canonical_under_no_x64(
     silently truncates to `float32` under no-x64 at construction time, so a
     JAX-built input would never reach the helper as `float64`.
     """
-    template = MappingProxyType({"regime_a": MappingProxyType({"schedule": "Array"})})
+    template = _as_template({"regime_a": {"fun": {"schedule": "Array"}}})
     user_params = {
-        "regime_a": {"schedule": np.asarray([0.1, 0.2, 0.3], dtype=np.float64)}
+        "regime_a": {"fun": {"schedule": np.asarray([0.1, 0.2, 0.3], dtype=np.float64)}}
     }
 
     out = process_params(
@@ -104,23 +112,21 @@ def test_process_params_casts_float64_array_to_canonical_under_no_x64(
         params_template=template,
     )
 
-    schedule = out["regime_a"]["schedule"]
+    schedule = out["regime_a"]["fun__schedule"]
     assert schedule.dtype == jnp.float32
 
 
 def test_process_params_casts_python_float_to_canonical(x64_disabled: None):
     """A Python `float` param leaf is cast to `canonical_float_dtype()`."""
-    template = MappingProxyType(
-        {"regime_a": MappingProxyType({"discount_factor": "float"})}
-    )
-    user_params = {"regime_a": {"discount_factor": 0.95}}
+    template = _as_template({"regime_a": {"fun": {"discount_factor": "float"}}})
+    user_params = {"regime_a": {"fun": {"discount_factor": 0.95}}}
 
     out = process_params(
         params=user_params,
         params_template=template,
     )
 
-    discount_factor = out["regime_a"]["discount_factor"]
+    discount_factor = out["regime_a"]["fun__discount_factor"]
     np.testing.assert_allclose(float(discount_factor), 0.95, rtol=1e-6)
     assert discount_factor.dtype == canonical_float_dtype()
 
@@ -129,8 +135,10 @@ def test_process_params_float_array_overflow_raises_with_qualified_name(
     x64_disabled: None,
 ):
     """An out-of-float32 float64 array raises naming the qualified leaf."""
-    template = MappingProxyType({"regime_a": MappingProxyType({"schedule": "Array"})})
-    user_params = {"regime_a": {"schedule": np.asarray([0.0, 1e40], dtype=np.float64)}}
+    template = _as_template({"regime_a": {"fun": {"schedule": "Array"}}})
+    user_params = {
+        "regime_a": {"fun": {"schedule": np.asarray([0.0, 1e40], dtype=np.float64)}}
+    }
 
     with pytest.raises(OverflowError, match="schedule"):
         process_params(
@@ -234,17 +242,17 @@ def test_process_params_casts_float_array_inside_mapping_leaf_to_canonical(
     key: str, x64_disabled: None
 ):
     """`MappingLeaf` float arrays land at `canonical_float_dtype()`."""
-    template = MappingProxyType(
-        {"regime_a": MappingProxyType({"sched": "MappingLeaf"})}
-    )
+    template = _as_template({"regime_a": {"fun": {"sched": "MappingLeaf"}}})
     user_params = {
         "regime_a": {
-            "sched": MappingLeaf(
-                {
-                    "low": np.asarray([0.1, 0.2], dtype=np.float64),
-                    "high": np.asarray([0.5, 0.7], dtype=np.float64),
-                }
-            )
+            "fun": {
+                "sched": MappingLeaf(
+                    {
+                        "low": np.asarray([0.1, 0.2], dtype=np.float64),
+                        "high": np.asarray([0.5, 0.7], dtype=np.float64),
+                    }
+                )
+            }
         }
     }
 
@@ -254,7 +262,7 @@ def test_process_params_casts_float_array_inside_mapping_leaf_to_canonical(
     )
 
     assert (
-        out["regime_a"]["sched"].data[key].dtype  # ty: ignore[unresolved-attribute]
+        out["regime_a"]["fun__sched"].data[key].dtype  # ty: ignore[unresolved-attribute]
         == jnp.float32
     )
 
@@ -264,17 +272,17 @@ def test_process_params_casts_float_array_inside_sequence_leaf_to_canonical(
     index: int, x64_disabled: None
 ):
     """`SequenceLeaf` float arrays land at `canonical_float_dtype()`."""
-    template = MappingProxyType(
-        {"regime_a": MappingProxyType({"sched": "SequenceLeaf"})}
-    )
+    template = _as_template({"regime_a": {"fun": {"sched": "SequenceLeaf"}}})
     user_params = {
         "regime_a": {
-            "sched": SequenceLeaf(
-                [
-                    np.asarray([0.1, 0.2], dtype=np.float64),
-                    np.asarray([0.5, 0.7], dtype=np.float64),
-                ]
-            )
+            "fun": {
+                "sched": SequenceLeaf(
+                    [
+                        np.asarray([0.1, 0.2], dtype=np.float64),
+                        np.asarray([0.5, 0.7], dtype=np.float64),
+                    ]
+                )
+            }
         }
     }
 
@@ -284,6 +292,6 @@ def test_process_params_casts_float_array_inside_sequence_leaf_to_canonical(
     )
 
     assert (
-        out["regime_a"]["sched"].data[index].dtype  # ty: ignore[unresolved-attribute]
+        out["regime_a"]["fun__sched"].data[index].dtype  # ty: ignore[unresolved-attribute]
         == jnp.float32
     )

--- a/tests/test_function_representation.py
+++ b/tests/test_function_representation.py
@@ -58,7 +58,7 @@ def test_function_evaluator_with_one_continuous_variable():
     func = partial(evaluator, next_V_arr=next_V_arr)
 
     # test the evaluator
-    got = func(next_wealth=0.5)
+    got = func(next_wealth=jnp.asarray(0.5))
     expected = 0.5 * jnp.pi + 2
     assert jnp.allclose(got, expected)
 
@@ -146,8 +146,8 @@ def test_function_evaluator(binary_discrete_grid):
     out = evaluator(
         next_retired=1,
         next_insured=0,
-        next_wealth=600,
-        next_human_capital=1.5,
+        next_wealth=jnp.asarray(600.0),
+        next_human_capital=jnp.asarray(1.5),
         next_V_arr=next_V_arr,
     )
 
@@ -169,7 +169,7 @@ def test_get_coordinate_finder():
         grid=LinSpacedGrid(start=0, stop=10, n_points=21),
     )
     find_coordinate = partial(find_coordinate)
-    calculated = find_coordinate(wealth=5.75)
+    calculated = find_coordinate(wealth=jnp.asarray(5.75))
     assert calculated == 11.5
 
 
@@ -224,7 +224,7 @@ def test_get_function_evaluator_illustrative():
     # partial the function values into the evaluator
     f = partial(evaluator, values_name=values)
 
-    got = f(prefix_a=0.25)
+    got = f(prefix_a=jnp.asarray(0.25))
     expected = jnp.pi * 0.25 + 2
 
     assert jnp.allclose(got, expected)
@@ -245,10 +245,10 @@ def test_get_coordinate_finder_illustrative():
         in_name="a",
         grid=LinSpacedGrid(start=0, stop=1, n_points=3),
     )
-    assert find_coordinate(a=0) == 0
-    assert find_coordinate(a=0.5) == 1
-    assert find_coordinate(a=1) == 2
-    assert find_coordinate(a=0.25) == 0.5
+    assert find_coordinate(a=jnp.asarray(0.0)) == 0
+    assert find_coordinate(a=jnp.asarray(0.5)) == 1
+    assert find_coordinate(a=jnp.asarray(1.0)) == 2
+    assert find_coordinate(a=jnp.asarray(0.25)) == 0.5
 
 
 @pytest.mark.illustrative
@@ -349,9 +349,9 @@ def test_function_evaluator_performs_linear_extrapolation():
     func = partial(evaluator, next_V_arr=next_V_arr)
 
     # test the evaluator on values outside the grid
-    wealth_outside_of_grid = [-0.5, 3.5, 10]
+    wealth_outside_of_grid = [-0.5, 3.5, 10.0]
     # We expect linear extrapolation
     expected = jnp.pi * jnp.array(wealth_outside_of_grid) + 2
 
-    got = jnp.array([func(next_wealth=w) for w in wealth_outside_of_grid])
+    got = jnp.array([func(next_wealth=jnp.asarray(w)) for w in wealth_outside_of_grid])
     assert jnp.allclose(got, expected)

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -753,15 +753,15 @@ def test_piecewise_boundary_conditions(grid_cls, boundary_style: str):
         expected_coord_at = 5.0 if is_lin else 2.0
 
     # Test value just below boundary -> piece 0
-    coord_below = float(grid.get_coordinate(below_boundary))
+    coord_below = float(grid.get_coordinate(jnp.asarray(below_boundary)))
     assert coord_below < expected_coord_at
 
     # Test value exactly at boundary
-    coord_at = float(grid.get_coordinate(boundary))
+    coord_at = float(grid.get_coordinate(jnp.asarray(boundary)))
     assert coord_at == pytest.approx(expected_coord_at)
 
     # Test value just above boundary -> piece 1
-    coord_above = float(grid.get_coordinate(above_boundary))
+    coord_above = float(grid.get_coordinate(jnp.asarray(above_boundary)))
     assert coord_above > expected_coord_at
 
 

--- a/tests/test_int_dtype_invariants.py
+++ b/tests/test_int_dtype_invariants.py
@@ -128,10 +128,15 @@ def test_process_params_casts_python_int_to_int32() -> None:
 
 
 def test_process_params_casts_int64_array_to_int32() -> None:
-    """A `jnp.int64` array param leaf is normalised to `jnp.int32`."""
+    """An `int64` array param leaf is normalised to `jnp.int32`.
+
+    Built with `np.asarray`: a JAX `int64` array is rejected at the beartype
+    boundary (`_ParamsLeaf` pins JAX integer leaves to `int32`), so the
+    realistic raw-data path for a wider-dtype input is a numpy array.
+    """
     template = _as_template({"regime_a": {"fun": {"schedule": "Array"}}})
     user_params = {
-        "regime_a": {"fun": {"schedule": jnp.asarray([0, 1, 2], dtype=jnp.int64)}}
+        "regime_a": {"fun": {"schedule": np.asarray([0, 1, 2], dtype=np.int64)}}
     }
 
     out = process_params(

--- a/tests/test_int_dtype_invariants.py
+++ b/tests/test_int_dtype_invariants.py
@@ -110,7 +110,7 @@ def test_process_params_casts_python_int_to_int32() -> None:
 
     out = process_params(
         params=user_params,
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params_template=template,
     )
 
     final_age = out["regime_a"]["final_age"]
@@ -125,7 +125,7 @@ def test_process_params_casts_int64_array_to_int32() -> None:
 
     out = process_params(
         params=user_params,
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params_template=template,
     )
 
     schedule = out["regime_a"]["schedule"]
@@ -141,8 +141,8 @@ def test_process_params_int_array_overflow_raises_with_qualified_name() -> None:
 
     with pytest.raises(ValueError, match="big_param"):
         process_params(
-            params=user_params,  # ty: ignore[invalid-argument-type]
-            params_template=template,  # ty: ignore[invalid-argument-type]
+            params=user_params,
+            params_template=template,
         )
 
 
@@ -165,7 +165,7 @@ def test_process_params_casts_int_array_inside_mapping_leaf_to_int32(key: str) -
 
     out = process_params(
         params=user_params,
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params_template=template,
     )
 
     assert (
@@ -195,7 +195,7 @@ def test_process_params_casts_int_array_inside_sequence_leaf_to_int32(
 
     out = process_params(
         params=user_params,
-        params_template=template,  # ty: ignore[invalid-argument-type]
+        params_template=template,
     )
 
     assert (

--- a/tests/test_int_dtype_invariants.py
+++ b/tests/test_int_dtype_invariants.py
@@ -1,6 +1,7 @@
 """Integer dtypes are pinned to int32 across pylcm regardless of x64 mode."""
 
 from types import MappingProxyType
+from typing import cast
 
 import jax.numpy as jnp
 import numpy as np
@@ -17,6 +18,8 @@ from lcm.simulation.initial_conditions import (
     build_initial_states,
 )
 from lcm.simulation.transitions import _advance_states_for_subjects
+from lcm.typing import ParamsTemplate
+from lcm.utils.containers import ensure_containers_are_immutable
 from tests.test_models.deterministic.regression import (
     RegimeId,
     dead,
@@ -24,6 +27,12 @@ from tests.test_models.deterministic.regression import (
     get_params,
     working_life,
 )
+
+
+def _as_template(plain: dict) -> ParamsTemplate:
+    """Deep-freeze a plain nested dict into a `ParamsTemplate` for tests."""
+    return cast("ParamsTemplate", ensure_containers_are_immutable(plain))
+
 
 # These tests deliberately pass `int64` inputs to verify the cast at
 # the barrier. Re-allow the JAX truncation warning that the
@@ -105,39 +114,43 @@ def test_advance_states_for_subjects_keeps_same_dtype_round_trip() -> None:
 
 def test_process_params_casts_python_int_to_int32() -> None:
     """A Python `int` param leaf is cast to `jnp.int32`."""
-    template = MappingProxyType({"regime_a": MappingProxyType({"final_age": "int"})})
-    user_params = {"regime_a": {"final_age": 65}}
+    template = _as_template({"regime_a": {"fun": {"final_age": "int"}}})
+    user_params = {"regime_a": {"fun": {"final_age": 65}}}
 
     out = process_params(
         params=user_params,
         params_template=template,
     )
 
-    final_age = out["regime_a"]["final_age"]
+    final_age = out["regime_a"]["fun__final_age"]
     assert int(final_age) == 65
     assert final_age.dtype == jnp.int32
 
 
 def test_process_params_casts_int64_array_to_int32() -> None:
     """A `jnp.int64` array param leaf is normalised to `jnp.int32`."""
-    template = MappingProxyType({"regime_a": MappingProxyType({"schedule": "Array"})})
-    user_params = {"regime_a": {"schedule": jnp.asarray([0, 1, 2], dtype=jnp.int64)}}
+    template = _as_template({"regime_a": {"fun": {"schedule": "Array"}}})
+    user_params = {
+        "regime_a": {"fun": {"schedule": jnp.asarray([0, 1, 2], dtype=jnp.int64)}}
+    }
 
     out = process_params(
         params=user_params,
         params_template=template,
     )
 
-    schedule = out["regime_a"]["schedule"]
+    schedule = out["regime_a"]["fun__schedule"]
     assert schedule.dtype == jnp.int32
 
 
 def test_process_params_int_array_overflow_raises_with_qualified_name() -> None:
     """An out-of-int32-range int array surfaces the param's qualified name."""
-    template = MappingProxyType({"regime_a": MappingProxyType({"big_param": "Array"})})
+    template = _as_template({"regime_a": {"fun": {"big_param": "Array"}}})
     # Numpy here: under `jax_enable_x64=False`, `jnp.asarray(..., dtype=int64)`
     # of an out-of-int32 value raises before our helper sees it.
-    user_params = {"regime_a": {"big_param": np.asarray([0, 2**40], dtype=np.int64)}}
+    user_params = {
+        "regime_a": {"fun": {"big_param": np.asarray([0, 2**40], dtype=np.int64)}}
+    }
 
     with pytest.raises(ValueError, match="big_param"):
         process_params(
@@ -149,17 +162,17 @@ def test_process_params_int_array_overflow_raises_with_qualified_name() -> None:
 @pytest.mark.parametrize("key", ["low", "high"])
 def test_process_params_casts_int_array_inside_mapping_leaf_to_int32(key: str) -> None:
     """`MappingLeaf` int arrays land at `jnp.int32` after params processing."""
-    template = MappingProxyType(
-        {"regime_a": MappingProxyType({"sched": "MappingLeaf"})}
-    )
+    template = _as_template({"regime_a": {"fun": {"sched": "MappingLeaf"}}})
     user_params = {
         "regime_a": {
-            "sched": MappingLeaf(
-                {
-                    "low": jnp.asarray([0, 1], dtype=jnp.int64),
-                    "high": jnp.asarray([10, 20], dtype=jnp.int64),
-                }
-            )
+            "fun": {
+                "sched": MappingLeaf(
+                    {
+                        "low": jnp.asarray([0, 1], dtype=jnp.int64),
+                        "high": jnp.asarray([10, 20], dtype=jnp.int64),
+                    }
+                )
+            }
         }
     }
 
@@ -169,7 +182,7 @@ def test_process_params_casts_int_array_inside_mapping_leaf_to_int32(key: str) -
     )
 
     assert (
-        out["regime_a"]["sched"].data[key].dtype  # ty: ignore[unresolved-attribute]
+        out["regime_a"]["fun__sched"].data[key].dtype  # ty: ignore[unresolved-attribute]
         == jnp.int32
     )
 
@@ -179,17 +192,17 @@ def test_process_params_casts_int_array_inside_sequence_leaf_to_int32(
     index: int,
 ) -> None:
     """`SequenceLeaf` int arrays land at `jnp.int32` after params processing."""
-    template = MappingProxyType(
-        {"regime_a": MappingProxyType({"sched": "SequenceLeaf"})}
-    )
+    template = _as_template({"regime_a": {"fun": {"sched": "SequenceLeaf"}}})
     user_params = {
         "regime_a": {
-            "sched": SequenceLeaf(
-                [
-                    jnp.asarray([0, 1], dtype=jnp.int64),
-                    jnp.asarray([10, 20], dtype=jnp.int64),
-                ]
-            )
+            "fun": {
+                "sched": SequenceLeaf(
+                    [
+                        jnp.asarray([0, 1], dtype=jnp.int64),
+                        jnp.asarray([10, 20], dtype=jnp.int64),
+                    ]
+                )
+            }
         }
     }
 
@@ -199,7 +212,7 @@ def test_process_params_casts_int_array_inside_sequence_leaf_to_int32(
     )
 
     assert (
-        out["regime_a"]["sched"].data[index].dtype  # ty: ignore[unresolved-attribute]
+        out["regime_a"]["fun__sched"].data[index].dtype  # ty: ignore[unresolved-attribute]
         == jnp.int32
     )
 

--- a/tests/test_mapping_leaf.py
+++ b/tests/test_mapping_leaf.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
+from lcm.exceptions import InvalidParamsError
 from lcm.params import MappingLeaf, SequenceLeaf, as_leaf
 from lcm.utils.containers import (
     ensure_containers_are_immutable,
@@ -175,5 +176,5 @@ def test_as_leaf_tuple():
 
 
 def test_as_leaf_rejects_int():
-    with pytest.raises(TypeError, match="as_leaf"):
+    with pytest.raises(InvalidParamsError, match="as_leaf"):
         as_leaf(42)  # ty: ignore[no-matching-overload]

--- a/tests/test_ndimage.py
+++ b/tests/test_ndimage.py
@@ -26,7 +26,7 @@ import lcm.regime_building.ndimage as lcm_ndimage
 from tests.conftest import DECIMAL_PRECISION, X64_ENABLED
 
 # Use 64-bit dtypes when x64 is enabled, 32-bit otherwise
-TEST_DTYPES = [np.int64, np.float64] if X64_ENABLED else [np.int32, np.float32]
+TEST_DTYPES = [np.int32, np.float64] if X64_ENABLED else [np.int32, np.float32]
 
 jax_map_coordinates = partial(jax.scipy.ndimage.map_coordinates, order=1, cval=0)
 scipy_map_coordinates = partial(scipy.ndimage.map_coordinates, order=1, cval=0)

--- a/tests/test_shock_grids.py
+++ b/tests/test_shock_grids.py
@@ -35,9 +35,9 @@ def test_model_with_shock(distribution_type):
     got_simulate = model.simulate(
         params=params,
         initial_conditions={
-            "health": jnp.asarray([0, 0]),
-            "income": jnp.asarray([0, 0]),
-            "wealth": jnp.asarray([1, 1]),
+            "health": jnp.asarray([0, 0], dtype=jnp.int32),
+            "income": jnp.asarray([0.0, 0.0]),
+            "wealth": jnp.asarray([1.0, 1.0]),
             "age": jnp.asarray([0.0, 0.0]),
             "regime": jnp.array([RegimeId.alive] * 2),
         },
@@ -84,11 +84,11 @@ def test_model_with_cross_regime_shocks(distribution_type: str) -> None:
     result = model.simulate(
         params=params,
         initial_conditions={
-            "health": jnp.zeros(2, dtype=int),
+            "health": jnp.zeros(2, dtype=jnp.int32),
             "income": jnp.zeros(2),
             "wealth": jnp.ones(2),
             "age": jnp.zeros(2),
-            "regime": jnp.full(2, MultiRegimeId.work, dtype=int),
+            "regime": jnp.full(2, MultiRegimeId.work, dtype=jnp.int32),
         },
         period_to_regime_to_V_arr=None,
         seed=42,

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -41,8 +41,8 @@ def test_model_simulate_with_stochastic_model():
     result = model.simulate(
         params=params,
         initial_conditions={
-            "health": jnp.array([1, 1, 0, 0]),
-            "partner": jnp.array([0, 0, 1, 0]),
+            "health": jnp.array([1, 1, 0, 0], dtype=jnp.int32),
+            "partner": jnp.array([0, 0, 1, 0], dtype=jnp.int32),
             "wealth": jnp.array([10.0, 50.0, 30, 80.0]),
             "age": jnp.array([40.0, 40.0, 40.0, 40.0]),
             "regime": jnp.array([RegimeId.working_life] * 4),
@@ -190,8 +190,8 @@ def test_compare_deterministic_and_stochastic_results_value_function(
     # Compare simulation results
     # ==================================================================================
     initial_conditions = {
-        "health": jnp.array([1, 1, 0, 0]),
-        "partner": jnp.array([0, 0, 0, 0]),
+        "health": jnp.array([1, 1, 0, 0], dtype=jnp.int32),
+        "partner": jnp.array([0, 0, 0, 0], dtype=jnp.int32),
         "wealth": jnp.array([10.0, 50.0, 30, 80.0]),
         "age": jnp.array([40.0, 40.0, 40.0, 40.0]),
         "regime": jnp.array([RegimeId.working_life] * 4),

--- a/tests/test_validate_param_types.py
+++ b/tests/test_validate_param_types.py
@@ -60,7 +60,7 @@ def test_numpy_array_param_normalised_to_canonical_jax_array() -> None:
     """A numpy array param is cast to a JAX array at `canonical_float_dtype()`."""
     model = _make_model()
     internal = model._process_params(
-        params={"bonus": np.asarray(1.0, dtype=np.float64), "discount_factor": 0.95}  # ty: ignore[invalid-argument-type]
+        params={"bonus": np.asarray(1.0, dtype=np.float64), "discount_factor": 0.95}
     )
     bonus = internal["working"]["utility__bonus"]
     assert isinstance(bonus, Array)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -162,7 +162,7 @@ def test_from_regime_orders_discrete_states_continuous_states_actions(
         },
         functions={"utility": lambda c_action: 0},  # noqa: ARG005
     )
-    variables = Variables.from_regime(regime)  # ty: ignore[invalid-argument-type]
+    variables = Variables.from_regime(regime)
     assert list(variables) == ["a_discrete", "b_continuous", "c_action"]
 
 
@@ -188,5 +188,5 @@ def test_from_regime_within_states_orders_by_batch_size(
         actions={"a": DiscreteGrid(binary_category_class)},
         functions={"utility": lambda a: 0},  # noqa: ARG005
     )
-    variables = Variables.from_regime(regime)  # ty: ignore[invalid-argument-type]
+    variables = Variables.from_regime(regime)
     assert variables.discrete_state_names == ("first", "second", "third")


### PR DESCRIPTION
Stacked on #355.

## Summary

Activates beartype's AST-rewriting claw on `lcm.grids`, `lcm.shocks`,
and `lcm.params` and fixes every annotation lie those three subpackages
were carrying. Perimeter `@beartype` / `@beartype_init` decorators on
user-facing constructors (from #355) are unchanged.

### What's live

The claw registrations sit at the top of `lcm/__init__.py`, **before**
the bulk-import of submodules, so the AST-rewriting import hook gets
installed before any matching submodule loads. Per-subpackage
`BeartypeConf` maps type violations to the project exception most
natural to that scope:

- `lcm.grids` / `lcm.shocks` → `GridInitializationError`
- `lcm.params` → `InvalidParamsError`

A probe call into a deliberately-bad-typed helper (e.g.
`get_linspace_coordinate(value="not a float", ...)`) raises
`GridInitializationError` end-to-end.

The earlier `tests/conftest.py` registration ran *after* `from
lcm._beartype_conf import ...` triggered `lcm/__init__.py`, which
eagerly imports every targeted submodule — the claw was a no-op on
every prior run. Moving the registration into `lcm/__init__.py`
itself fixed that.

### Drift fixed alongside activation

- **`Piece` cumulative `n_points`**: explicit `dtype=jnp.int32` on the
  `_piece_n_points` array and `sum(dtype=jnp.int32)` so the property
  honours its `ScalarInt` annotation under `jax_enable_x64=True`
  (`jnp.sum` otherwise promotes to int64).
- **`_ShockGrid.compute_gridpoints` / `compute_transition_probs` /
  `Tauchen._innovation_variance`**: kwargs widened from `float |
  FloatND` to `float | FloatND | IntND`. Runtime params like `n_std=2`
  arrive as 0-d int arrays after pylcm's canonical-dtype cast.
- **`get_coordinate` on every continuous grid + `get_irreg_coordinate`**:
  accept Python `float` / `int` alongside `ScalarFloat | FloatND`.
- **`process_params(params_template=...)`** widened to
  `Mapping[RegimeName, Mapping[str, object]]` since real callers and
  test fixtures both use plain dicts at the inner levels.
- **`_ParamsLeaf`** adds `np.ndarray` so numpy-array params satisfy
  the perimeter check before pylcm casts them.
- **`create_regime_params_template(regime: ...)` and helpers**,
  **`create_params_template(internal_regimes: ...)`** typed as `Any`
  so duck-typed test mocks (`RegimeMock`, `MockRegime`) satisfy the
  signature — the functions themselves only touch a small structural
  interface.
- **PRNG keys**: every `draw_shock`'s `key:` parameter uses
  `KeyArray` (new alias in `lcm.typing`); JAX PRNG keys have
  `dtype=key<fry>`, not float, so they don't match `FloatND`.
- **`MappingProxyType → Mapping`** at internal entry points where
  callers pass plain `dict` (e.g. `solve_brute.solve`, perimeter of
  `process_params`).
- **JAX scalar/array dtype drift** in `grids/coordinates.py`:
  `get_linspace_coordinate` / `get_logspace_coordinate` widen
  `start: ScalarFloat` / `stop: ScalarFloat` to `ScalarFloat |
  FloatND` (recursive log → linear path passes 0-d arrays).
- **`Never` → `NoReturn`** in `simulation/initial_conditions.py`
  (`typing.Never` is unsupported by beartype 0.22).
- **`persistence.py`** defines `_ModelOrNone` / `_SimulationResultOrNone`
  as `TYPE_CHECKING`-conditional aliases that resolve to `Any` at
  runtime — the bare-union string forward reference `'Model | None'`
  was unparseable by beartype's forward-ref machinery, and importing
  `Model` at the top causes a circular import.
- **Two corrections found in passing**:
  - `dtypes.py:canonical_float_dtype` return type was `jnp.dtype` but
    actually returns `_ScalarMeta` (a class). Changed to `type`.
  - `utils/containers.py:get_field_names_and_values` parameter was
    `dc: type` but the function passes through `dataclasses.fields()`,
    which accepts both classes and instances. Changed to `dc: object`.

### Naming

`v_array` → `V_arr` rename on `_RegimeSharding.V_arr_sharding` and
`_build_zero_V_arr` to match the rest of the solve path (which
already uses `V_arr` / `next_regime_to_V_arr` throughout). Came in
through the merge from `distributed` (#346).

### Test plan
- [x] `pixi run -e tests-cpu pytest -n 4` — 979 passed, 10 skipped
- [x] `pixi run ty` — clean
- [x] `prek run --all-files` — clean
- [x] Probe call confirms the claw is genuinely live: a wrong-typed
      `get_linspace_coordinate(value="not a float", ...)` raises
      `GridInitializationError` from the claw-installed wrapper, not
      `TypeError` from the bare Python operator inside the function.
- [x] aca-dev workspace tests (414 passed) green against this branch's
      submodule pointer.

### Performance

Full pylcm test suite: ~88-90 s with claw live vs ~86-87 s without —
~3% overhead at suite scale. Inside `jax.jit`, beartype's checks run
during tracing only, so steady-state execution is unaffected.

### Out of scope

Extending the claw to `lcm.regime_building` / `lcm.solution` /
`lcm.simulation` is blocked on a structural conflict:
`lcm.regime_building.processing._wrap_regime_transition_probs` uses
`functools.wraps(user_func)` + dags' `with_signature` to propagate the
user function's annotations onto an internal wrapper. The claw then
decorates that wrapper with `@beartype`, and beartype enforces user
annotations like `age: float` / `period: int` against JIT tracers
inside `jax.jit`. Either annotation stripping at the wrap site, or a
beartype hint-override mapping `float`/`int` to `Array | float | int`,
is needed before that scope can go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
