### PR TITLE
Dissolution routing: revert each individual to its own single regime (synthetic mode)

### DIFF
--- a/src/_lcm/simulation/gated_routing.py
+++ b/src/_lcm/simulation/gated_routing.py
@@ -29,22 +29,28 @@ gated edge (e.g. a married couple's divorce edge) declares one leg per
 stakeholder, each with its OWN fallback regime (wife -> her own single
 regime, husband -> his). pylcm's forward simulation is a single fixed-size
 population pass: one subject ROW cannot occupy two regimes at once, so a
-genuine second forward-simulated row per additional stakeholder — subject
-population reallocation on divorce — is NOT implemented here; it is a
-follow-up engine feature (see `pylcm-extension-implementation-plan.md`,
-slice 6 notes), analogous in spirit to the deferred child-age
-state-reassignment hook. What IS implemented, faithfully and tested: the
+genuine second forward-simulated row per additional stakeholder — LINKED
+subject population reallocation on divorce, where both partners are
+independently tracked rows that unlink — is NOT implemented here; it is a
+follow-up engine feature (row-split PLAN, "linked mode"). What IS
+implemented, faithfully and tested (row-split PLAN, "synthetic mode"): the
 router recomputes the gate at the realized state, computes EVERY leg's own
 fallback state coordinates via `Regime.gated_edge_leg_projectors` and writes
 each into its OWN fallback regime's per-subject state slot (so a divorced
 household's row-level record of "what regime and state would each partner
 have started at" is complete and correct for every stakeholder), and then
-picks ONE of them — deterministically, the FIRST declared leg (source
-stakeholder order) — as the row's own continuing regime membership. This
-mirrors the ENGINE's existing pattern elsewhere (e.g. `calculate_next_states`
-already computes states for every structurally reachable target regime
-regardless of which one is stochastically drawn as `next_regime_id`) rather
-than inventing a new convention.
+picks ONE of them as the row's OWN continuing regime membership: the leg
+whose `source_stakeholder` matches `own_stakeholder` — the row's own,
+call-level-fixed role (e.g. "f" for an all-women simulate() population
+tracking synthetic male partners, "m" for an all-men population) — or, when
+`own_stakeholder` is `None` (the default: a singleton source, or a caller
+that never declares one), the FIRST declared leg (source stakeholder order),
+exactly as before. `own_stakeholder` is a single value for the whole
+`simulate()` call, not a per-subject array: this is the "synthetic partner"
+mode (EKL Appendix F's two independent, single-gender cohorts), which needs
+no cross-row linkage. A genuinely mixed population where individual rows
+have DIFFERING own-roles, or two TRACKED (linked) rows that must unlink into
+each other's rows on divorce, remains the deferred "linked mode".
 
 **Deferred: the generic between-period state-reassignment hook.** The
 design doc (§2 E4) and EKL's App. E.2 additionally motivate a callback that
@@ -74,6 +80,7 @@ from _lcm.engine import Regime, StateActionSpace
 from _lcm.regime_building.gated_edges import (
     GATE_ARR_NAME,
     GATE_THRESHOLD,
+    ResolvedEdgeLeg,
     build_same_period_mapping_for_fold,
 )
 from _lcm.simulation.transitions import _advance_states_for_subjects
@@ -136,6 +143,29 @@ def _call_with_accepted_kwargs(func: Callable, kwargs: Mapping[str, object]) -> 
     return func(**{name: value for name, value in kwargs.items() if name in accepted})
 
 
+def _select_own_leg(
+    legs: tuple[ResolvedEdgeLeg, ...], own_stakeholder: str | None
+) -> ResolvedEdgeLeg:
+    """Pick the leg whose fallback IS this row's own continuing regime.
+
+    ROW-SPLIT (synthetic mode). A collective source declares one leg per
+    stakeholder (`leg.source_stakeholder`); `own_stakeholder` is this
+    `simulate()` call's fixed own-role (e.g. "f" for an all-women
+    population), so the matching leg's fallback is the row's own single
+    regime on divorce — not unconditionally the first declared leg. Falls
+    back to the first declared leg when `own_stakeholder` is `None` (a
+    singleton source has exactly one leg anyway) or matches no leg (a
+    caller-error-tolerant default, not a silent per-edge mismatch: singleton
+    sources' sole leg has `source_stakeholder=None` and never matches a
+    non-`None` `own_stakeholder`, which is the common, correct case).
+    """
+    if own_stakeholder is not None:
+        for leg in legs:
+            if leg.source_stakeholder == own_stakeholder:
+                return leg
+    return legs[0]
+
+
 def route_gated_edges(
     *,
     regime: Regime,
@@ -145,6 +175,7 @@ def route_gated_edges(
     new_subject_regime_ids: Int1D,
     subjects_in_regime: Bool1D,
     flat_params: FlatParams,
+    own_stakeholder: str | None = None,
 ) -> tuple[StatesPerRegime, Int1D]:
     """Route each subject through its regime's declared gated edges (E4).
 
@@ -158,9 +189,17 @@ def route_gated_edges(
     structurally reaches a gated edge's target — see module docstring), then
     for `subjects_in_regime`: writes EVERY leg's own fallback state
     coordinates into its fallback regime's state slot, and sets this row's
-    own continuing regime membership to the target (gate open) or the FIRST
-    leg's fallback (gate closed) — see the module docstring's scope fence for
-    a collective (multi-leg) source.
+    own continuing regime membership to the target (gate open) or its OWN
+    leg's fallback (gate closed, selected via `own_stakeholder` — see
+    `_select_own_leg` and the module docstring's scope fence for a
+    collective (multi-leg) source).
+
+    Args:
+        own_stakeholder: This `simulate()` call's fixed own-role (ROW-SPLIT,
+            synthetic mode), e.g. "f"/"m" for an all-women/all-men
+            population tracking synthetic partners. `None` (default)
+            preserves the original "first declared leg" convention exactly
+            — byte-identical for any caller that does not pass it.
     """
     if not regime.gated_edges:
         return next_states, new_subject_regime_ids
@@ -183,8 +222,9 @@ def route_gated_edges(
 
         target_id = regime_names_to_ids[target_name]
         legs = edge.legs
-        primary_fallback_id = regime_names_to_ids[legs[0].fallback.regime]
-        candidate_id = jnp.where(gate_bool, target_id, primary_fallback_id)
+        own_leg = _select_own_leg(legs, own_stakeholder)
+        own_fallback_id = regime_names_to_ids[own_leg.fallback.regime]
+        candidate_id = jnp.where(gate_bool, target_id, own_fallback_id)
         routed_ids = jnp.where(subjects_in_regime, candidate_id, routed_ids)
 
         projectors = regime.gated_edge_leg_projectors[target_name]

--- a/src/_lcm/simulation/simulate.py
+++ b/src/_lcm/simulation/simulate.py
@@ -73,6 +73,7 @@ def simulate(
     period_to_regime_to_divorce_flags: MappingProxyType[
         int, MappingProxyType[RegimeName, BoolND]
     ] = MappingProxyType({}),
+    own_stakeholder: str | None = None,
 ) -> SimulationResult:
     """Simulate the model forward in time given pre-computed value function arrays.
 
@@ -113,6 +114,16 @@ def simulate(
             caller does not have it at hand — not yet surfaced through the
             public `Model.solve`/`Model.simulate` API (mirrors solve's own
             internal-only status; a public accessor is a follow-up).
+        own_stakeholder: ROW-SPLIT (synthetic mode). This simulate() call's
+            fixed own-role for divorce routing on a COLLECTIVE source's
+            gated edge — e.g. "f" for an all-women population tracking
+            synthetic male partners, "m" for an all-men population. A
+            single value for the WHOLE call, not a per-subject array (see
+            `_lcm.simulation.gated_routing._select_own_leg`). `None`
+            (default) preserves the original "first declared leg" routing
+            convention exactly — byte-identical for any caller that does
+            not pass it (e.g. the public `Model.simulate()`, not yet
+            surfaced here either).
 
     Returns:
         SimulationResult object. Call .to_dataframe() to get a pandas DataFrame.
@@ -177,6 +188,7 @@ def simulate(
             ages=ages,
             seed=seed,
             logger=logger,
+            own_stakeholder=own_stakeholder,
         )
         if host_device is not None:
             # `block_until_ready` forces the D2H copy to complete before the loop
@@ -250,6 +262,7 @@ def _simulate_subject_chunk(
     ages: AgeGrid,
     seed: int,
     logger: logging.Logger,
+    own_stakeholder: str | None = None,
 ) -> dict[RegimeName, dict[int, PeriodRegimeSimulationData]]:
     """Run the full period loop for one chunk of subjects.
 
@@ -258,6 +271,7 @@ def _simulate_subject_chunk(
     chunk's position in the full population so RNG keys stay full-population and are
     sliced by global index. The key stream is re-derived from `seed` here so the
     per-period carry is identical across chunks (it is subject-count-independent).
+    `own_stakeholder`: see `simulate()`'s docstring (ROW-SPLIT synthetic mode).
 
     Returns the per-(regime, period) results for this chunk's subjects.
     """
@@ -331,6 +345,7 @@ def _simulate_subject_chunk(
                     n_subjects=n_subjects,
                     subject_slice=subject_slice,
                     original_n_subjects=original_n_subjects,
+                    own_stakeholder=own_stakeholder,
                 )
             )
             states = new_states
@@ -438,6 +453,7 @@ def _simulate_regime_in_period(
     n_subjects: int,
     subject_slice: slice,
     original_n_subjects: int | None = None,
+    own_stakeholder: str | None = None,
 ) -> tuple[PeriodRegimeSimulationData, StatesPerRegime, Int1D, PRNGKeyND]:
     """Simulate one regime for one period.
 
@@ -469,6 +485,8 @@ def _simulate_regime_in_period(
         n_subjects: Total number of subjects (the full population), used to keep RNG
             key generation independent of how subjects are chunked.
         subject_slice: Global-index slice of the subjects in this chunk.
+        own_stakeholder: See `simulate()`'s docstring (ROW-SPLIT synthetic mode);
+            threaded down to `route_gated_edges`.
 
     Returns:
         Tuple containing:
@@ -653,6 +671,7 @@ def _simulate_regime_in_period(
             new_subject_regime_ids=new_subject_regime_ids,
             subjects_in_regime=subject_ids_in_regime,
             flat_params=flat_params,
+            own_stakeholder=own_stakeholder,
         )
         states = next_states
 

--- a/tests/regime_building/test_row_split_synthetic.py
+++ b/tests/regime_building/test_row_split_synthetic.py
@@ -1,0 +1,178 @@
+"""Tests for the divorce row-split, synthetic mode (row-split PLAN, commit 1).
+
+pylcm's forward simulation tracks INDIVIDUALS, not households: a married
+individual's row carries its own state plus a DRAWN (synthetic) partner
+block (slice-5/6 machinery). On divorce (`~gate`), the row must revert to
+`single_<own role>` with its OWN projected state — the leg whose
+`source_stakeholder` matches the row's own role — not unconditionally the
+FIRST declared leg (`_lcm.simulation.gated_routing.route_gated_edges`'s
+prior "primary leg" convention, still the `own_stakeholder=None` default).
+
+This is EKL Appendix F's design: two independent, single-gender cohorts
+(all-women, all-men), each simulated with a synthetic opposite-gender
+partner, each correctly reverting to ITS OWN single regime on divorce. No
+cross-row linkage, no matcher, no new per-subject array — `own_stakeholder`
+is a single value for the whole `simulate()` call (see
+`_lcm.simulation.gated_routing._select_own_leg`).
+
+Reuses the divorce miniature from `test_collective_regime_simulate.py`
+(`_make_divorce_regimes` / `_solve_divorce`): a collective `married` regime
+with stakeholders `("f", "m")`, a divorce edge with two legs (`"f" ->
+single_f`, `"m" -> single_m`), and a slice-3 IR mask that empties (`D=True`)
+at `wage=2` on the `WAGE_3 = {1, 2, 3}` grid.
+"""
+
+from types import MappingProxyType
+
+import jax.numpy as jnp
+import numpy as np
+
+from _lcm.simulation.simulate import simulate
+from _lcm.utils.logging import get_logger
+from tests.regime_building.test_collective_regime_simulate import _solve_divorce
+
+
+def _simulate_divorce_cohort(*, own_stakeholder: str | None):
+    """Simulate the 3-subject divorce miniature with a fixed own-role."""
+    ages, regimes, regime_names_to_ids, flat_params, solution, divorce_flags = (
+        _solve_divorce()
+    )
+    initial_conditions = MappingProxyType(
+        {
+            "wage": jnp.array([1.0, 2.0, 3.0]),
+            "age": jnp.array([0.0, 0.0, 0.0]),
+            "regime_id": jnp.array(
+                [regime_names_to_ids["married"]] * 3, dtype=jnp.int32
+            ),
+        }
+    )
+    return simulate(
+        flat_params=flat_params,
+        initial_conditions=initial_conditions,
+        regimes=regimes,
+        regime_names_to_ids=regime_names_to_ids,
+        logger=get_logger(log_level="off"),
+        period_to_regime_to_V_arr=solution,
+        period_to_regime_to_divorce_flags=divorce_flags,
+        ages=ages,
+        simulation_output_dtypes={},
+        seed=0,
+        own_stakeholder=own_stakeholder,
+    ), solution
+
+
+# ----------------------------------------------------------------------------------
+# Test (a): a synthetic-married individual whose slice-3 IR mask empties at t+1
+# (D=True) reverts to `single_<own role>` with its own projected state.
+# ----------------------------------------------------------------------------------
+
+
+def test_synthetic_divorce_reverts_to_own_role_single_regime_for_m():
+    """`own_stakeholder="m"` routes the divorced row to `single_m`, not `single_f`.
+
+    D=True only at wage=2 (hand-verified in `test_gated_edges_collective_solve.py`
+    / `test_collective_regime_simulate.py`'s divorce test). Under the PRIOR
+    "first declared leg" convention this row would incorrectly become
+    `single_f`; the row's own role here is "m".
+    """
+    result, solution = _simulate_divorce_cohort(own_stakeholder="m")
+
+    married_ir = result.raw_results["married_ir"][1]
+    single_f = result.raw_results["single_f"][1]
+    single_m = result.raw_results["single_m"][1]
+
+    # The divorce DECISION itself (the gate) does not depend on own_stakeholder.
+    np.testing.assert_array_equal(np.asarray(married_ir.in_regime), [True, False, True])
+    # But the ROUTING does: the row's own continuing membership is single_m now.
+    np.testing.assert_array_equal(np.asarray(single_m.in_regime), [False, True, False])
+    np.testing.assert_array_equal(np.asarray(single_f.in_regime), [False, False, False])
+
+    # The row's own projected state (identity wage projection) is correct.
+    np.testing.assert_array_equal(np.asarray(single_m.states["wage"])[1], 2.0)
+
+    # And its value matches the solved single_m array at that same grid point
+    # (WAGE_3 = {1, 2, 3}, index 1 = wage=2.0) -- ground truth independently
+    # verified by test_gated_edges_collective_solve.py's IR miniature.
+    np.testing.assert_allclose(
+        np.asarray(single_m.V_arr)[1],
+        np.asarray(solution[1]["single_m"])[1],
+        rtol=1e-6,
+    )
+
+
+def test_synthetic_divorce_default_still_takes_first_declared_leg():
+    """`own_stakeholder=None` (the default) is byte-identical to the prior behavior.
+
+    Regression pin: omitting `own_stakeholder` must keep routing the divorced
+    row to the FIRST declared leg's fallback (`single_f`, since `married`'s
+    legs are declared in stakeholder order `("f", "m")`) -- exactly the
+    pre-row-split convention `test_collective_regime_simulate.py`'s
+    `test_divorce_edge_routes_primary_leg_to_own_single_regime` pins.
+    """
+    result, _solution = _simulate_divorce_cohort(own_stakeholder=None)
+
+    single_f = result.raw_results["single_f"][1]
+    single_m = result.raw_results["single_m"][1]
+    np.testing.assert_array_equal(np.asarray(single_f.in_regime), [False, True, False])
+    np.testing.assert_array_equal(np.asarray(single_m.in_regime), [False, False, False])
+
+
+# ----------------------------------------------------------------------------------
+# Test (b): two independent populations (EKL Appendix F) -- an all-women cohort
+# and an all-men cohort, each correctly reverting on divorce, with no
+# cross-population coupling.
+# ----------------------------------------------------------------------------------
+
+
+def test_two_independent_synthetic_populations_each_revert_correctly():
+    """A women-role run and a men-role run each divorce-revert to their own single.
+
+    Both runs share the identical input population (same wages, same solved
+    value functions) and differ ONLY in `own_stakeholder`; their outputs
+    differ ONLY in which single regime the divorced row (wage=2) lands in --
+    everything else (the gate decision, the still-married rows' values) is
+    identical, confirming the two populations are independent (no
+    cross-population state leakage through shared solved arrays).
+    """
+    women_result, _ = _simulate_divorce_cohort(own_stakeholder="f")
+    men_result, _ = _simulate_divorce_cohort(own_stakeholder="m")
+
+    # Women cohort: divorced row (index 1) becomes single_f, not single_m.
+    np.testing.assert_array_equal(
+        np.asarray(women_result.raw_results["single_f"][1].in_regime),
+        [False, True, False],
+    )
+    np.testing.assert_array_equal(
+        np.asarray(women_result.raw_results["single_m"][1].in_regime),
+        [False, False, False],
+    )
+
+    # Men cohort: divorced row becomes single_m, not single_f.
+    np.testing.assert_array_equal(
+        np.asarray(men_result.raw_results["single_m"][1].in_regime),
+        [False, True, False],
+    )
+    np.testing.assert_array_equal(
+        np.asarray(men_result.raw_results["single_f"][1].in_regime),
+        [False, False, False],
+    )
+
+    # The divorce decision and the still-married rows' recorded values are
+    # identical across the two cohorts (own_stakeholder never touches them).
+    np.testing.assert_array_equal(
+        np.asarray(women_result.raw_results["married_ir"][1].in_regime),
+        np.asarray(men_result.raw_results["married_ir"][1].in_regime),
+    )
+    np.testing.assert_allclose(
+        np.asarray(women_result.raw_results["married_ir"][1].V_arr),
+        np.asarray(men_result.raw_results["married_ir"][1].V_arr),
+        rtol=1e-6,
+    )
+
+    # Re-running the women cohort is deterministic and unaffected by having
+    # just run the men cohort (pure functions, no shared mutable state).
+    women_result_again, _ = _simulate_divorce_cohort(own_stakeholder="f")
+    np.testing.assert_array_equal(
+        np.asarray(women_result.raw_results["single_f"][1].in_regime),
+        np.asarray(women_result_again.raw_results["single_f"][1].in_regime),
+    )


### PR DESCRIPTION
## Dissolution routing: revert each individual to its own single regime (synthetic mode)

**Draft — stacked on the collective-regimes extension.** Review the row-split commit; the base carries the extension.

> Naming: this routes an individual to its own single regime when a **collective/matched regime dissolves** (the general `D` dissolution flag — empty feasible set). "Dissolution" is the engine term; in a marriage model (e.g. EKL) the instance is divorce.

### Motivation

The collective-regimes extension's forward simulation is a fixed-size pass, so on **dissolution** a household row could not become two independently-tracked single rows — the continuing membership followed the *first declared* edge leg regardless of which partner the row represents. Wrong for any two-sided dissolution simulation.

The immediate driver is **Eckstein–Keane–Lifshitz (2019)** (`ecksteinCareerFamilyDecisions2019`). EKL's simulation (Appendix F) tracks **individuals with synthetic partners**: two independent single-gender cohorts, each drawing a synthetic spouse on marriage, no cross-population linkage. On dissolution each tracked individual must revert to *its own* single regime (`single_f` for women, `single_m` for men). The old "first leg" convention routed both cohorts to the same leg — silently wrong for one gender.

### What this PR does (synthetic mode)

Adds `own_stakeholder: str | None = None` to the simulation router (`route_gated_edges`), threaded through `simulate()`. When set, a dissolved row routes to the leg whose `source_stakeholder` matches — its *own* single regime with its own projected state — instead of unconditionally `legs[0]`:

```python
women = simulate(..., own_stakeholder="f")   # → single_f on dissolution
men   = simulate(..., own_stakeholder="m")   # → single_m on dissolution
```

- `own_stakeholder=None` (default) reproduces the exact prior "first declared leg" routing — **byte-identical** for every existing caller.
- New helper `_select_own_leg(legs, own_stakeholder)`. No cross-row gather, no matcher, no new per-subject array — those belong to linked mode (below).

### Synthetic vs the general two-sided (linked) split

A true two-way split — one row becoming two *linked* tracked singles, both ex-partners living on with transfers/asset-division between them — is a larger, separate feature (**linked mode**): a per-subject `role` state + `partner_row` link array, a model-declared matcher (a global cross-subject reduction the row-independent `simulate` deliberately avoids), and marriage-time pairing. Deferred and scoped in `ROWSPLIT-STATUS.md` (incl. a gather-only, no-scatter simplification). Synthetic mode is the minimum that makes EKL's Appendix-F simulation faithful. Linked mode is what these pool papers additionally require (both ex-partners tracked):

| paper | why linked mode |
|---|---|
| `foersterUntyingKnotHow2024` — *Untying the Knot* | alimony/child-support flow *between* the two ex-spouses |
| `voenaYoursMineOurs2015` — *Yours, Mine, and Ours: Do Divorce Laws Affect…* | endogenous divorce; separate post-divorce budgets/assets per spouse |
| `reynosoImpactDivorceLaws2024` — *Impact of Divorce Laws on the Marriage Market* | marriage-market equilibrium, both ex-spouses tracked |
| `borellaAreMarriageRelatedTaxes2022` — Borella, De Nardi & Yang | divorce shock splits wealth equally → tracked single man + single woman |
| `denardiWageRiskGovernment2024` — *Wage Risk and Government and Spousal Insurance* | wealth pooled on marriage, divided equally on divorce; separate single-m/single-f value fns |

(Widowhood models — `hongLifeInsuranceHousehold2012`, `denardiWhyCouplesSingles2025` — are couple→single with *one* surviving row, no two-way split; `chiapporiMarriageMarketLabor2018` models no dissolution.)

### Tests & verification

`tests/regime_building/test_row_split_synthetic.py` (3, green): own-role routing, `own_stakeholder=None` byte-identical regression pin, two independent cohorts differing only in landing regime. Broad `tests/solution tests/simulation` = 570/5/2 (default path byte-identical). `ty` + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
