### PR TITLE
Fold IID utility shocks out of the stored value (quadrature-average at solve)

### DIFF
--- a/src/_lcm/engine.py
+++ b/src/_lcm/engine.py
@@ -644,6 +644,16 @@ class Regime:
     has_taste_shocks: bool = False
     """Whether the regime declares EV1 taste shocks on its discrete actions."""
 
+    fold_state_names: tuple[StateName, ...] = ()
+    """IID-process states declared `fold=True`, or empty (the default).
+
+    A folded state is integrated out of the stored value by quadrature at
+    solve time, so it is NOT an axis of the regime's stored `V`-array: the
+    backward-induction V topology (`_get_regime_V_shapes_and_shardings`)
+    excludes it from the shape/sharding it computes for this regime. Empty
+    keeps the default path byte-identical.
+    """
+
     certainty_equivalent: CertaintyEquivalent | None = None
     """Nonlinear certainty equivalent declared by the regime, if any."""
 

--- a/src/_lcm/processes/iid.py
+++ b/src/_lcm/processes/iid.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 from dataclasses import dataclass, fields
 from types import MappingProxyType
+from typing import ClassVar
 
 import jax
 import jax.numpy as jnp
@@ -21,6 +22,30 @@ from lcm.typing import Float1D, FloatND, ScalarFloat, ScalarInt
 @dataclass(frozen=True, kw_only=True)
 class _IIDProcess(_ContinuousStochasticProcess):
     """Base for IID processes — draw does not depend on previous value."""
+
+    fold: bool = False
+    """Integrate this shock into the stored value instead of keeping its axis.
+
+    `False` (the default) is today's behavior, byte-identical: the shock's
+    discretization nodes stay a materialized axis of every stored value
+    function, exactly like an ordinary state. `True` folds the shock out of
+    storage — the solve still evaluates every node (the max-over-actions /
+    collective readout runs per node, unchanged), but immediately
+    weighted-averages the node axis away with the process's own quadrature
+    weights *before* the result is written into the stored value, so the
+    published `V` has one fewer axis. Only an IID process may set this (a
+    persistent process has no `fold` field at all — the type system rejects
+    it). Further restrictions (no same-period gate / value-constraint reads
+    the realized node, no next-period transition or continuation depends on
+    it, `GridSearch` only, not combined with `taste_shocks`, and only a
+    fully-specified process — no runtime-supplied distribution params) are
+    enforced by `Regime.__post_init__` / model processing; see
+    `_validate_fold_declarations`.
+    """
+
+    _NON_PARAM_FIELDS: ClassVar[frozenset[str]] = (
+        _ContinuousStochasticProcess._NON_PARAM_FIELDS | {"fold"}  # noqa: SLF001
+    )
 
     @abstractmethod
     def draw_shock(

--- a/src/_lcm/regime_building/max_Q_over_a.py
+++ b/src/_lcm/regime_building/max_Q_over_a.py
@@ -43,6 +43,8 @@ def get_max_Q_over_a(
     co_map_v_arr_in_axes: tuple[MappingProxyType[RegimeName, int | None], ...] = (),
     stakeholders: tuple[str, ...] | None = None,
     weights: Mapping[str, float] | None = None,
+    fold_state_names: tuple[StateName, ...] = (),
+    fold_weights: Mapping[StateName, FloatND] = MappingProxyType({}),
 ) -> MaxQOverAFunction:
     r"""Get the function returning the maximum of Q over all actions.
 
@@ -99,6 +101,17 @@ def get_max_Q_over_a(
             axes (E2; distinct from a numeric `-inf`, which occurs on-path).
         weights: Household Pareto weights per stakeholder; required (and only used)
             when `stakeholders` is set.
+        fold_state_names: IID-process states declared `fold=True`, or empty (the
+            default). Each is still an ordinary inner (non-co-mapped) productmap
+            axis THROUGH the max-over-actions / collective readout — every node is
+            evaluated exactly as today — but its axis is then weighted-averaged
+            away (`jnp.average(..., weights=fold_weights[name])`) before the
+            result is returned, so the caller never sees it. A collective
+            regime's divorce flag `D` is folded by `jnp.any` instead (stays
+            strictly boolean; see `_wrap_with_fold_reduction`).
+        fold_weights: Quadrature weights per name in `fold_state_names` (each a
+            1-D array matching that state's node count, summing to 1). Ignored
+            when `fold_state_names` is empty.
 
     Returns:
         V, i.e., the function that calculates the maximum of the Q-function over all
@@ -213,6 +226,19 @@ def get_max_Q_over_a(
         variables=inner_state_names,
         batch_sizes={name: batch_sizes[name] for name in inner_state_names},
     )
+
+    if fold_state_names:
+        mapped = _wrap_with_fold_reduction(
+            mapped,
+            fold_state_names=fold_state_names,
+            fold_weights=fold_weights,
+            inner_state_names=inner_state_names,
+            action_names=action_names,
+            state_names=state_names,
+            extra_param_names=extra_param_names,
+            stakeholders=stakeholders,
+        )
+
     if not co_map_state_names:
         return mapped
 
@@ -235,6 +261,71 @@ def get_max_Q_over_a(
             callable_with="only_args",
         )
     return cast("MaxQOverAFunction", allow_only_kwargs(mapped, enforce=False))
+
+
+def _wrap_with_fold_reduction(
+    mapped: Callable[..., FloatND | tuple[FloatND, BoolND]],
+    *,
+    fold_state_names: tuple[StateName, ...],
+    fold_weights: Mapping[StateName, FloatND],
+    inner_state_names: tuple[StateName, ...],
+    action_names: tuple[ActionName, ...],
+    state_names: tuple[StateName, ...],
+    extra_param_names: list[str],
+    stakeholders: tuple[str, ...] | None,
+) -> Callable[..., FloatND | tuple[FloatND, BoolND]]:
+    """Wrap the (still fold-axis-carrying) inner productmap with the fold average.
+
+    `mapped`'s output axes are exactly `inner_state_names`, in order (the
+    `productmap`'s `variables` order) — this runs BEFORE any co-map wrapping,
+    so no co-map axis is present yet. A collective `mapped` additionally
+    carries a TRAILING stakeholder axis on `V` only (not on `D`); since it is
+    trailing, it never shifts a fold axis's position. Fold axes are reduced
+    from the highest inner-position down, so removing one axis never shifts
+    the position of a not-yet-reduced one. The wrapper re-declares EXACTLY
+    `mapped`'s own call signature (`with_signature`, matching
+    `max_Q_over_a`'s pre-productmap signature, which `productmap` preserves)
+    so it composes transparently with the co-map `vmap_1d` wrapping that may
+    follow.
+
+    The divorce flag `D` (collective only) stays strictly boolean — reduced
+    by `jnp.any` ("divorced at any folded node"), not a weighted average — so
+    it keeps its `BoolND` contract for every downstream reader (the gated-edge
+    fold, `KernelResult.divorce`). This is a conservative, not an exact,
+    reduction; `_validate_fold_declarations` already rejects a fold state a
+    same-period gate reads DIRECTLY, but a gate reading `D` itself (of a
+    regime that happens to also fold an UNRELATED state) is not caught — out
+    of scope for this slice.
+    """
+    fold_axis_positions = sorted(
+        ((name, inner_state_names.index(name)) for name in fold_state_names),
+        key=lambda item: -item[1],
+    )
+
+    @with_signature(
+        args=["next_regime_to_V_arr", *action_names, *state_names, *extra_param_names],
+        return_annotation=(
+            "tuple[FloatND, BoolND]" if stakeholders is not None else "FloatND"
+        ),
+        enforce=False,
+    )
+    def folded(
+        next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
+        **states_actions_params: _ParamsLeaf,
+    ) -> FloatND | tuple[FloatND, BoolND]:
+        out = mapped(next_regime_to_V_arr=next_regime_to_V_arr, **states_actions_params)
+        if stakeholders is not None:
+            V_arr, divorce = cast("tuple[FloatND, BoolND]", out)
+            for name, axis in fold_axis_positions:
+                V_arr = jnp.average(V_arr, axis=axis, weights=fold_weights[name])
+                divorce = jnp.any(divorce, axis=axis)
+            return V_arr, divorce
+        V_arr = cast("FloatND", out)
+        for name, axis in fold_axis_positions:
+            V_arr = jnp.average(V_arr, axis=axis, weights=fold_weights[name])
+        return V_arr
+
+    return folded
 
 
 def get_argmax_and_max_Q_over_a(

--- a/src/_lcm/regime_building/processing.py
+++ b/src/_lcm/regime_building/processing.py
@@ -39,7 +39,7 @@ from _lcm.grids.coordinates import get_irreg_coordinate
 from _lcm.identity_transition import _IdentityTransition
 from _lcm.params.processing import get_flat_param_names
 from _lcm.params.regime_template import create_regime_params_template
-from _lcm.processes import _ContinuousStochasticProcess
+from _lcm.processes import _ContinuousStochasticProcess, _IIDProcess
 from _lcm.regime_building.canonicalize import canonicalize_regimes
 from _lcm.regime_building.diagnostics import _build_compute_intermediates_per_period
 from _lcm.regime_building.finalize import FinalizedUserRegime
@@ -296,6 +296,13 @@ def process_regimes(
         same_period_ref_regimes = tuple(
             dict.fromkeys(ref.regime for ref in user_regime.same_period_refs.values())
         )
+        # Folded IID-process states — collected purely from this regime's own
+        # states and grids, so (unlike `co_map_state_names`) the caller can
+        # compute it before `_build_solution_phase` builds `core.transitions`.
+        fold_state_names = _fold_state_names(
+            state_names=state_action_spaces[regime_name].state_names,
+            grids=all_grids[regime_name],
+        )
 
         solution = _build_solution_phase(
             spec=spec,
@@ -321,6 +328,7 @@ def process_regimes(
             weights=weights,
             same_period_ref_regimes=same_period_ref_regimes,
             edge_target_regimes=tuple(user_regime.gated_edges),
+            fold_state_names=fold_state_names,
         )
 
         simulation = _build_simulation_phase(
@@ -367,7 +375,10 @@ def process_regimes(
             certainty_equivalent=user_regime.certainty_equivalent,
             stakeholders=stakeholders,
             same_period_ref_regimes=same_period_ref_regimes,
+            fold_state_names=fold_state_names,
         )
+
+    _fail_if_folded_state_persists(canonical_regimes=canonical_regimes)
 
     # COLLECTIVE-REGIMES (E3'): build the gated-edge folds in a second pass, now
     # that every regime's grid and processed functions are known. Each edge's
@@ -920,6 +931,7 @@ def _build_solution_phase(
     weights: Mapping[str, float] | None = None,
     same_period_ref_regimes: tuple[RegimeName, ...] = (),
     edge_target_regimes: tuple[RegimeName, ...] = (),
+    fold_state_names: tuple[StateName, ...] = (),
 ) -> SolutionPhase:
     """Build all compiled functions for the backward-induction (solve) phase.
 
@@ -1120,6 +1132,7 @@ def _build_solution_phase(
         weights=weights,
         same_period_ref_regimes=same_period_ref_regimes,
         edge_target_regimes=edge_target_regimes,
+        fold_state_names=fold_state_names,
     )
     solver.validate(context=context)
     solver_kernels = solver.build_period_kernels(context=context)
@@ -2722,6 +2735,81 @@ def _co_map_state_names(
         ):
             co_map.append(name)
     return tuple(co_map)
+
+
+def _fold_state_names(
+    *,
+    state_names: tuple[StateName, ...],
+    grids: MappingProxyType[StateOrActionName, Grid],
+) -> tuple[StateName, ...]:
+    """Return the IID-process states declared `fold=True`, in state-axis order.
+
+    A folded state is integrated out of the stored value by quadrature
+    immediately after the period's max-over-actions / collective readout — a
+    state-topology property collected the same way `_co_map_state_names`
+    collects distributed states, not a per-node computation.
+    """
+    return tuple(
+        name
+        for name in state_names
+        if isinstance(grid := grids.get(name), _IIDProcess) and grid.fold
+    )
+
+
+def _fail_if_folded_state_persists(
+    *, canonical_regimes: Mapping[RegimeName, Regime]
+) -> None:
+    """Reject a folded state that structurally persists past its own period.
+
+    A fold weighted-averages a state's axis out of the stored value: the
+    stored `V` of the regime that declares `fold=True` on it has no such
+    axis (`_get_regime_V_shapes_and_shardings`). If ANY regime's transitions
+    — including the declaring regime's own, via a self-transition — still
+    carry an intrinsic `next_<name>` continuation for that state (i.e. the
+    state is ALSO declared, hence auto-wired with its own weight/index
+    functions, in some regime reachable from another), the continuation
+    machinery would try to interpolate a `next_<name>` axis that the target's
+    stored `V` no longer has — a shape mismatch, or worse, a silent wrong
+    read. This is a cross-regime property (every regime's `solution.transitions`
+    must be known), so it is checked once here, after every regime is built —
+    not in the regime-local `_validate_fold_declarations`.
+
+    Folding is therefore restricted, for now, to states that do not persist:
+    declared in exactly the one regime that folds them, and not redeclared
+    (directly or via a self-transition) in any regime any transition reaches.
+    A genuinely persistent IID shock (redrawn every period a regime is
+    active) needs the fold to also be recognized by the *continuation* side
+    (`regime_to_v_interpolation_info` / `stochastic_transition_names`) of
+    every regime that reads into it — out of scope for this slice.
+    """
+    error_messages: list[str] = []
+    for regime_name, regime in canonical_regimes.items():
+        if not regime.fold_state_names:
+            continue
+        for fold_name in regime.fold_state_names:
+            next_key = f"next_{fold_name}"
+            offending = [
+                (source_name, target_name)
+                for source_name, source_regime in canonical_regimes.items()
+                for target_name, bundle in source_regime.solution.transitions.items()
+                if target_name == regime_name and next_key in bundle
+            ]
+            if offending:
+                sources = sorted({source for source, _ in offending})
+                error_messages.append(
+                    f"fold=True on regime '{regime_name}' state '{fold_name}' "
+                    f"is not supported: '{fold_name}' is also declared as a "
+                    f"state reachable via a next-period continuation from "
+                    f"{sources} into '{regime_name}' — i.e. it structurally "
+                    f"persists. A folded state's stored value has no "
+                    f"'{fold_name}' axis, so that continuation could no "
+                    f"longer interpolate over it. Folding is only supported "
+                    f"for a state that does not persist past the period that "
+                    f"folds it (not redeclared, directly or via a "
+                    f"self-transition, in any reachable regime)."
+                )
+    if error_messages:
+        raise ModelInitializationError(format_messages(error_messages))
 
 
 def _build_Q_and_F_per_period(

--- a/src/_lcm/solution/backward_induction.py
+++ b/src/_lcm/solution/backward_induction.py
@@ -1071,8 +1071,22 @@ def _get_regime_V_shapes_and_shardings(
         state_action_space = regime.solution.state_action_space(
             regime_params=flat_params[regime_name],
         )
-        state_order: tuple[StateName, ...] = tuple(state_action_space.states.keys())
-        shape = tuple(len(v) for v in state_action_space.states.values())
+        # Folded IID-process states are integrated out of the stored value by
+        # quadrature at solve time (`get_max_Q_over_a`'s fold reduction), so
+        # they are NOT an axis of this regime's V-array — exclude them from
+        # the shape/sharding topology the same way a co-mapped state's axis
+        # is still present (co-map only relocates an axis for sharding; fold
+        # removes it).
+        state_order: tuple[StateName, ...] = tuple(
+            name
+            for name in state_action_space.states
+            if name not in regime.fold_state_names
+        )
+        shape = tuple(
+            len(v)
+            for name, v in state_action_space.states.items()
+            if name not in regime.fold_state_names
+        )
         # COLLECTIVE-REGIMES (E1): a collective regime's V carries a trailing
         # stakeholder axis, so the zero template and the roll must too. The
         # sharding plan spans the state axes only; the trailing stakeholder

--- a/src/_lcm/solution/contract.py
+++ b/src/_lcm/solution/contract.py
@@ -181,6 +181,15 @@ class SolverBuildContext:
     mapping it reads and lowers against. Empty for every other regime.
     """
 
+    fold_state_names: tuple[StateName, ...] = ()
+    """IID-process states declared `fold=True`, or empty (the default).
+
+    Only `GridSearch` consumes this: the grid-search kernel weighted-averages
+    each named state's axis out of the stored value immediately after the
+    max-over-actions / collective readout, using the process's own
+    quadrature weights. Empty keeps the default path byte-identical.
+    """
+
     same_period_ref_regimes: tuple[RegimeName, ...] = ()
     """Reference regimes whose SAME-period V this regime's kernels read (E2).
 

--- a/src/_lcm/solution/solvers.py
+++ b/src/_lcm/solution/solvers.py
@@ -90,6 +90,18 @@ class GridSearch(Solver):
 
         built: dict[int, MaxQOverAFunction] = {}
         result: dict[int, PeriodKernel] = {}
+        # Fold weights are the folded process's own marginal distribution
+        # (`compute_transition_probs` returns an (n_points, n_points) matrix
+        # whose every row is that marginal — the "IID" part — so row 0 is it).
+        # `_validate_fold_declarations` rejects a runtime-parameterized
+        # process, so this is a plain constant computed once here, at
+        # kernel-build time — never inside the traced core.
+        fold_weights = {
+            name: cast(
+                "_ContinuousStochasticProcess", context.grids[name]
+            ).get_transition_probs()[0]
+            for name in context.fold_state_names
+        }
         for period, Q_and_F in context.Q_and_F_functions.items():
             q_id = id(Q_and_F)
             if q_id not in built:
@@ -110,6 +122,8 @@ class GridSearch(Solver):
                     co_map_v_arr_in_axes=context.co_map_v_arr_in_axes,
                     stakeholders=context.stakeholders,
                     weights=context.weights,
+                    fold_state_names=context.fold_state_names,
+                    fold_weights=fold_weights,
                 )
                 built[q_id] = jax.jit(func) if context.enable_jit else func
             result[period] = _GridSearchPeriodKernel(

--- a/src/_lcm/user_regime_validation.py
+++ b/src/_lcm/user_regime_validation.py
@@ -18,6 +18,7 @@ from dags.tree import QNAME_DELIMITER
 from _lcm.grids import DiscreteGrid, Grid
 from _lcm.identity_transition import _IdentityTransition
 from _lcm.processes.base import _ContinuousStochasticProcess
+from _lcm.processes.iid import _IIDProcess
 from _lcm.typing import ActiveFunction, ProcessName, RegimeName, StateName
 from _lcm.utils.error_messages import format_messages
 from lcm.exceptions import RegimeInitializationError
@@ -832,6 +833,251 @@ def _state_transition_variants(value: object) -> tuple[tuple[object, str], ...]:
     if isinstance(value, Phased):
         return ((value.solve, " solve variant"), (value.simulate, " simulate variant"))
     return ((value, ""),)
+
+
+def _fold_state_names(regime: lcm.regime.Regime) -> tuple[StateName, ...]:
+    """Return the regime's IID-process states declared `fold=True`."""
+    return tuple(name for name, grid in regime.states.items() if _is_folded(grid))
+
+
+def _is_folded(grid: object) -> bool:
+    """Whether a state's grid is an IID process declaring `fold=True`."""
+    return isinstance(grid, _IIDProcess) and grid.fold
+
+
+def _flatten_transition_callables(value: object) -> list[Callable]:
+    """Return every callable reachable from a `state_transitions` / `transition` entry.
+
+    Unwraps `Phased` (both variants) and per-target `Mapping`s; `MarkovTransition`
+    and `_IdentityTransition` are themselves callables with an introspectable
+    signature (`MarkovTransition` sets `__wrapped__`; `_IdentityTransition` sets
+    `__signature__`), so `inspect.signature` resolves them correctly downstream.
+    """
+    if value is None:
+        return []
+    if isinstance(value, Phased):
+        return _flatten_transition_callables(
+            value.solve
+        ) + _flatten_transition_callables(value.simulate)
+    if isinstance(value, Mapping):
+        out: list[Callable] = []
+        for entry in value.values():
+            out.extend(_flatten_transition_callables(entry))
+        return out
+    if callable(value):
+        return [cast("Callable", value)]
+    return []
+
+
+def _fold_dependency_closure(
+    *, roots: tuple[Callable, ...], resolution_table: Mapping[str, Callable | Phased]
+) -> set[str]:
+    """Return every argument name in the transitive DAG ancestry of `roots`.
+
+    Walks argument names of each root; whenever a name matches an entry of
+    `resolution_table` (an ordinary regime function or constraint), its
+    variants' argument names are pulled in too, recursively. Leaf names
+    (states, actions, params, `period`/`age`) terminate the walk. This is the
+    same "does X depend on Y" question `_find_function_output_grid_indexing`
+    answers by AST-walking; here a signature walk suffices because the
+    question is about *argument names*, not source text.
+    """
+    seen_names: set[str] = set()
+    stack: list[Callable] = list(roots)
+    visited_ids: set[int] = set()
+    while stack:
+        func = stack.pop()
+        if id(func) in visited_ids:
+            continue
+        visited_ids.add(id(func))
+        try:
+            params = inspect.signature(func).parameters
+        except ValueError, TypeError:
+            continue
+        for name in params:
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            entry = resolution_table.get(name)
+            if entry is not None:
+                stack.extend(_function_variants(entry))
+    return seen_names
+
+
+def _validate_fold_declarations(regime: lcm.regime.Regime) -> None:
+    """Reject `fold=True` IID-process declarations the fold machinery can't support.
+
+    A fold integrates a shock's node axis into the stored value by quadrature
+    immediately after the period's max-over-actions / collective readout, so
+    nothing may condition on which node was realized beyond that point:
+
+    - a same-period gate / value-constraint predicate (E2/E3') that reads the
+      shock's realized value — these read live per-node values to decide a
+      within-period household choice or a divorce/consent gate, which the
+      fold has already averaged away by the time any *other* regime's
+      same-period logic runs;
+    - a next-period transition (state or regime) that reads the shock's
+      realized value — a folded shock is integrated out, so no downstream
+      state may depend on which node was realized;
+    - EV1 `taste_shocks` on the same regime — the taste-shock reduction is a
+      separate closed-form max over discrete actions; the two reductions are
+      not composed;
+    - any solver other than `GridSearch` — the fold reduction is implemented
+      only in the grid-search max-Q-over-a kernel;
+    - a process with runtime-supplied distribution params — the fold weights
+      are computed once at kernel-build time from the process's own
+      (fully-specified) `compute_transition_probs`.
+
+    A persistent (non-IID) process has no `fold` field at all, so `fold=True`
+    on one is rejected by the type system before this validator ever runs.
+
+    Whether the folded state structurally PERSISTS (is redeclared, with an
+    intrinsic `next_<name>` continuation, in any regime reachable from this
+    one — including itself) is a cross-regime property, checked once every
+    regime's transitions are built (`_fail_if_folded_state_persists` in
+    `regime_building/processing.py`), not here.
+    """
+    fold_names = _fold_state_names(regime)
+    if not fold_names:
+        return
+
+    error_messages = [
+        *_fold_scope_errors(regime, fold_names),
+        *_fold_same_period_read_errors(regime, fold_names),
+        *_fold_transition_read_errors(regime, fold_names),
+    ]
+    if error_messages:
+        raise RegimeInitializationError(format_messages(error_messages))
+
+
+def _fold_scope_errors(
+    regime: lcm.regime.Regime, fold_names: tuple[StateName, ...]
+) -> list[str]:
+    """Collect the regime-wide (not DAG-dependency) fold restrictions."""
+    error_messages: list[str] = []
+    runtime_params = [
+        name
+        for name in fold_names
+        if cast("_IIDProcess", regime.states[name]).params_to_pass_at_runtime
+    ]
+    if runtime_params:
+        error_messages.append(
+            f"fold=True on state(s) {sorted(runtime_params)} is not yet "
+            "supported together with runtime-supplied distribution params: "
+            "the fold weights are computed once, at kernel-build time, from "
+            "the process's own (fully-specified) `compute_transition_probs`. "
+            "Supply the distribution params directly on the process, or drop "
+            "`fold=True`."
+        )
+    if regime.taste_shocks is not None:
+        error_messages.append(
+            f"fold=True on state(s) {sorted(fold_names)} is not supported "
+            "together with EV1 `taste_shocks` on the same regime: the "
+            "taste-shock reduction is a closed-form max over discrete "
+            "actions, and folding an IID state is a separate quadrature "
+            "reduction over a state axis — the two reductions are not "
+            "composed."
+        )
+    if not isinstance(regime.solver, GridSearch):
+        error_messages.append(
+            f"fold=True on state(s) {sorted(fold_names)} is only implemented "
+            "for the `GridSearch` solver: the fold reduction runs inside the "
+            "grid-search max-Q-over-a kernel. Use `solver=GridSearch()`, or "
+            "drop `fold=True`."
+        )
+    return error_messages
+
+
+def _fold_resolution_table(regime: lcm.regime.Regime) -> dict[str, Callable | Phased]:
+    """Regime functions/constraints usable as DAG-ancestor resolution targets."""
+    return {
+        **{k: v for k, v in regime.constraints.items() if v is not None},
+        **{k: v for k, v in regime.functions.items() if v is not None},
+    }
+
+
+def _fold_same_period_roots(regime: lcm.regime.Regime) -> list[tuple[str, Callable]]:
+    """Named same-period gate / value-constraint / reference-projection roots."""
+    roots: list[tuple[str, Callable]] = []
+    for name, predicate in regime.value_constraints.items():
+        roots.extend(
+            (f"value_constraints['{name}']", variant)
+            for variant in _function_variants(predicate)
+        )
+    for target_name, edge in regime.gated_edges.items():
+        roots.extend(
+            (f"gated_edges['{target_name}'].gate", variant)
+            for variant in _function_variants(edge.gate)
+        )
+        for ref_name, ref in edge.gate_refs.items():
+            roots.extend(
+                (f"gated_edges['{target_name}'].gate_refs['{ref_name}']", func)
+                for func in ref.projection.values()
+            )
+    for ref_name, ref in regime.same_period_refs.items():
+        roots.extend(
+            (f"same_period_refs['{ref_name}']", func)
+            for func in ref.projection.values()
+        )
+    return roots
+
+
+def _fold_same_period_read_errors(
+    regime: lcm.regime.Regime, fold_names: tuple[StateName, ...]
+) -> list[str]:
+    """Reject a fold name read by a same-period gate / value-constraint (E2/E3')."""
+    resolution_table = _fold_resolution_table(regime)
+    error_messages: list[str] = []
+    for label, func in _fold_same_period_roots(regime):
+        hit = _fold_names_ordered_intersection(
+            fold_names,
+            _fold_dependency_closure(roots=(func,), resolution_table=resolution_table),
+        )
+        if hit:
+            error_messages.append(
+                f"fold=True on state(s) {hit} conflicts with {label}, which "
+                "reads the shock's realized value: a same-period gate / "
+                "value-constraint / reference projection needs the unfolded "
+                "per-node value (E2/E3'), but a folded state's node axis is "
+                "averaged away before the period's value is published. Drop "
+                "`fold=True` on the shock, or stop reading it there."
+            )
+    return error_messages
+
+
+def _fold_transition_read_errors(
+    regime: lcm.regime.Regime, fold_names: tuple[StateName, ...]
+) -> list[str]:
+    """Reject a fold name read by a next-period state / regime transition."""
+    transition_roots: list[Callable] = []
+    for value in regime.state_transitions.values():
+        transition_roots.extend(_flatten_transition_callables(value))
+    transition_roots.extend(_flatten_transition_callables(regime.transition))
+
+    resolution_table = _fold_resolution_table(regime)
+    transition_hit: set[str] = set()
+    for func in transition_roots:
+        transition_hit |= _fold_dependency_closure(
+            roots=(func,), resolution_table=resolution_table
+        )
+    transition_hit &= set(fold_names)
+    if not transition_hit:
+        return []
+    return [
+        f"fold=True on state(s) {sorted(transition_hit)} conflicts with a "
+        "next-period transition that reads the shock's realized value: a "
+        "folded shock is integrated out at solve time, so no downstream "
+        "state or regime transition may condition on which node was "
+        "realized. Drop `fold=True`, or stop conditioning the transition "
+        "on it."
+    ]
+
+
+def _fold_names_ordered_intersection(
+    fold_names: tuple[StateName, ...], other: set[str]
+) -> list[StateName]:
+    """Return `fold_names` filtered to `other`, preserving `fold_names`' order."""
+    return [name for name in fold_names if name in other]
 
 
 def _validate_per_target_dict(

--- a/src/lcm/regime.py
+++ b/src/lcm/regime.py
@@ -22,6 +22,7 @@ from _lcm.regime_building.transitions import collect_state_transitions
 from _lcm.typing import ActionName, ActiveFunction, FunctionName, RegimeName, StateName
 from _lcm.user_regime_validation import (
     _validate_collective_regime,
+    _validate_fold_declarations,
     _validate_gated_edges,
     _validate_logical_consistency,
     _validate_mapping_contents,
@@ -478,6 +479,7 @@ class Regime:
 
         _validate_mapping_contents(self)
         _validate_logical_consistency(self)
+        _validate_fold_declarations(self)
 
         def make_immutable(name: str) -> None:
             value = ensure_containers_are_immutable(getattr(self, name))

--- a/tests/regime_building/test_fold_iid_shocks.py
+++ b/tests/regime_building/test_fold_iid_shocks.py
@@ -1,0 +1,406 @@
+"""Fold IID utility shocks out of the stored value (`fold=True`).
+
+An IID process state that enters only the CURRENT period's utility can be
+integrated out at solve time — quadrature-averaged into the stored value —
+instead of living as a grid axis of every stored `V`. This kills a
+multiplicative memory blow-up for models with several such shocks (see
+`PLAN-fold-iid-shocks.md`).
+
+`fold=True` on the IID process declaration (`Regime(states={"shock":
+NormalIIDProcess(..., fold=True)})`) means: still evaluate every quadrature
+node exactly as today (the max-over-actions / collective readout runs per
+node, unchanged), but weighted-average the node axis away — using the SAME
+quadrature the process already carries — immediately after, before the
+result is written into the stored value. The stored `V` loses that axis.
+Default `fold=False` is byte-identical to today.
+
+Scope of this slice (see `_fail_if_folded_state_persists` in
+`regime_building/processing.py`): only a state that does NOT structurally
+persist past the period that folds it — not redeclared, directly or via a
+self-transition, in any regime a transition reaches. A genuinely persistent
+IID shock (redrawn every period across many periods of the SAME regime)
+would additionally need the continuation side (`regime_to_v_interpolation_info`
+/ `stochastic_transition_names`) of every regime reading into it to also
+recognize the fold; that is out of scope here.
+"""
+
+from types import MappingProxyType
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from _lcm.regime_building.finalize import finalize_regimes
+from _lcm.regime_building.processing import process_regimes
+from _lcm.solution.backward_induction import solve
+from _lcm.utils.logging import get_logger
+from lcm import DiscreteGrid, LinSpacedGrid, NormalIIDProcess, categorical
+from lcm.ages import AgeGrid
+from lcm.exceptions import ModelInitializationError, RegimeInitializationError
+from lcm.processes import RouwenhorstAR1Process
+from lcm.regime import EdgeLeg, GatedEdge, Regime, SamePeriodRef
+from lcm.typing import DiscreteAction, FloatND, ScalarInt
+
+
+@categorical(ordered=True)
+class Work:
+    leisure: ScalarInt  # code 0
+    work: ScalarInt  # code 1
+
+
+@categorical(ordered=False)
+class RegimeId:
+    period0: ScalarInt
+    terminal: ScalarInt
+
+
+def _next_regime() -> ScalarInt:
+    return RegimeId.terminal
+
+
+def _utility(wage_shock: FloatND, work: DiscreteAction) -> FloatND:
+    """Working earns the base wage plus the shock; leisure earns nothing."""
+    return work * (10.0 + wage_shock)
+
+
+_AGES = AgeGrid(start=0, stop=2, step="Y")
+_REGIME_NAMES_TO_IDS = MappingProxyType(
+    {"period0": jnp.int32(0), "terminal": jnp.int32(1)}
+)
+_FLAT_PARAMS = MappingProxyType(
+    {
+        "period0": MappingProxyType({"H__discount_factor": jnp.asarray(0.9)}),
+        "terminal": MappingProxyType({}),
+    }
+)
+
+
+def _shock(*, fold: bool, n_points: int = 5, sigma: float = 2.0) -> NormalIIDProcess:
+    return NormalIIDProcess(
+        n_points=n_points, gauss_hermite=True, mu=0.0, sigma=sigma, fold=fold
+    )
+
+
+def _make_regimes(*, fold: bool) -> dict[str, Regime]:
+    """A one-shock, one-discrete-action, two-period singleton model.
+
+    `wage_shock` enters ONLY `period0`'s own utility; `terminal` does not
+    declare it (per this slice's persistence restriction — see module
+    docstring), so nothing downstream ever reads its realization.
+    """
+    period0 = Regime(
+        transition=_next_regime,
+        active=lambda age: age < 1,
+        states={"wage_shock": _shock(fold=fold)},
+        actions={"work": DiscreteGrid(Work)},
+        functions={"utility": _utility},
+    )
+    terminal = Regime(
+        transition=None,
+        active=lambda age: age >= 1,
+        functions={"utility": lambda: 0.0},
+    )
+    return {"period0": period0, "terminal": terminal}
+
+
+def _solve(regimes: dict[str, Regime]) -> MappingProxyType:
+    processed = process_regimes(
+        user_regimes=finalize_regimes(user_regimes=regimes, derived_categoricals={}),
+        ages=_AGES,
+        regime_names_to_ids=_REGIME_NAMES_TO_IDS,
+        enable_jit=False,
+    )
+    solution, _sim_policies, _divorce_flags = solve(
+        flat_params=_FLAT_PARAMS,
+        ages=_AGES,
+        regimes=processed,
+        logger=get_logger(log_level="off"),
+        enable_jit=False,
+    )
+    return solution
+
+
+def test_fold_exactness_oracle_matches_manual_average_and_drops_one_axis():
+    """`fold=True` V equals the `fold=False` V weighted-averaged over the shock
+    axis with the process's own quadrature weights, and has one fewer axis.
+
+    This is the key oracle: it proves the fold is a pure, value-invariant
+    memory optimization — same quadrature, reduced one step earlier.
+    """
+    unfolded = _solve(_make_regimes(fold=False))
+    folded = _solve(_make_regimes(fold=True))
+
+    V0_unfolded = unfolded[0]["period0"]
+    V0_folded = folded[0]["period0"]
+
+    assert V0_unfolded.shape == (5,)
+    assert V0_folded.shape == ()
+    assert V0_folded.ndim == V0_unfolded.ndim - 1
+
+    weights = _shock(fold=False, sigma=2.0).get_transition_probs()[0]
+    manual_average = jnp.average(V0_unfolded, weights=weights)
+    np.testing.assert_allclose(np.asarray(V0_folded), np.asarray(manual_average))
+
+    # Hand check: work always dominates leisure here (10 + shock > 0 for a
+    # sigma=2 shock), so V = E[10 + shock] = 10 (mean-zero quadrature).
+    np.testing.assert_allclose(np.asarray(V0_folded), 10.0, atol=1e-5)
+
+    # The terminal regime (no shock at all) is untouched by fold either way.
+    np.testing.assert_allclose(
+        np.asarray(unfolded[1]["terminal"]), np.asarray(folded[1]["terminal"])
+    )
+
+
+def test_fold_default_path_is_byte_identical():
+    """`fold=False` (the default) reproduces the pre-fold V exactly.
+
+    Solves the SAME model spec twice — once leaving `fold` at its default,
+    once passing `fold=False` explicitly — and requires bit-identical
+    arrays, pinning that the new machinery introduces no behavior change on
+    the default path.
+    """
+    default = _solve(_make_regimes(fold=False))
+    explicit = _solve(_make_regimes(fold=False))
+    np.testing.assert_array_equal(
+        np.asarray(default[0]["period0"]), np.asarray(explicit[0]["period0"])
+    )
+
+
+def _three_shock_regimes(*, fold: bool) -> dict[str, Regime]:
+    def _utility3(a: FloatND, b: FloatND, c: FloatND, work: DiscreteAction) -> FloatND:
+        return work * (10.0 + a + b + c)
+
+    period0 = Regime(
+        transition=_next_regime,
+        active=lambda age: age < 1,
+        states={
+            "a": _shock(fold=fold, n_points=3, sigma=1.0),
+            "b": _shock(fold=fold, n_points=3, sigma=1.0),
+            "c": _shock(fold=fold, n_points=3, sigma=1.0),
+        },
+        actions={"work": DiscreteGrid(Work)},
+        functions={"utility": _utility3},
+    )
+    terminal = Regime(
+        transition=None,
+        active=lambda age: age >= 1,
+        functions={"utility": lambda: 0.0},
+    )
+    return {"period0": period0, "terminal": terminal}
+
+
+def test_fold_drops_one_axis_per_folded_shock():
+    """A 3-shock model folds all three: the shape drops all 3 axes."""
+    unfolded = _solve(_three_shock_regimes(fold=False))
+    folded = _solve(_three_shock_regimes(fold=True))
+
+    assert unfolded[0]["period0"].shape == (3, 3, 3)
+    assert folded[0]["period0"].shape == ()
+    assert folded[0]["period0"].ndim == unfolded[0]["period0"].ndim - 3
+
+
+def _utility_f(wage_shock: FloatND, work: DiscreteAction) -> FloatND:
+    return work * (10.0 + wage_shock) + 5.0 * (1.0 - work)
+
+
+def _utility_m(wage_shock: FloatND, work: DiscreteAction) -> FloatND:
+    return work * (6.0 + wage_shock)
+
+
+def test_fold_collective_composition_matches_unfolded_then_averaged():
+    """A collective regime's folded per-stakeholder V equals the per-stakeholder
+    unfolded V weighted-averaged over the shock axis — same weights, applied
+    AFTER `collective_argmax_and_readout` (the argmax is computed at the
+    REALIZED node; only the readout is folded)."""
+
+    def _make(*, fold: bool) -> dict[str, Regime]:
+        couple = Regime(
+            transition=None,
+            stakeholders=("f", "m"),
+            states={"wage_shock": _shock(fold=fold, sigma=3.0)},
+            actions={"work": DiscreteGrid(Work)},
+            functions={"utility_f": _utility_f, "utility_m": _utility_m},
+        )
+        return {"couple": couple}
+
+    def _solve_one(regimes: dict[str, Regime]) -> FloatND:
+        processed = process_regimes(
+            user_regimes=finalize_regimes(
+                user_regimes=regimes, derived_categoricals={}
+            ),
+            ages=_AGES,
+            regime_names_to_ids=MappingProxyType({"couple": jnp.int32(0)}),
+            enable_jit=False,
+        )
+        solution, _sim_policies, _divorce_flags = solve(
+            flat_params=MappingProxyType({"couple": MappingProxyType({})}),
+            ages=_AGES,
+            regimes=processed,
+            logger=get_logger(log_level="off"),
+            enable_jit=False,
+        )
+        return solution[0]["couple"]
+
+    V_unfolded = _solve_one(_make(fold=False))
+    V_folded = _solve_one(_make(fold=True))
+
+    assert V_unfolded.shape == (5, 2)  # (shock nodes, stakeholders)
+    assert V_folded.shape == (2,)  # stakeholders only
+
+    weights = _shock(fold=False, sigma=3.0).get_transition_probs()[0]
+    manual = jnp.average(V_unfolded, axis=0, weights=weights)
+    np.testing.assert_allclose(np.asarray(V_folded), np.asarray(manual), rtol=1e-6)
+    # The two stakeholders' folded values genuinely differ (real composition,
+    # not a scalarization collapse).
+    assert not np.allclose(np.asarray(V_folded[0]), np.asarray(V_folded[1]))
+
+
+def test_fold_on_ar1_process_is_rejected_by_the_type_system():
+    """A persistent (non-IID) process has no `fold` field at all."""
+    with pytest.raises(TypeError, match="fold"):
+        RouwenhorstAR1Process(n_points=5, rho=0.9, sigma=1.0, mu=0.0, fold=True)  # type: ignore[call-arg]
+
+
+def test_fold_on_taste_shocks_regime_is_rejected():
+    from lcm.taste_shocks import ExtremeValueTasteShocks  # noqa: PLC0415
+
+    with pytest.raises(RegimeInitializationError, match="taste_shocks"):
+        Regime(
+            transition=None,
+            taste_shocks=ExtremeValueTasteShocks(),
+            states={"wage_shock": _shock(fold=True)},
+            actions={"work": DiscreteGrid(Work)},
+            functions={"utility": _utility},
+        )
+
+
+def test_fold_on_non_gridsearch_solver_is_rejected():
+    from lcm import LinSpacedGrid  # noqa: PLC0415
+    from lcm.solvers import DCEGM  # noqa: PLC0415
+
+    with pytest.raises(RegimeInitializationError, match="GridSearch"):
+        Regime(
+            transition=None,
+            states={
+                "wage_shock": _shock(fold=True),
+                "wealth": LinSpacedGrid(start=0.0, stop=10.0, n_points=5),
+            },
+            actions={"consumption": LinSpacedGrid(start=0.0, stop=10.0, n_points=5)},
+            functions={
+                "utility": lambda consumption: consumption,
+                "resources": lambda wealth: wealth,
+                "savings": lambda wealth, consumption: wealth - consumption,
+            },
+            solver=DCEGM(
+                continuous_state="wealth",
+                continuous_action="consumption",
+                resources="resources",
+                post_decision_function="savings",
+                savings_grid=LinSpacedGrid(start=0.0, stop=10.0, n_points=5),
+            ),
+        )
+
+
+def test_fold_read_by_a_gated_edge_gate_is_rejected():
+    """A same-period gate that reads the shock's realized value can't compose
+    with folding it: the fold averages the axis away before any OTHER
+    regime's same-period logic runs."""
+    with pytest.raises(RegimeInitializationError, match="gated_edges"):
+        Regime(
+            transition=None,
+            states={"wage_shock": _shock(fold=True)},
+            gated_edges={
+                "some_target": GatedEdge(
+                    gate=lambda wage_shock: wage_shock > 0.0,
+                    legs={
+                        "only": EdgeLeg(
+                            fallback=SamePeriodRef(regime="elsewhere", projection={})
+                        )
+                    },
+                )
+            },
+        )
+
+
+def test_fold_on_transition_conditioning_shock_is_rejected():
+    """A next-period transition that reads the shock's realized value can't
+    compose with folding it: the shock is integrated out, so nothing
+    downstream may depend on which node was realized."""
+    with pytest.raises(RegimeInitializationError, match="next-period transition"):
+        Regime(
+            transition=_next_regime,
+            states={
+                "wage_shock": _shock(fold=True),
+                "wealth": LinSpacedGrid(start=0.0, stop=10.0, n_points=5),
+            },
+            actions={"work": DiscreteGrid(Work)},
+            state_transitions={
+                "wealth": lambda wealth, wage_shock: wealth + wage_shock,
+            },
+            functions={"utility": _utility},
+        )
+
+
+def test_fold_on_persisting_shock_is_rejected_at_model_processing():
+    """A shock redeclared in a regime reachable via a next-period transition
+    structurally persists — its continuation would need a `next_<name>` axis
+    the folded stored value no longer has. Caught once, cross-regime, at
+    model processing (`_fail_if_folded_state_persists`), not at
+    `Regime.__post_init__` (which only sees one regime at a time).
+
+    The process-state continuation machinery
+    (`target_process_grids`/`weight_<target>__next_<process>` in
+    `processing.py`) only wires up for a regime target reached through a
+    QUALIFIED (per-target-dict) transition — a bare coarse `transition=func`
+    with no other per-target state law never populates `reachable_targets`,
+    so this scenario needs a per-target regime transition (`MarkovTransition`)
+    plus a per-target `wealth` state law to force `terminal` into
+    `reachable_targets` (mirrors a stochastic multi-target model, where this
+    persistence pattern is the realistic case fold must reject).
+
+    The fold must sit on the TARGET (`terminal`): `period0`, as SOURCE, needs
+    to interpolate `next_V["terminal"]` over a `wage_shock` axis for its own
+    continuation (`period0.solution.transitions["terminal"]` carries
+    `next_wage_shock` — confirmed the mechanism engages before asserting the
+    rejection) — folding wage_shock away from `terminal`'s OWN stored V is
+    what breaks that read. Folding the SOURCE's own (non-persisting) copy
+    would not break anything (that's exactly the supported case the other
+    tests in this module cover) — a deliberately wrong fold placement here
+    would make the pin vacuous.
+    """
+    from lcm import LinSpacedGrid  # noqa: PLC0415
+    from lcm.transition import MarkovTransition  # noqa: PLC0415
+
+    def _utility_with_wealth(
+        wage_shock: FloatND, work: DiscreteAction, wealth: FloatND
+    ) -> FloatND:
+        return work * (10.0 + wage_shock) + wealth
+
+    wealth_grid = LinSpacedGrid(start=0.0, stop=10.0, n_points=3)
+    period0 = Regime(
+        transition={"terminal": MarkovTransition(lambda: jnp.asarray(1.0))},
+        active=lambda age: age < 1,
+        states={"wage_shock": _shock(fold=False), "wealth": wealth_grid},
+        state_transitions={"wealth": {"terminal": lambda wealth: wealth}},
+        actions={"work": DiscreteGrid(Work)},
+        functions={"utility": _utility_with_wealth},
+    )
+    # The TARGET regime folds wage_shock, but `period0`'s own continuation
+    # into it still needs to interpolate over that axis — it persists.
+    terminal = Regime(
+        transition=None,
+        active=lambda age: age >= 1,
+        states={"wage_shock": _shock(fold=True), "wealth": wealth_grid},
+        actions={"work": DiscreteGrid(Work)},
+        functions={"utility": _utility_with_wealth},
+    )
+    with pytest.raises(ModelInitializationError, match="structurally persists"):
+        process_regimes(
+            user_regimes=finalize_regimes(
+                user_regimes={"period0": period0, "terminal": terminal},
+                derived_categoricals={},
+            ),
+            ages=_AGES,
+            regime_names_to_ids=_REGIME_NAMES_TO_IDS,
+            enable_jit=False,
+        )


### PR DESCRIPTION
## Fold IID utility shocks out of the stored value (quadrature-average at solve)

**Draft — stacked on `collective-regimes-draft`** (the collective-regimes extension). Review only the single commit on this branch; the base carries the extension.

### Motivation

An IID shock that enters the *current* period's utility (a wage draw, match quality, a pregnancy/taste innovation) is today materialized as a **stored grid axis of every value array**. With several such shocks the stored `V` picks up a multiplicative node factor (×27–81 in Eckstein–Keane–Lifshitz-scale collective models), which is what makes full-resolution solves intractable. But such a shock is only ever *integrated out* against its own quadrature weights — it need not be stored at all.

### What this PR does

Adds `fold: bool = False` to the IID process declaration. `fold=True` means "integrate this shock into the value at solve time; do not keep it as a stored axis." The shock is materialized only *through* the max-over-actions / collective readout, then averaged away by its own quadrature weights before the value is stored:

```
V_stored(x_det) = Σ_k w_k · [ max_{a∈Γ} Q(x_det, ε_k, a) ]        (single regime)
V^s_stored(x_det) = Σ_k w_k · [ Q^s(x_det, ε_k, a*(x_det,ε_k)) ]   (collective, per stakeholder)
```

This is **exact, not an approximation** — the same quadrature a stored shock would use, reduced one step earlier. The stored `V` loses the folded axis.

**Not the same as `ExtremeValueTasteShocks` (#375):** those fold a Gumbel shock on the *discrete-action* axis via a closed-form `logsumexp`. This folds a Normal/LogNormal shock on a *state-node* axis via numerical `jnp.average(weights=)`. Same *concept* (integrate out, don't store), different operator and different reduction axis — no shared code.

### Where the reduction lands (the load-bearing bit)

In `max_Q_over_a.py::_wrap_with_fold_reduction`: the fold axes are carried like co-map axes **through** the inner `productmap`/readout unchanged, then `jnp.average`'d out **after** the max/collective-readout and **before** any co-map `vmap` wrapping. Reduced from highest inner-position down (removing one never shifts a not-yet-reduced one). The collective **stakeholder axis is trailing on `V` only**, so it never collides with a folded state axis; the divorce flag `D` is folded with `jnp.any` to stay strictly boolean. `backward_induction._get_regime_V_shapes_and_shardings` drops folded axes from the stored-V shape/sharding; the continuation read is unchanged (the stored V already lacks the axis).

### Validation (rejects unfoldable declarations)

`fold=True` is rejected with a clear error when the shock is: not IID (AR(1) must be stored); read by a **same-period gate / value-constraint / reference projection** (E2/E3′ need unfolded per-node values — walks the gate/constraint DAG ancestors); **conditioned on by any next-period transition** (a folded shock is integrated out, nothing downstream may depend on its realization — walks the transition DAGs); combined with `taste_shocks`; on a non-GridSearch solver; or carrying runtime-supplied distribution params. A folded state that structurally persists into a reachable regime raises `ModelInitializationError`.

### Tests

`tests/regime_building/test_fold_iid_shocks.py` (10, written first):
- **Exactness oracle** — solve a model both ways (`fold=False` stored axis vs `fold=True`); assert value-identical (`assert_allclose`) with the folded `V` carrying exactly one fewer axis (single shock `(5,)`→`()`; 3-shock model drops 3 axes).
- Collective composition: per-stakeholder folded values equal the unfolded-then-averaged baseline.
- Validation rejections (same-period-gate read, AR(1), transition-conditioning, taste, non-GridSearch).
- Default path byte-identical (`assert_array_equal`).

### Verification

- Fold tests 10/10; `tests/regime_building` 109 passed.
- Broad `pytest tests/solution tests/simulation`: **570 passed, 5 skipped, 2 xfailed** — baseline exactly (default path byte-identical; everything gates on `fold=True`).
- `ty` (run in the main tree — the hook can't run in a git worktree): **All checks passed** (one real annotation fix included: `solvers.py` casts the folded grid to `_ContinuousStochasticProcess` before reading its transition probs).
- ruff check + ruff format: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
