### PR TITLE
Restrict PyPI publish workflow to v* release tags

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,9 @@
 ---
 name: PyPI
-on: push
+on:
+  push:
+    tags:
+      - v*
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
@@ -25,7 +28,7 @@ jobs:
           --wheel
           --outdir dist/
       - name: Publish distribution 📦 to PyPI
-        if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYLCM_PYPI_TOKEN }}


### PR DESCRIPTION
## What happened

On 2026-07-22 at 06:48 UTC, an unintended release `pylcm 22` was published to PyPI ([run 29897963430](https://github.com/OpenSourceEconomics/pylcm/actions/runs/29897963430)). The chain of events:

1. A branch-snapshot tag `collective-regimes-preproper-2026-07-22` was pushed to the repository.
2. The publish workflow triggers on `on: push`, which includes tag pushes, and its publish step was gated only by `startsWith(github.ref, 'refs/tags')`. Any tag push therefore published to PyPI.
3. hatch-vcs derives the package version from the git tag. Its default tag pattern allows an arbitrary dashed prefix, so it parsed the trailing `22` of the tag name as the version.

The published artifact was an honest build of commit c2d86507 on that branch, so no credentials were compromised. The release was still harmful: version `22` sorts above every real release, so `pip install pylcm` resolved to it. It has been yanked on PyPI.

## Fix

- Trigger the workflow only on `v*` tag pushes instead of every push. This also stops the workflow from building distributions on every branch push.
- Tighten the publish guard to `startsWith(github.ref, 'refs/tags/v')` as a second line of defense.

The existing non-release tags on the remote (`collective-regimes-preproper-2026-07-22`, `parked/*`) can no longer trigger a publish after this change.