### PR TITLE
Emit solved V-arrays sharded via out_shardings (continuous-axis prerequisite)

### DIFF
--- a/src/_lcm/solution/solve_brute.py
+++ b/src/_lcm/solution/solve_brute.py
@@ -73,12 +73,20 @@ def solve(
         }
     )
 
-    # AOT-compile all unique max_Q_over_a functions in parallel.
+    # AOT-compile all unique max_Q_over_a functions in parallel. The regime's
+    # declared V-array sharding rides along as `out_shardings` so the solved V
+    # is emitted on the layout its next-period consumers were lowered against.
     compiled_functions = _compile_all_functions(
         regimes=regimes,
         flat_params=flat_params,
         ages=ages,
         next_regime_to_V_arr=next_regime_to_V_arr,
+        regime_V_shardings=MappingProxyType(
+            {
+                regime_name: topology.sharding
+                for regime_name, topology in regime_V_topology.items()
+            }
+        ),
         enable_jit=enable_jit,
         max_compilation_workers=max_compilation_workers,
         logger=logger,
@@ -279,6 +287,7 @@ def _compile_all_functions(
     flat_params: FlatParams,
     ages: AgeGrid,
     next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
+    regime_V_shardings: MappingProxyType[RegimeName, jax.NamedSharding | None],
     enable_jit: bool,
     max_compilation_workers: int | None,
     logger: logging.Logger,
@@ -299,6 +308,14 @@ def _compile_all_functions(
         ages: Age grid for the model.
         next_regime_to_V_arr: Template with consistent keys and V array shapes
             for constructing lowering arguments.
+        regime_V_shardings: Immutable mapping of each regime's V-array device
+            sharding, or `None` where the regime distributes no state. Passed as
+            the `out_shardings` of the compiled `max_Q_over_a` so the solved
+            array carries the declared sharding its next-period consumers were
+            lowered against, without a post-hoc `device_put` reshard. Natural jit
+            output inference reproduces the declared layout for a sharded
+            discrete axis but not for a sharded continuous one, where the
+            interpolation read mixes the axis into the output.
         enable_jit: Whether to JIT-compile the functions of the internal regimes.
         max_compilation_workers: Maximum threads for parallel compilation.
             Defaults to `os.cpu_count()`.
@@ -360,7 +377,9 @@ def _compile_all_functions(
         logger.info("%d/%d  %s", i, n_unique, label)
         logger.info("  lowering ...")
         start = time.monotonic()
-        lowered[func_id] = jax.jit(func).lower(**lower_args)
+        lowered[func_id] = jax.jit(
+            func, out_shardings=regime_V_shardings[regime_name]
+        ).lower(**lower_args)
         elapsed = time.monotonic() - start
         logger.info("  lowered in %s", format_duration(seconds=elapsed))
 


### PR DESCRIPTION
Stacked on #370.

Re-adds the `out_shardings` path dropped from #364: `solve` lowers each `max_Q_over_a` with the regime's declared V-array sharding as `out_shardings`, so the solved V is emitted on the layout its next-period `next_regime_to_V_arr` consumers were lowered against — no post-hoc `device_put` reshard.

For a sharded **discrete** axis, natural jit output inference already reproduces this layout (the existing `test_solution_running_on_multiple_cpus` covers it), so this is a no-op there. Its purpose is to enable a sharded **continuous** axis (e.g. `aime`): there the next-period interpolation read folds the axis into the output, so without explicit `out_shardings` the solved V returns on a layout its consumers were not lowered against. This is the prerequisite for lifting `_fail_if_continuous_grid_distributed` and sharding `aime` to scale past the 3-device `pref_type` ceiling.

Ported from #364's `3009542` (the `batch_size>0 + distributed=True` combo its original test used is now rejected at grid construction, so the existing distributed suite is the regression guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)