### PR TITLE
BUG Aggregate the continuation lottery stably under a certainty equivalent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,14 @@ chronological order. We follow [semantic versioning](https://semver.org/).
   including into states the source regime does not carry and across grids that
   differ between regimes.
 
+- A bare callable or bare `MarkovTransition` on `Regime.transition` declares
+  conservative support over every regime active in the next period, so every
+  temporally compatible candidate must have a valid state handoff (a carried
+  state, a deterministic/stochastic law, or an explicit target-local/entry
+  law). Use a per-target mapping to declare narrower support instead. Runtime
+  transition probabilities of zero do not narrow this topology — only the
+  declared form does.
+
 - Model-level regime slots: `Model(functions=..., constraints=..., states=...,
   state_transitions=..., actions=...)` declares shared structure once and
   merges it into every regime under the exactly-one-level rule. Broadcast

--- a/docs/explanations/architecture.md
+++ b/docs/explanations/architecture.md
@@ -58,6 +58,7 @@ _lcm/
 ├── jaxtyping_patch.py     ← bootstrap patch run before any jaxtyping type
 ├── model_processing.py    ← Model.__init__ build pipeline
 ├── pandas_utils.py        ← pd.Series ↔ JAX array bridge
+├── reachability.py        ← construction-time solve/simulate regime graphs
 ├── state_action_space.py  ← state / action space validators
 ├── transition_checks.py   ← pre-solve regime + state transition prob checks
 ├── typing.py              ← engine-side type aliases and protocols
@@ -280,6 +281,35 @@ The numerical checks fired at solve / simulate time live outside `regime_buildin
   the diagnostic-intermediates closure built in `regime_building/diagnostics.py` to
   pinpoint which intermediate (`U`, `F`, `E[V]`, `Q`) produced the NaN.
 
+## Reachability: `_lcm/reachability.py`
+
+`build_model_reachability` builds the model's static solve and simulate graphs once, at
+model construction, from the single canonical `active_periods_by_regime` mapping
+(`regime_building.processing.compute_active_periods_by_regime`) and the declared regime
+transitions. There is no runtime topology pass — the graph never changes after
+construction, and no runtime probability value narrows or widens it.
+
+Every retained edge is `EdgeStatus.CONDITIONAL`; there is no `TRUE` status, because no
+declaration form (not even a per-target dict with one key) proves unconditional positive
+probability independently of state, action, and free runtime parameters. A coarse (bare
+callable / bare `MarkovTransition`) regime transition is therefore conservative: it
+retains an edge to every regime active in the next period, and every such edge's state
+handoff is checked at model build — a carried state, a deterministic/stochastic law, or
+an explicit target-local/entry law must supply each target state's next-period value. A
+per-target dict narrows support to its declared key set instead.
+
+The solve and simulate phases build independent graphs (`ModelReachability.solution` /
+`.simulation`), because a regime transition's `Phased` sides can differ between them —
+so the two graphs may retain different edges for the same source period.
+
+Solver and simulation runtime code (`_lcm/solution/`, `_lcm/simulation/`) consume this
+graph — `PhaseReachability.targets`, `.union_targets`, `.edge_status`, ... — but never
+infers reachability itself: no runtime module calls an activity predicate, inspects a
+declared transition's raw mapping keys, or derives continuation-target membership from
+state-law-bundle keys. `regime_building/processing.py` and `diagnostics.py` read the
+graph to decide which targets a period's `Q_and_F` (or diagnostic) closure needs to
+build; they do not re-derive it.
+
 ## Solve and simulate
 
 ```
@@ -425,8 +455,10 @@ If you're reading the codebase for the first time, the path of least confusion i
 1. **`_lcm/regime_building/processing.py`** for per-regime canonicalisation — the
    longest single file and the heart of the build.
 1. **`_lcm/engine.py`** for the canonical dataclasses the DP machinery consumes.
+1. **`_lcm/reachability.py`** for the static solve/simulate graphs solve and simulate
+   consume but never infer.
 1. **`_lcm/solution/backward_induction.py`** and **`_lcm/simulation/simulate.py`** for
    the actual DP and sampling.
 
-By the time you reach (6), the canonical form should feel familiar and the JAX-traced
+By the time you reach (7), the canonical form should feel familiar and the JAX-traced
 code becomes easy to read.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,9 @@ per-file-ignores."tests/*" = [
   "S301",    # Use of pickle
   "SLF001",  # Private member access
 ]
+per-file-ignores."tests/test_certainty_equivalent.py" = [
+  "ARG001", # Unused function argument (x64_enabled / x64_disabled fixtures)
+]
 per-file-ignores."tests/test_compilation_cache.py" = [
   "S603", # subprocess call with test-controlled input
 ]

--- a/src/_lcm/certainty_equivalent.py
+++ b/src/_lcm/certainty_equivalent.py
@@ -6,7 +6,7 @@ Engine modules may import directly from here.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
 
@@ -82,6 +82,40 @@ class QuasiArithmeticMean(CertaintyEquivalent):
             get_union_of_args([self.transform, self.inverse]) - {CE_VALUE_ARG}
         )
 
+    def aggregate(
+        self,
+        *,
+        values: FloatND,
+        weights: FloatND,
+        params: Mapping[str, FloatND],
+    ) -> FloatND:
+        """Return the certainty equivalent `g⁻¹(Σ w · g(v))` over the last axis.
+
+        The single aggregation entry point of the engine: the whole
+        continuation lottery — every stochastic node of every reachable
+        target regime, weighted by the regime probability — arrives here
+        flattened, so `transform` is applied before every expectation and
+        `inverse` exactly once.
+
+        Args:
+            values: Continuation values of the lottery along the last axis.
+            weights: Nonnegative probabilities over `values`. A unit-mass
+                lottery yields a certainty equivalent; a smaller mass carries
+                through as the correspondingly smaller aggregate.
+            params: Mapping of runtime parameter names to their values.
+                `transform` and `inverse` each receive the subset their
+                signature declares.
+
+        Returns:
+            The certainty equivalent, reduced over the last axis.
+
+        """
+        transformed = self.transform(value=values, **_args_for(self.transform, params))
+        return self.inverse(
+            value=jnp.sum(weights * transformed, axis=-1),
+            **_args_for(self.inverse, params),
+        )
+
 
 def power_transform(value: FloatND, risk_aversion: FloatND) -> FloatND:
     """Apply `g(v) = v^(1 - risk_aversion)`, or `log(v)` at `risk_aversion = 1`."""
@@ -111,10 +145,102 @@ class PowerMean(QuasiArithmeticMean):
     Requires strictly positive continuation values. `risk_aversion = 1` is
     the geometric-mean (log) limit, `CE = exp(E[log V'])`; `risk_aversion
     = 0` reduces to the linear expectation.
+
+    The aggregation is evaluated in an anchored log form, so the result stays
+    finite wherever the mathematical power mean is — including high risk
+    aversion at continuation values near the borrowing constraint, where
+    `V'^(1 - risk_aversion)` alone would overflow the dtype.
     """
 
     transform: Callable[..., FloatND] = power_transform
     inverse: Callable[..., FloatND] = power_inverse
+
+    def aggregate(
+        self,
+        *,
+        values: FloatND,
+        weights: FloatND,
+        params: Mapping[str, FloatND],
+    ) -> FloatND:
+        """Return the weighted power mean `(Σ w · v^(1-ra))^(1/(1-ra))`, stably.
+
+        `ra` is `risk_aversion`. The naive `inverse(Σ w · transform(v))`
+        overflows when `risk_aversion > 1` and `v` is near the borrowing
+        constraint: the intermediate `v^(1-ra)` exceeds the dtype's range and
+        the certainty equivalent collapses to zero or infinity. The
+        aggregation evaluates in an anchored weight/deviation log form —
+        `log CE = a + [log(W) + log1p(E/W)] / (1-ra)` with `a` the extremal
+        log value, `W` the weight sum, and `E` the `expm1`-deviation sum —
+        which stays finite wherever the mathematical value is and keeps the
+        geometric-mean limit exact arbitrarily close to `risk_aversion = 1`.
+        `risk_aversion = 1` is the weighted geometric mean `exp(E[log v])`.
+
+        Args:
+            values: Strictly positive continuation values along the last axis.
+            weights: Nonnegative probabilities over `values`, summing to one.
+                A weight sum within sqrt(eps) of one is floating summation
+                roundoff on a unit-mass lottery and aggregates as exactly
+                normalized — the power mean has a finite `ra -> 1` limit only
+                at unit mass. Scaling the weights by a materially non-unit
+                `k` scales the result by `k^(1/(1-ra))` (with no `ra -> 1`
+                limit; `ra = 1` publishes the normalized geometric mean), so
+                only a unit-mass lottery yields a certainty equivalent.
+                Zero-weight entries drop out exactly.
+            params: Mapping carrying the `risk_aversion` runtime parameter.
+
+        Returns:
+            The certainty equivalent, reduced over the last axis.
+
+        """
+        risk_aversion = params["risk_aversion"]
+        log_v = jnp.log(values)
+        positive = weights > 0.0
+        exponent = 1.0 - risk_aversion
+        # The `risk_aversion == 1` power branch must not divide by zero.
+        safe_exponent = jnp.where(exponent == 0.0, 1.0, exponent)
+        # Anchored weight/deviation form: with `a` the extremal log value on
+        # the side that keeps every exponent nonpositive,
+        # `log CE = a + [log(W) + log1p(E / W)] / (1-ra)` where `W = sum w`
+        # and `E = sum w expm1((1-ra)(log v - a))`. The deviation ratio keeps
+        # the quotient exact arbitrarily close to `ra = 1` — a rounded
+        # log-sum divided by a near-zero exponent loses the geometric-mean
+        # limit to cancellation — while the mass term `log(W)` carries a
+        # materially non-unit weight sum exactly and drops out for a
+        # unit-mass lottery (up to summation roundoff; see below).
+        anchor_high = jnp.max(jnp.where(positive, log_v, -jnp.inf), axis=-1)
+        anchor_low = jnp.min(jnp.where(positive, log_v, jnp.inf), axis=-1)
+        anchor = jnp.where(exponent >= 0.0, anchor_high, anchor_low)
+        anchor = jnp.where(exponent == 0.0, 0.0, anchor)
+        centered = log_v - anchor[..., None]
+        masked_weights = jnp.where(positive, weights, weights * 0.0)
+        weight_sum = jnp.sum(jnp.broadcast_to(masked_weights, centered.shape), axis=-1)
+        deviation_sum = jnp.sum(
+            jnp.where(
+                positive,
+                weights * jnp.expm1(exponent * centered),
+                weights * 0.0,
+            ),
+            axis=-1,
+        )
+        safe_weight = jnp.where(weight_sum > 0.0, weight_sum, 1.0)
+        # A mass gap below sqrt(eps) is floating summation roundoff on a
+        # mathematically unit-mass lottery (quadrature weights rarely sum to
+        # one bit-exactly): `log(W)/(1-ra)` would amplify it to an order-one
+        # error near `ra = 1`, so such lotteries aggregate as exactly
+        # normalized. A materially non-unit mass keeps its exact `log(W)`
+        # contribution (the documented `k^(1/(1-ra))` scaling).
+        roundoff_mass = jnp.abs(weight_sum - 1.0) <= jnp.sqrt(
+            jnp.finfo(safe_weight.dtype).eps
+        )
+        log_mass = jnp.where(roundoff_mass, 0.0, jnp.log(safe_weight))
+        log_ce_power = (
+            anchor + (log_mass + jnp.log1p(deviation_sum / safe_weight)) / safe_exponent
+        )
+        log_ce_geometric = (
+            jnp.sum(jnp.where(positive, weights * log_v, weights * 0.0), axis=-1)
+            / safe_weight
+        )
+        return jnp.exp(jnp.where(exponent == 0.0, log_ce_geometric, log_ce_power))
 
 
 def resolve_certainty_equivalent(
@@ -122,23 +248,21 @@ def resolve_certainty_equivalent(
 ) -> tuple[
     QuasiArithmeticMean | None,
     MappingProxyType[str, str],
-    MappingProxyType[str, str],
 ]:
     """Narrow the certainty equivalent and map its args to flat param names.
 
     The runtime parameters live under the pseudo-function name
     `certainty_equivalent` in the regime's flat params
-    (`certainty_equivalent__<arg>`); the returned mappings let the Q-and-F
-    closure pull each callable's kwargs from `states_actions_params`.
+    (`certainty_equivalent__<arg>`); the returned mapping lets the Q-and-F
+    closure assemble `aggregate`'s `params` from `states_actions_params`.
 
     Returns:
-        Tuple of the narrowed quasi-arithmetic-mean CE (or `None`), the
-        transform's arg-to-flat-name mapping, and the inverse's
+        Tuple of the narrowed quasi-arithmetic-mean CE (or `None`) and its
         arg-to-flat-name mapping.
 
     """
     if certainty_equivalent is None:
-        return None, MappingProxyType({}), MappingProxyType({})
+        return None, MappingProxyType({})
     if not isinstance(certainty_equivalent, QuasiArithmeticMean):
         msg = (
             "Only `QuasiArithmeticMean` certainty equivalents are "
@@ -146,16 +270,19 @@ def resolve_certainty_equivalent(
         )
         raise NotImplementedError(msg)
 
-    def flat_names(func: Callable[..., FloatND]) -> MappingProxyType[str, str]:
-        return MappingProxyType(
-            {
-                arg: f"certainty_equivalent__{arg}"
-                for arg in get_union_of_args([func]) - {CE_VALUE_ARG}
-            }
-        )
-
     return (
         certainty_equivalent,
-        flat_names(certainty_equivalent.transform),
-        flat_names(certainty_equivalent.inverse),
+        MappingProxyType(
+            {
+                arg: f"certainty_equivalent__{arg}"
+                for arg in certainty_equivalent.param_names
+            }
+        ),
     )
+
+
+def _args_for(
+    func: Callable[..., FloatND], params: Mapping[str, FloatND]
+) -> dict[str, FloatND]:
+    """Pick the entries of `params` that `func`'s signature declares."""
+    return {name: params[name] for name in get_union_of_args([func]) - {CE_VALUE_ARG}}

--- a/src/_lcm/model_processing.py
+++ b/src/_lcm/model_processing.py
@@ -173,6 +173,7 @@ def validate_model_inputs(
     n_subjects: int | None = None,
     broadcast_variables: Mapping[RegimeName, frozenset[str]] | None = None,
     ages: AgeGrid | None = None,
+    active_periods_by_regime: Mapping[RegimeName, tuple[int, ...]] | None = None,
 ) -> None:
     """Validate model constructor inputs.
 
@@ -228,7 +229,10 @@ def validate_model_inputs(
         )
     error_messages.extend(
         _validate_all_variables_used(
-            user_regimes, broadcast_variables=broadcast_variables, ages=ages
+            user_regimes,
+            broadcast_variables=broadcast_variables,
+            ages=ages,
+            active_periods_by_regime=active_periods_by_regime,
         )
     )
 
@@ -265,6 +269,7 @@ def _validate_all_variables_used(
     *,
     broadcast_variables: Mapping[RegimeName, frozenset[str]] | None = None,
     ages: AgeGrid | None = None,
+    active_periods_by_regime: Mapping[RegimeName, tuple[int, ...]] | None = None,
 ) -> list[str]:
     """Validate that all states and actions are used somewhere in each regime.
 
@@ -296,7 +301,11 @@ def _validate_all_variables_used(
             variable_names -= broadcast_variables.get(regime_name, frozenset())
         user_functions = dict(user_regime.get_all_functions(phase="solve"))
         if ages is not None:
-            active_periods = ages.get_periods_where(user_regime.active)
+            active_periods = (
+                ()
+                if active_periods_by_regime is None
+                else active_periods_by_regime.get(regime_name, ())
+            )
             if not active_periods and _regime_has_markers(user_regime):
                 # This regime is about to fail with the precise
                 # "active at no model age" `RegimeInitializationError` once

--- a/src/_lcm/persistence/io.py
+++ b/src/_lcm/persistence/io.py
@@ -88,7 +88,7 @@ def _write_metadata(
         "platform": _get_platform(),
         "fields": fields,
     }
-    with (snap_dir / "metadata.json").open("w") as fh:
+    with (snap_dir / "metadata.json").open("w", encoding="utf-8") as fh:
         json.dump(metadata, fh, indent=2)
 
 
@@ -117,7 +117,7 @@ def _write_environment_files(snap_dir: Path) -> None:
 
         Platform: {platform_str}
     """)
-    (snap_dir / "REPRODUCE.md").write_text(reproduce_md)
+    (snap_dir / "REPRODUCE.md").write_text(reproduce_md, encoding="utf-8")
 
 
 def _snapshot_counter(entry: Path, prefix: str) -> int:

--- a/src/_lcm/reachability.py
+++ b/src/_lcm/reachability.py
@@ -1,7 +1,27 @@
 """Construction-time, solver-independent temporal regime reachability.
 
-This module owns the model graph. Solver code may derive layouts from the graph,
-but may not infer which regime pairs are reachable.
+This module owns the model graph, built once — via `build_model_reachability` — at
+model construction, from the single canonical `active_periods_by_regime` mapping and
+the declared regime transitions. There is no runtime topology pass: the graph never
+changes after construction, and no runtime probability value narrows or widens it.
+
+Every retained edge in `targets_by_period` / `edge_status_by_period` is
+`EdgeStatus.CONDITIONAL` — there is no `TRUE` status, because no declaration form
+proves unconditional positive probability independently of state, action, and free
+runtime parameters. A coarse (bare callable / bare `MarkovTransition`) regime
+transition is therefore conservative: it retains an edge to every regime active in
+the next period, and every such edge is checked for a valid state handoff (a carried
+state, a deterministic/stochastic law, or an explicit target-local/entry law) at
+model build. A per-target dict narrows support to its declared key set instead.
+
+The solve and simulate phases build independent graphs (`ModelReachability.solution`
+/ `.simulation`) from the same construction-time semantics, and may retain different
+edges for the same source period when the regime transition's `Phased` sides differ.
+
+Solver and simulation runtime code consume this graph (`PhaseReachability.targets`,
+`.union_targets`, `.edge_status`, ...) but never infers reachability itself — it does
+not call an activity predicate, inspect a declared transition's raw mapping keys, or
+derive continuation targets from state-law-bundle keys.
 """
 
 from collections.abc import Collection, Mapping

--- a/src/_lcm/reachability.py
+++ b/src/_lcm/reachability.py
@@ -4,23 +4,28 @@ This module owns the model graph. Solver code may derive layouts from the graph,
 but may not infer which regime pairs are reachable.
 """
 
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from enum import IntEnum
 from types import MappingProxyType
 from typing import Literal
 
-from _lcm.typing import ActiveFunction, RegimeName
-from lcm.typing import UserAge
+from _lcm.typing import RegimeName
 
 type PhaseName = Literal["solution", "simulation"]
 
 
 class EdgeStatus(IntEnum):
-    """Static classification of a declared one-period regime edge."""
+    """Static classification of a declared one-period regime edge.
+
+    No current declaration proves unconditional positive probability
+    independently of state, action, and free runtime parameters — a
+    per-target mapping with one key is still not such a proof. Every
+    retained edge is therefore `CONDITIONAL`; there is no `TRUE` status to
+    infer from declaration shape alone.
+    """
 
     FALSE = 0
-    TRUE = 1
     CONDITIONAL = 2
 
 
@@ -114,22 +119,6 @@ class ModelReachability:
         return self.solution if phase == "solution" else self.simulation
 
 
-def active_periods_from_predicates(
-    *,
-    ages: Sequence[UserAge],
-    active_by_regime: Mapping[RegimeName, ActiveFunction],
-) -> MappingProxyType[RegimeName, frozenset[int]]:
-    """Evaluate all activity predicates once at model construction."""
-    return MappingProxyType(
-        {
-            regime: frozenset(
-                period for period, age in enumerate(ages) if bool(is_active(age))
-            )
-            for regime, is_active in active_by_regime.items()
-        }
-    )
-
-
 def candidate_targets_from_transition(
     *, transition: object, all_regime_names: Collection[RegimeName]
 ) -> tuple[RegimeName, ...]:
@@ -158,10 +147,8 @@ def build_phase_reachability(
     active_periods_by_regime: Mapping[RegimeName, Collection[int]],
     candidate_targets_by_source: Mapping[RegimeName, Collection[RegimeName]],
     terminal_regimes: Collection[RegimeName] = (),
-    unconditional_targets_by_source: Mapping[RegimeName, Collection[RegimeName]]
-    | None = None,
 ) -> PhaseReachability:
-    """Build one static graph; retain both TRUE and CONDITIONAL edges."""
+    """Build one static graph; every retained edge is `CONDITIONAL`."""
     if n_periods < 1:
         raise ValueError("n_periods must be positive")
 
@@ -184,7 +171,6 @@ def build_phase_reachability(
         for regime, periods in active_periods_by_regime.items()
     }
     terminal = frozenset(terminal_regimes)
-    unconditional = unconditional_targets_by_source or {}
     candidates = MappingProxyType(
         {
             source: tuple(sorted(set(targets)))
@@ -210,8 +196,6 @@ def build_phase_reachability(
                     or period + 1 not in active[target]
                 ):
                     status = EdgeStatus.FALSE
-                elif target in unconditional.get(source, ()):
-                    status = EdgeStatus.TRUE
                 else:
                     status = EdgeStatus.CONDITIONAL
                 period_status[(source, target)] = status
@@ -233,16 +217,18 @@ def build_phase_reachability(
 
 def build_model_reachability(
     *,
-    ages: Sequence[UserAge],
-    active_by_regime: Mapping[RegimeName, ActiveFunction],
+    n_periods: int,
+    active_periods_by_regime: Mapping[RegimeName, Collection[int]],
     transitions_by_phase: Mapping[PhaseName, Mapping[RegimeName, object]],
     terminal_regimes: Collection[RegimeName] = (),
 ) -> ModelReachability:
-    """Build solve and simulate graphs from the same construction-time semantics."""
-    all_regime_names = frozenset(active_by_regime)
-    active = active_periods_from_predicates(
-        ages=ages, active_by_regime=active_by_regime
-    )
+    """Build solve and simulate graphs from the same construction-time semantics.
+
+    `active_periods_by_regime` must be the single canonical activity mapping
+    computed once at model preparation (via `AgeGrid.get_periods_where`) —
+    this function does not evaluate `Regime.active` itself.
+    """
+    all_regime_names = frozenset(active_periods_by_regime)
 
     def build(phase: PhaseName) -> PhaseReachability:
         transitions = transitions_by_phase[phase]
@@ -254,8 +240,8 @@ def build_model_reachability(
             for source in all_regime_names
         }
         return build_phase_reachability(
-            n_periods=len(ages),
-            active_periods_by_regime=active,
+            n_periods=n_periods,
+            active_periods_by_regime=active_periods_by_regime,
             candidate_targets_by_source=candidates,
             terminal_regimes=terminal_regimes,
         )

--- a/src/_lcm/regime_building/Q_and_F.py
+++ b/src/_lcm/regime_building/Q_and_F.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from types import MappingProxyType
 from typing import Any, cast
 
@@ -23,6 +23,7 @@ from _lcm.typing import (
     TransitionFunction,
     TransitionFunctionName,
     TransitionFunctionsMapping,
+    _ParamsLeaf,
 )
 from _lcm.utils.dispatchers import productmap
 from _lcm.utils.functools import get_union_of_args
@@ -72,79 +73,20 @@ def get_Q_and_F(
 
     """
     U_and_F = _get_U_and_F(functions=functions, constraints=constraints)
-    state_transitions = {}
-    next_stochastic_states_weights = {}
-    joint_weights_from_marginals = {}
-    next_V = {}
-
-    next_V_extra_param_names: dict[RegimeName, frozenset[str]] = {}
-    next_V_has_stochastic_states: dict[RegimeName, bool] = {}
-
-    for target_regime_name in period_targets:
-        # Transitions from the current regime to the target regime
-        bundle = transitions.get(target_regime_name, MappingProxyType({}))
-
-        # Functions required to calculate the expected continuation values
-        state_transitions[target_regime_name] = get_next_state_function_for_solution(
-            functions=functions,
-            transitions=bundle,
-        )
-        next_stochastic_states_weights[target_regime_name] = (
-            get_next_stochastic_weights_function(
-                functions=functions,
-                transitions=bundle,
-                stochastic_transition_names=stochastic_transition_names,
-                regime_name=target_regime_name,
-            )
-        )
-        joint_weights_from_marginals[target_regime_name] = _get_joint_weights_function(
-            transitions=bundle,
-            stochastic_transition_names=stochastic_transition_names,
-            regime_name=target_regime_name,
-        )
-        V_arr_name = "next_V_arr"
-        next_V_interpolator = get_V_interpolator(
-            v_interpolation_info=regime_to_v_interpolation_info[target_regime_name],
-            state_prefix="next_",
-            V_arr_name=V_arr_name,
-            co_map_state_names=co_map_state_names,
-        )
-        # Determine extra kwargs needed by next_V beyond next_states and next_V_arr
-        # (e.g. wealth__points for IrregSpacedGrid with runtime-supplied points).
-        next_V_extra_param_names[target_regime_name] = frozenset(
-            get_union_of_args([next_V_interpolator]) - set(bundle) - {V_arr_name}
-        )
-        stochastic_variables = tuple(
-            key for key in bundle if key in stochastic_transition_names
-        )
-        next_V_has_stochastic_states[target_regime_name] = bool(stochastic_variables)
-        next_V[target_regime_name] = productmap(
-            func=next_V_interpolator,
-            variables=stochastic_variables,
-            batch_sizes=dict.fromkeys(stochastic_variables, 0),
-        )
-
-    # ----------------------------------------------------------------------------------
-    # Create the state-action value and feasibility function
-    # ----------------------------------------------------------------------------------
-
-    _build_H_kwargs = _get_build_H_kwargs(functions)
-    ce, ce_transform_flat_names, ce_inverse_flat_names = resolve_certainty_equivalent(
-        certainty_equivalent
+    compute_E_next_V, continuation_deps = _get_compute_E_next_V(
+        functions=functions,
+        period_targets=period_targets,
+        transitions=transitions,
+        stochastic_transition_names=stochastic_transition_names,
+        compute_regime_transition_probs=compute_regime_transition_probs,
+        regime_to_v_interpolation_info=regime_to_v_interpolation_info,
+        certainty_equivalent=certainty_equivalent,
+        co_map_state_names=co_map_state_names,
     )
-
-    # Co-mapped states are sliced off each `next_V_arr` leaf by the backward-
-    # induction co-map, so their `next_`-prefixed coordinates are not passed to
-    # the interpolator (which no longer indexes those axes).
-    _co_map_next_names = frozenset(f"next_{name}" for name in co_map_state_names)
+    _build_H_kwargs = _get_build_H_kwargs(functions)
 
     arg_names_of_Q_and_F = _get_arg_names_of_Q_and_F(
-        deps=[
-            U_and_F,
-            compute_regime_transition_probs,
-            *list(state_transitions.values()),
-            *list(next_stochastic_states_weights.values()),
-        ],
+        deps=[U_and_F, *continuation_deps],
         include=frozenset({"next_regime_to_V_arr", "period", "age"} | flat_param_names),
         exclude=frozenset(),
     )
@@ -167,72 +109,12 @@ def get_Q_and_F(
             A tuple containing the arrays with state-action values and feasibilities.
 
         """
-        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (
-            compute_regime_transition_probs(**states_actions_params)
-        )
         U_arr, F_arr = U_and_F(**states_actions_params)
-        active_regime_probs = MappingProxyType(
-            {r: regime_transition_probs[r] for r in period_targets}
+        E_next_V, _ = compute_E_next_V(
+            next_regime_to_V_arr=next_regime_to_V_arr,
+            zero=jnp.zeros_like(U_arr),
+            states_actions_params=states_actions_params,
         )
-
-        E_next_V = jnp.zeros_like(U_arr)
-        for target_regime_name in period_targets:
-            next_states = state_transitions[target_regime_name](
-                **states_actions_params,
-            )
-            marginal_next_stochastic_states_weights = next_stochastic_states_weights[
-                target_regime_name
-            ](**states_actions_params)
-            joint_next_stochastic_states_weights = joint_weights_from_marginals[
-                target_regime_name
-            ](**marginal_next_stochastic_states_weights)
-
-            # As we productmap'd the value function over the stochastic variables, the
-            # resulting next value function gets a new dimension for each stochastic
-            # variable.
-            extra_kw = {
-                k: states_actions_params[k]
-                for k in next_V_extra_param_names[target_regime_name]
-            }
-            next_V_at_stochastic_states_arr = next_V[target_regime_name](
-                **{
-                    name: val
-                    for name, val in next_states.items()
-                    if name not in _co_map_next_names
-                },
-                next_V_arr=next_regime_to_V_arr[target_regime_name],
-                **extra_kw,
-            )
-            if ce is not None:
-                next_V_at_stochastic_states_arr = ce.transform(
-                    value=next_V_at_stochastic_states_arr,
-                    **{
-                        arg: states_actions_params[flat_name]
-                        for arg, flat_name in ce_transform_flat_names.items()
-                    },
-                )
-
-            # We then take the weighted average of the next value function at the
-            # stochastic states to get the expected next value function.
-            if next_V_has_stochastic_states[target_regime_name]:
-                next_V_expected_arr = jnp.average(
-                    next_V_at_stochastic_states_arr,
-                    weights=joint_next_stochastic_states_weights,
-                )
-            else:
-                next_V_expected_arr = jnp.average(next_V_at_stochastic_states_arr)
-            E_next_V = (
-                E_next_V + active_regime_probs[target_regime_name] * next_V_expected_arr
-            )
-
-        if ce is not None:
-            E_next_V = ce.inverse(
-                value=E_next_V,
-                **{
-                    arg: states_actions_params[flat_name]
-                    for arg, flat_name in ce_inverse_flat_names.items()
-                },
-            )
 
         Q_arr = functions["H"](
             utility=U_arr,
@@ -289,63 +171,19 @@ def get_compute_intermediates(
 
     """
     U_and_F = _get_U_and_F(functions=functions, constraints=constraints)
-    state_transitions = {}
-    next_stochastic_states_weights = {}
-    joint_weights_from_marginals = {}
-    next_V = {}
-
-    next_V_extra_param_names: dict[RegimeName, frozenset[str]] = {}
-    next_V_has_stochastic_states: dict[RegimeName, bool] = {}
-
-    for target_regime_name in period_targets:
-        bundle = transitions.get(target_regime_name, MappingProxyType({}))
-        state_transitions[target_regime_name] = get_next_state_function_for_solution(
-            functions=functions,
-            transitions=bundle,
-        )
-        next_stochastic_states_weights[target_regime_name] = (
-            get_next_stochastic_weights_function(
-                functions=functions,
-                transitions=bundle,
-                stochastic_transition_names=stochastic_transition_names,
-                regime_name=target_regime_name,
-            )
-        )
-        joint_weights_from_marginals[target_regime_name] = _get_joint_weights_function(
-            transitions=bundle,
-            stochastic_transition_names=stochastic_transition_names,
-            regime_name=target_regime_name,
-        )
-        V_arr_name = "next_V_arr"
-        next_V_interpolator = get_V_interpolator(
-            v_interpolation_info=regime_to_v_interpolation_info[target_regime_name],
-            state_prefix="next_",
-            V_arr_name=V_arr_name,
-        )
-        next_V_extra_param_names[target_regime_name] = frozenset(
-            get_union_of_args([next_V_interpolator]) - set(bundle) - {V_arr_name}
-        )
-        stochastic_variables = tuple(
-            key for key in bundle if key in stochastic_transition_names
-        )
-        next_V_has_stochastic_states[target_regime_name] = bool(stochastic_variables)
-        next_V[target_regime_name] = productmap(
-            func=next_V_interpolator,
-            variables=stochastic_variables,
-            batch_sizes=dict.fromkeys(stochastic_variables, 0),
-        )
-
-    ce, ce_transform_flat_names, ce_inverse_flat_names = resolve_certainty_equivalent(
-        certainty_equivalent
+    compute_E_next_V, continuation_deps = _get_compute_E_next_V(
+        functions=functions,
+        period_targets=period_targets,
+        transitions=transitions,
+        stochastic_transition_names=stochastic_transition_names,
+        compute_regime_transition_probs=compute_regime_transition_probs,
+        regime_to_v_interpolation_info=regime_to_v_interpolation_info,
+        certainty_equivalent=certainty_equivalent,
     )
+    _build_H_kwargs = _get_build_H_kwargs(functions)
 
     arg_names_of_compute_intermediates = _get_arg_names_of_Q_and_F(
-        deps=[
-            U_and_F,
-            compute_regime_transition_probs,
-            *list(state_transitions.values()),
-            *list(next_stochastic_states_weights.values()),
-        ],
+        deps=[U_and_F, *continuation_deps],
         include=frozenset({"next_regime_to_V_arr", "period", "age"} | flat_param_names),
         exclude=frozenset(),
     )
@@ -364,60 +202,17 @@ def get_compute_intermediates(
         FloatND, FloatND, FloatND, FloatND, MappingProxyType[RegimeName, FloatND]
     ]:
         """Compute all Q_and_F intermediates."""
-        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (
-            compute_regime_transition_probs(**states_actions_params)
-        )
         U_arr, F_arr = U_and_F(**states_actions_params)
-        active_regime_probs = MappingProxyType(
-            {r: regime_transition_probs[r] for r in period_targets}
+        E_next_V, active_regime_probs = compute_E_next_V(
+            next_regime_to_V_arr=next_regime_to_V_arr,
+            zero=jnp.zeros_like(U_arr),
+            states_actions_params=states_actions_params,
         )
-
-        E_next_V = jnp.zeros_like(U_arr)
-        for target_regime_name in period_targets:
-            next_states = state_transitions[target_regime_name](
-                **states_actions_params,
-            )
-            marginal = next_stochastic_states_weights[target_regime_name](
-                **states_actions_params,
-            )
-            joint = joint_weights_from_marginals[target_regime_name](**marginal)
-            extra_kw = {
-                k: states_actions_params[k]
-                for k in next_V_extra_param_names[target_regime_name]
-            }
-            next_V_stoch = next_V[target_regime_name](
-                **next_states,
-                next_V_arr=next_regime_to_V_arr[target_regime_name],
-                **extra_kw,
-            )
-            if ce is not None:
-                next_V_stoch = ce.transform(
-                    value=next_V_stoch,
-                    **{
-                        arg: states_actions_params[flat_name]
-                        for arg, flat_name in ce_transform_flat_names.items()
-                    },
-                )
-            contribution = (
-                jnp.average(next_V_stoch, weights=joint)
-                if next_V_has_stochastic_states[target_regime_name]
-                else jnp.average(next_V_stoch)
-            )
-            E_next_V = E_next_V + active_regime_probs[target_regime_name] * contribution
-
-        if ce is not None:
-            E_next_V = ce.inverse(
-                value=E_next_V,
-                **{
-                    arg: states_actions_params[flat_name]
-                    for arg, flat_name in ce_inverse_flat_names.items()
-                },
-            )
 
         Q_arr = functions["H"](
             utility=U_arr,
             E_next_V=E_next_V,
-            **_get_build_H_kwargs(functions)(states_actions_params),
+            **_build_H_kwargs(states_actions_params),
         )
 
         return U_arr, F_arr, E_next_V, Q_arr, active_regime_probs
@@ -480,6 +275,252 @@ def get_Q_and_F_terminal(
         return jnp.asarray(U_arr), jnp.asarray(F_arr)
 
     return Q_and_F
+
+
+def _get_compute_E_next_V(
+    *,
+    functions: EconFunctionsMapping,
+    period_targets: tuple[RegimeName, ...],
+    transitions: TransitionFunctionsMapping,
+    stochastic_transition_names: frozenset[TransitionFunctionName],
+    compute_regime_transition_probs: RegimeTransitionFunction,
+    regime_to_v_interpolation_info: MappingProxyType[RegimeName, VInterpolationInfo],
+    certainty_equivalent: CertaintyEquivalent | None,
+    co_map_state_names: tuple[StateName, ...] = (),
+) -> tuple[
+    Callable[..., tuple[FloatND, MappingProxyType[RegimeName, FloatND]]],
+    tuple[Callable[..., Any], ...],
+]:
+    """Build the closure that aggregates next period's value into `E[V']`.
+
+    The single continuation-aggregation site of the engine: both the Bellman
+    `Q` and the NaN diagnostics call the closure this returns, so they cannot
+    disagree. The continuation is a lottery over the stochastic nodes of every
+    reachable target regime, weighted by that target's regime-transition
+    probability:
+
+    - Without a certainty equivalent, it is aggregated as the linear
+      expectation `Σ_r p_r · E_w[V'_r]`.
+    - With one, the whole joint lottery is handed to
+      `CertaintyEquivalent.aggregate` in one piece, which applies the
+      transform before every expectation and inverts exactly once. Flattening
+      before aggregating is what lets `PowerMean` anchor the transform, which
+      a per-target `transform -> reduce -> inverse` decomposition cannot.
+
+    Args:
+        functions: Immutable mapping of function names to internal user functions.
+        period_targets: Graph targets whose continuation enters E[V] this period.
+        transitions: Immutable mapping of transition names to transition functions.
+        stochastic_transition_names: Frozenset of stochastic transition function names.
+        compute_regime_transition_probs: Regime transition probability function
+            for solve.
+        regime_to_v_interpolation_info: Immutable mapping of regime names to
+            V-interpolation info.
+        certainty_equivalent: Nonlinear certainty equivalent declared by the
+            regime, or `None` for the linear expectation.
+        co_map_state_names: Tuple of state names co-mapped with the continuation V.
+
+    Returns:
+        Tuple of the closure returning `(E_next_V, active_regime_probs)` and the
+        dependencies whose arguments must enter the calling closure's signature.
+
+    """
+    state_transitions = {}
+    next_stochastic_states_weights = {}
+    joint_weights_from_marginals = {}
+    next_V = {}
+
+    next_V_extra_param_names: dict[RegimeName, frozenset[str]] = {}
+    next_V_has_stochastic_states: dict[RegimeName, bool] = {}
+
+    for target_regime_name in period_targets:
+        # Transitions from the current regime to the target regime
+        bundle = transitions.get(target_regime_name, MappingProxyType({}))
+
+        # Functions required to calculate the expected continuation values
+        state_transitions[target_regime_name] = get_next_state_function_for_solution(
+            functions=functions,
+            transitions=bundle,
+        )
+        next_stochastic_states_weights[target_regime_name] = (
+            get_next_stochastic_weights_function(
+                functions=functions,
+                transitions=bundle,
+                stochastic_transition_names=stochastic_transition_names,
+                regime_name=target_regime_name,
+            )
+        )
+        joint_weights_from_marginals[target_regime_name] = _get_joint_weights_function(
+            transitions=bundle,
+            stochastic_transition_names=stochastic_transition_names,
+            regime_name=target_regime_name,
+        )
+        V_arr_name = "next_V_arr"
+        next_V_interpolator = get_V_interpolator(
+            v_interpolation_info=regime_to_v_interpolation_info[target_regime_name],
+            state_prefix="next_",
+            V_arr_name=V_arr_name,
+            co_map_state_names=co_map_state_names,
+        )
+        # Determine extra kwargs needed by next_V beyond next_states and next_V_arr
+        # (e.g. wealth__points for IrregSpacedGrid with runtime-supplied points).
+        next_V_extra_param_names[target_regime_name] = frozenset(
+            get_union_of_args([next_V_interpolator]) - set(bundle) - {V_arr_name}
+        )
+        stochastic_variables = tuple(
+            key for key in bundle if key in stochastic_transition_names
+        )
+        next_V_has_stochastic_states[target_regime_name] = bool(stochastic_variables)
+        next_V[target_regime_name] = productmap(
+            func=next_V_interpolator,
+            variables=stochastic_variables,
+            batch_sizes=dict.fromkeys(stochastic_variables, 0),
+        )
+
+    ce, ce_flat_param_names = resolve_certainty_equivalent(certainty_equivalent)
+
+    # Co-mapped states are sliced off each `next_V_arr` leaf by the backward-
+    # induction co-map, so their `next_`-prefixed coordinates are not passed to
+    # the interpolator (which no longer indexes those axes).
+    co_map_next_names = frozenset(f"next_{name}" for name in co_map_state_names)
+
+    def compute_E_next_V(
+        *,
+        next_regime_to_V_arr: MappingProxyType[RegimeName, FloatND],
+        zero: FloatND,
+        states_actions_params: Mapping[str, _ParamsLeaf],
+    ) -> tuple[FloatND, MappingProxyType[RegimeName, FloatND]]:
+        """Aggregate the continuation lottery into `E[V']` at one state-action point.
+
+        Args:
+            next_regime_to_V_arr: Immutable mapping of target regime names to
+                next period's value function arrays.
+            zero: Zero at the shape and dtype of the value being built up.
+            states_actions_params: Mapping of states, actions, age, period, and
+                flat regime params.
+
+        Returns:
+            Tuple of the aggregated continuation value and the regime transition
+            probabilities of the reachable targets.
+
+        """
+        regime_transition_probs: MappingProxyType[RegimeName, FloatND] = (
+            compute_regime_transition_probs(**states_actions_params)
+        )
+        active_regime_probs = MappingProxyType(
+            {r: regime_transition_probs[r] for r in period_targets}
+        )
+
+        E_next_V = zero
+        lottery_values: list[FloatND] = []
+        lottery_weights: list[FloatND] = []
+        for target_regime_name in period_targets:
+            next_states = state_transitions[target_regime_name](
+                **states_actions_params,
+            )
+            marginal_next_stochastic_states_weights = next_stochastic_states_weights[
+                target_regime_name
+            ](**states_actions_params)
+            joint_next_stochastic_states_weights = joint_weights_from_marginals[
+                target_regime_name
+            ](**marginal_next_stochastic_states_weights)
+
+            # As we productmap'd the value function over the stochastic variables, the
+            # resulting next value function gets a new dimension for each stochastic
+            # variable.
+            extra_kw = {
+                k: states_actions_params[k]
+                for k in next_V_extra_param_names[target_regime_name]
+            }
+            next_V_at_stochastic_states_arr = next_V[target_regime_name](
+                **{
+                    name: val
+                    for name, val in next_states.items()
+                    if name not in co_map_next_names
+                },
+                next_V_arr=next_regime_to_V_arr[target_regime_name],
+                **extra_kw,
+            )
+
+            if ce is None:
+                # We then take the weighted average of the next value function at the
+                # stochastic states to get the expected next value function.
+                if next_V_has_stochastic_states[target_regime_name]:
+                    next_V_expected_arr = jnp.average(
+                        next_V_at_stochastic_states_arr,
+                        weights=joint_next_stochastic_states_weights,
+                    )
+                else:
+                    next_V_expected_arr = jnp.average(next_V_at_stochastic_states_arr)
+                E_next_V = (
+                    E_next_V
+                    + active_regime_probs[target_regime_name] * next_V_expected_arr
+                )
+            else:
+                values, node_weights = _as_lottery(
+                    values=next_V_at_stochastic_states_arr,
+                    weights=joint_next_stochastic_states_weights,
+                    has_stochastic_states=next_V_has_stochastic_states[
+                        target_regime_name
+                    ],
+                )
+                lottery_values.append(values)
+                lottery_weights.append(
+                    active_regime_probs[target_regime_name] * node_weights
+                )
+
+        if ce is not None and lottery_values:
+            E_next_V = ce.aggregate(
+                values=jnp.concatenate(lottery_values),
+                weights=jnp.concatenate(lottery_weights),
+                # The params template types every certainty-equivalent
+                # parameter as a float, so its runtime values are float arrays.
+                params=cast(
+                    "Mapping[str, FloatND]",
+                    {
+                        arg: states_actions_params[flat_name]
+                        for arg, flat_name in ce_flat_param_names.items()
+                    },
+                ),
+            )
+
+        return E_next_V, active_regime_probs
+
+    deps = (
+        compute_regime_transition_probs,
+        *state_transitions.values(),
+        *next_stochastic_states_weights.values(),
+    )
+    return compute_E_next_V, deps
+
+
+def _as_lottery(
+    *,
+    values: FloatND,
+    weights: FloatND,
+    has_stochastic_states: bool,
+) -> tuple[Float1D, Float1D]:
+    """Flatten one target regime's continuation into a unit-mass lottery.
+
+    Args:
+        values: Next period's value at this target's stochastic nodes.
+        weights: Joint weights over those nodes; ignored when the target has
+            no stochastic states.
+        has_stochastic_states: Whether the target's transition draws stochastic
+            states.
+
+    Returns:
+        Tuple of the flattened values and their probabilities, which sum to one.
+
+    """
+    flat_values = jnp.ravel(values)
+    if has_stochastic_states:
+        flat_weights = jnp.ravel(weights)
+        return flat_values, flat_weights / jnp.sum(flat_weights)
+    uniform = jnp.full(
+        flat_values.shape, 1.0 / flat_values.size, dtype=flat_values.dtype
+    )
+    return flat_values, uniform
 
 
 def _get_arg_names_of_Q_and_F(

--- a/src/_lcm/regime_building/age_normalization.py
+++ b/src/_lcm/regime_building/age_normalization.py
@@ -36,15 +36,18 @@ from jax import numpy as jnp
 
 from _lcm.grids.continuous import ContinuousGrid
 from _lcm.processes.base import _ContinuousStochasticProcess
+from _lcm.reachability import PhaseReachability
 from _lcm.regime_building.age_specialization import (
     INVARIANT,
     _describe_trait_mismatch,
     _grid_traits,
     _GridTraits,
     _GridTraitsError,
+    _tree_signature,
 )
 from _lcm.regime_building.finalize import FinalizedUserRegime
 from _lcm.regime_building.phases import PhasedRegimeSpec, RegimePhaseSpec
+from _lcm.regime_building.V import VInterpolationInfo
 from _lcm.typing import EconFunction, RegimeName, StateName
 from lcm.ages import AgeGrid
 from lcm.exceptions import RegimeInitializationError
@@ -203,15 +206,9 @@ def periodized_tree_signature(tree: Mapping[str, object], period: int) -> Hashab
     periodized node nested under one key cannot collide with one under another.
     Mirrors the structure of pylcm's nested transition trees.
     """
-    pairs: list[tuple[str, Hashable]] = []
-    for key in sorted(tree):
-        value = tree[key]
-        if isinstance(value, Mapping):
-            nested = cast("Mapping[str, object]", value)
-            pairs.append((key, periodized_tree_signature(nested, period)))
-        else:
-            pairs.append((key, periodized_node_signature(value, period)))
-    return tuple(pairs)
+    return _tree_signature(
+        tree, leaf_signature=lambda node: periodized_node_signature(node, period)
+    )
 
 
 def continuation_grid_signature_from_schedule(
@@ -317,6 +314,75 @@ def expand_groups_to_periods(
         for period in periods:
             result[period] = built_by_group[group_key]
     return MappingProxyType(result)
+
+
+def continuation_group_key(
+    *,
+    phase_reachability: PhaseReachability,
+    source_regime_name: RegimeName,
+    functions: Mapping[str, object],
+    constraints: Mapping[str, object],
+    grid_schedule: AgeGridSchedule | None,
+) -> Callable[[int], tuple[tuple[RegimeName, ...], Hashable]]:
+    """Build the per-period grouping key shared by Q_and_F construction and diagnostics.
+
+    Groups by (target configuration, per-period policy signature,
+    continuation-grid signature): with no age-specialized node the policy
+    signature is constant and the grouping collapses to the target
+    configuration alone.
+    """
+
+    def group_key(period: int) -> tuple[tuple[RegimeName, ...], Hashable]:
+        complete = (
+            ()
+            if period == phase_reachability.n_periods - 1
+            else phase_reachability.targets(period=period, source=source_regime_name)
+        )
+        continuation_sig = continuation_grid_signature_from_schedule(
+            grid_schedule=grid_schedule,
+            target_period=period + 1,
+            target_regimes=complete,
+        )
+        signature = (
+            periodized_tree_signature(functions, period),
+            periodized_tree_signature(constraints, period),
+            continuation_sig,
+        )
+        return (complete, signature)
+
+    return group_key
+
+
+def continuation_info_lookup(
+    *,
+    period_to_regime_v_interp: (
+        Mapping[int, MappingProxyType[RegimeName, VInterpolationInfo]] | None
+    ),
+    regime_to_v_interpolation_info: MappingProxyType[RegimeName, VInterpolationInfo],
+) -> Callable[[int], MappingProxyType[RegimeName, VInterpolationInfo]]:
+    """Build the per-period continuation-info lookup shared by solve and diagnostics.
+
+    Uses each target's grid at period `t+1` where age-specialized (from the
+    schedule-built per-period map), falling back to its representative grid
+    otherwise.
+    """
+
+    def continuation_info(
+        period: int,
+    ) -> MappingProxyType[RegimeName, VInterpolationInfo]:
+        if period_to_regime_v_interp is None:
+            return regime_to_v_interpolation_info
+        per_period = period_to_regime_v_interp.get(
+            period + 1, cast("MappingProxyType[RegimeName, VInterpolationInfo]", {})
+        )
+        return MappingProxyType(
+            {
+                regime_name: per_period.get(regime_name, info)
+                for regime_name, info in regime_to_v_interpolation_info.items()
+            }
+        )
+
+    return continuation_info
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/src/_lcm/regime_building/age_normalization.py
+++ b/src/_lcm/regime_building/age_normalization.py
@@ -643,6 +643,7 @@ def normalize_age_specialization(
     user_regimes: Mapping[RegimeName, FinalizedUserRegime],
     phased_specs: Mapping[RegimeName, PhasedRegimeSpec],
     ages: AgeGrid,
+    active_periods_by_regime: Mapping[RegimeName, tuple[int, ...]],
 ) -> AgeNormalizationResult:
     """Resolve every age-specialized marker into concrete model-creation objects.
 
@@ -680,7 +681,7 @@ def normalize_age_specialization(
             rewritten_specs[regime_name] = spec
             continue
 
-        active_periods = ages.get_periods_where(user_regime.active)
+        active_periods = active_periods_by_regime[regime_name]
         if not active_periods:
             msg = (
                 f"Regime '{regime_name}' declares age-specialized objects but is "

--- a/src/_lcm/regime_building/age_specialization.py
+++ b/src/_lcm/regime_building/age_specialization.py
@@ -12,7 +12,7 @@ lazily; this module also hosts the grid shape-invariance traits (`_grid_traits` 
 `_GridTraits`) that the normalizer reuses to validate `AgeSpecializedGrid` families.
 """
 
-from collections.abc import Hashable, Mapping
+from collections.abc import Callable, Hashable, Mapping
 from dataclasses import dataclass
 from typing import Any, Final, cast
 
@@ -52,8 +52,12 @@ def node_signature(node: object, age: float) -> Hashable:
     return INVARIANT
 
 
-def tree_signature(tree: Mapping[str, object], age: float) -> Hashable:
-    """Fingerprint a (possibly nested) mapping of nodes at `age`.
+def _tree_signature(
+    tree: Mapping[str, object],
+    *,
+    leaf_signature: Callable[[object], Hashable],
+) -> Hashable:
+    """Fingerprint a (possibly nested) mapping of nodes via `leaf_signature`.
 
     Recurse into `Mapping` values and emit sorted `(path, signature)` pairs, so a
     marked node nested under one key cannot collide with one under another.
@@ -61,12 +65,24 @@ def tree_signature(tree: Mapping[str, object], age: float) -> Hashable:
     pairs: list[tuple[str, Hashable]] = []
     for key in sorted(tree):
         value = tree[key]
-        if isinstance(value, Mapping):
-            nested = cast("Mapping[str, object]", value)
-            pairs.append((key, tree_signature(nested, age)))
-        else:
-            pairs.append((key, node_signature(value, age)))
+        signature = (
+            _tree_signature(
+                cast("Mapping[str, object]", value), leaf_signature=leaf_signature
+            )
+            if isinstance(value, Mapping)
+            else leaf_signature(value)
+        )
+        pairs.append((key, signature))
     return tuple(pairs)
+
+
+def tree_signature(tree: Mapping[str, object], age: float) -> Hashable:
+    """Fingerprint a (possibly nested) mapping of nodes at `age`.
+
+    Recurse into `Mapping` values and emit sorted `(path, signature)` pairs, so a
+    marked node nested under one key cannot collide with one under another.
+    """
+    return _tree_signature(tree, leaf_signature=lambda node: node_signature(node, age))
 
 
 class _GridTraitsError(Exception):

--- a/src/_lcm/regime_building/broadcast.py
+++ b/src/_lcm/regime_building/broadcast.py
@@ -140,6 +140,7 @@ def prune_broadcast_variables(
     user_regimes: Mapping[RegimeName, UserRegime],
     broadcast_variables: Mapping[RegimeName, frozenset[StateOrActionName]],
     ages: AgeGrid | None = None,
+    active_periods_by_regime: Mapping[RegimeName, tuple[int, ...]] | None = None,
 ) -> tuple[
     MappingProxyType[RegimeName, UserRegime],
     MappingProxyType[RegimeName, frozenset[StateOrActionName]],
@@ -154,8 +155,13 @@ def prune_broadcast_variables(
     Args:
         user_regimes: Mapping of regime names to merged `Regime` instances.
         broadcast_variables: Per regime, the broadcast state/action names.
-        ages: The model's `AgeGrid`, used to resolve `AgeSpecializedFunction`
-            markers to a representative age before DAG-reachability walks so a
+        ages: The model's `AgeGrid`, used to convert a representative period
+            to an age before resolving `AgeSpecializedFunction` markers.
+            `None` skips resolution (no marker can appear then).
+        active_periods_by_regime: The canonical per-regime activity mapping
+            (from `compute_active_periods_by_regime`), used to pick each
+            regime's representative active period before resolving
+            `AgeSpecializedFunction` markers to a representative age so a
             broadcast variable read only through a marker is not misread as
             unused. `None` skips resolution (no marker can appear then).
 
@@ -189,6 +195,7 @@ def prune_broadcast_variables(
             phase_name=phase_name,
             all_regime_names=all_regime_names,
             ages=ages,
+            active_periods_by_regime=active_periods_by_regime,
         )
 
     pruned_regimes: dict[RegimeName, UserRegime] = {}
@@ -238,6 +245,7 @@ def _phase_fixed_point(
     phase_name: PhaseName,
     all_regime_names: frozenset[RegimeName],
     ages: AgeGrid | None,
+    active_periods_by_regime: Mapping[RegimeName, tuple[int, ...]] | None,
 ) -> dict[RegimeName, frozenset[StateOrActionName]]:
     """Grow the kept-sets to this phase slice's least fixed point.
 
@@ -271,6 +279,11 @@ def _phase_fixed_point(
                 candidate_targets=candidates_by_source[regime_name],
                 kept=grown,
                 ages=ages,
+                active_periods=(
+                    None
+                    if active_periods_by_regime is None
+                    else active_periods_by_regime.get(regime_name, ())
+                ),
             )
             newly_kept = candidates & needed
             if newly_kept:
@@ -283,22 +296,23 @@ def _phase_fixed_point(
 def _resolved_at_representative_age(
     mapping: Mapping[str, UserFunction],
     *,
-    user_regime: UserRegime,
     ages: AgeGrid | None,
+    active_periods: tuple[int, ...] | None,
 ) -> Mapping[str, UserFunction]:
     """Resolve `AgeSpecializedFunction` markers in `mapping` at a representative age.
 
     The dependency structure `get_ancestors` needs is age-invariant, so any active
-    age serves. Returns `mapping` unchanged when `ages` is `None` (no marker can
-    appear then) or the regime has no active period (it is about to fail with a
+    period serves. Returns `mapping` unchanged when `ages` is `None` (no marker can
+    appear then) or `active_periods` is empty (the regime is about to fail with a
     more specific error once age normalization runs).
     """
-    if ages is None or not any(
-        isinstance(value, AgeSpecializedFunction) for value in mapping.values()
+    if (
+        ages is None
+        or not active_periods
+        or not any(
+            isinstance(value, AgeSpecializedFunction) for value in mapping.values()
+        )
     ):
-        return mapping
-    active_periods = ages.get_periods_where(user_regime.active)
-    if not active_periods:
         return mapping
     representative_age = float(ages.period_to_age(active_periods[0]))
     return {
@@ -314,6 +328,7 @@ def _needed_names(
     candidate_targets: frozenset[RegimeName],
     kept: Mapping[RegimeName, frozenset[StateOrActionName]],
     ages: AgeGrid | None,
+    active_periods: tuple[int, ...] | None,
 ) -> set[str]:
     """Collect every name this phase slice's root computations read.
 
@@ -325,15 +340,15 @@ def _needed_names(
     - the regime transition (coarse inputs, or every granular cell)
     - the laws of motion toward candidate targets that keep the law's state
 
-    `functions`/`constraints` are resolved at a representative active age before
+    `functions`/`constraints` are resolved at a representative active period before
     the DAG walk, so `get_ancestors` sees a marked node's real argument names
     instead of `AgeSpecializedFunction.__call__`'s generic `(*args, **kwargs)`.
     """
     functions = _resolved_at_representative_age(
-        phase_slice.functions, user_regime=user_regime, ages=ages
+        phase_slice.functions, ages=ages, active_periods=active_periods
     )
     constraints = _resolved_at_representative_age(
-        phase_slice.constraints, user_regime=user_regime, ages=ages
+        phase_slice.constraints, ages=ages, active_periods=active_periods
     )
 
     pool: dict[str, UserFunction] = dict(functions)

--- a/src/_lcm/regime_building/diagnostics.py
+++ b/src/_lcm/regime_building/diagnostics.py
@@ -22,10 +22,10 @@ from _lcm.grids import Grid
 from _lcm.reachability import PhaseReachability
 from _lcm.regime_building.age_normalization import (
     AgeGridSchedule,
-    continuation_grid_signature_from_schedule,
+    continuation_group_key,
+    continuation_info_lookup,
     expand_groups_to_periods,
     group_periods_by_key,
-    periodized_tree_signature,
     resolve_periodized_nodes,
 )
 from _lcm.regime_building.Q_and_F import get_compute_intermediates
@@ -105,47 +105,21 @@ def _build_compute_intermediates_per_period(
         if name in state_action_space.state_names
     }
 
-    def continuation_info(
-        period: int,
-    ) -> MappingProxyType[RegimeName, VInterpolationInfo]:
-        """All-regime interpolation info for period `t`'s continuation V_{t+1}.
-
-        Mirrors `_build_Q_and_F_per_period.continuation_info` so a NaN diagnostic
-        recomputes intermediates on the *same* period-specific target grid the primary
-        solve used, not the representative grid.
-        """
-        if period_to_regime_v_interp is None:
-            return regime_to_v_interpolation_info
-        per_period = period_to_regime_v_interp.get(
-            period + 1, cast("MappingProxyType[RegimeName, VInterpolationInfo]", {})
-        )
-        return MappingProxyType(
-            {
-                regime_name: per_period.get(regime_name, info)
-                for regime_name, info in regime_to_v_interpolation_info.items()
-            }
-        )
-
-    # Group by (target configuration, per-period policy signature, continuation-grid
-    # signature), mirroring `_build_Q_and_F_per_period`: with no age-specialized node
-    # the signature is constant and the grouping collapses to the target configuration.
-    def group_key(period: int) -> tuple[tuple[RegimeName, ...], Hashable]:
-        complete = (
-            ()
-            if period == phase_reachability.n_periods - 1
-            else phase_reachability.targets(period=period, source=source_regime_name)
-        )
-        cont_sig = continuation_grid_signature_from_schedule(
-            grid_schedule=grid_schedule,
-            target_period=period + 1,
-            target_regimes=complete,
-        )
-        signature = (
-            periodized_tree_signature(functions, period),
-            periodized_tree_signature(constraints, period),
-            cont_sig,
-        )
-        return (complete, signature)
+    # `continuation_info` mirrors `_build_Q_and_F_per_period.continuation_info` so a
+    # NaN diagnostic recomputes intermediates on the *same* period-specific target
+    # grid the primary solve used, not the representative grid. `group_key` mirrors
+    # `_build_Q_and_F_per_period.group_key`'s grouping.
+    continuation_info = continuation_info_lookup(
+        period_to_regime_v_interp=period_to_regime_v_interp,
+        regime_to_v_interpolation_info=regime_to_v_interpolation_info,
+    )
+    group_key = continuation_group_key(
+        phase_reachability=phase_reachability,
+        source_regime_name=source_regime_name,
+        functions=functions,
+        constraints=constraints,
+        grid_schedule=grid_schedule,
+    )
 
     configs = group_periods_by_key(active_periods, group_key)
 

--- a/src/_lcm/regime_building/processing.py
+++ b/src/_lcm/regime_building/processing.py
@@ -9,7 +9,7 @@ from typing import Any, Literal, cast
 import jax
 from dags import concatenate_functions, get_annotations, with_signature
 from dags.signature import rename_arguments
-from dags.tree import QNAME_DELIMITER, qname_from_tree_path, tree_path_from_qname
+from dags.tree import qname_from_tree_path, tree_path_from_qname
 from jax import numpy as jnp
 
 from _lcm.certainty_equivalent import CertaintyEquivalent
@@ -588,6 +588,8 @@ def _build_solution_phase(
         all_grids=all_grids,
         regime_params_template=regime_params_template,
         variables=variables,
+        phase_reachability=phase_reachability,
+        source_regime_name=regime_name,
     )
 
     flat_param_names = _engine_flat_param_names(
@@ -834,6 +836,8 @@ def _build_simulation_phase(
         all_grids=all_grids,
         regime_params_template=regime_params_template,
         variables=variables,
+        phase_reachability=simulation_reachability,
+        source_regime_name=regime_name,
     )
     functions = core.functions
     constraints = core.constraints
@@ -1025,6 +1029,8 @@ def _process_regime_core(
     all_grids: MappingProxyType[RegimeName, MappingProxyType[StateOrActionName, Grid]],
     regime_params_template: RegimeParamsTemplate,
     variables: Variables,
+    phase_reachability: PhaseReachability,
+    source_regime_name: RegimeName,
 ) -> _CoreResult:
     """Process one phase's regime functions and transitions.
 
@@ -1042,6 +1048,10 @@ def _process_regime_core(
         all_grids: Immutable mapping of regime names to Grid spec objects.
         regime_params_template: The regime's parameter template.
         variables: States and actions of the regime with kind/topology/process tags.
+        phase_reachability: This phase's static regime graph, the sole source
+            of which targets need a continuation built.
+        source_regime_name: This regime's name, used to read its retained
+            targets from `phase_reachability`.
 
     Returns:
         Core processing result with functions, constraints, transitions, stochastic
@@ -1133,21 +1143,20 @@ def _process_regime_core(
         )
 
     # Transitions of continuous stochastic processes bypass the stub pipeline
-    # entirely. Build weight and next functions for carried-to target regimes
-    # from each target's grid. Scope to targets already present in non-process
-    # transitions to avoid spurious entries for unrelated regimes.
+    # entirely. Build weight and next functions for every graph-retained
+    # continuation target's grid. Scope to the phase reachability graph's
+    # retained targets for this source — not to whichever targets happen to
+    # have a non-process law bundle — so a target reached solely by carrying
+    # a shared process state (no other law) still gets its intrinsic
+    # process transition synthesized.
     process_names = variables.process_names
-    carry_targets = {
-        tree_path_from_qname(k)[0]
-        for k in flat_nested_transitions
-        if QNAME_DELIMITER in k
-    }
+    continuation_targets = phase_reachability.union_targets(source=source_regime_name)
     target_process_grids: dict[
         tuple[RegimeName, ProcessName], _ContinuousStochasticProcess
     ] = {
         (user_regime, process): grid
         for user_regime, grids in all_grids.items()
-        if user_regime in carry_targets
+        if user_regime in continuation_targets
         for process in process_names
         if isinstance(grid := grids.get(process), _ContinuousStochasticProcess)
     }

--- a/src/_lcm/regime_building/processing.py
+++ b/src/_lcm/regime_building/processing.py
@@ -167,17 +167,45 @@ def build_period_v_interpolation_info(
     return MappingProxyType(result)
 
 
+def compute_active_periods_by_regime(
+    *,
+    ages: AgeGrid,
+    user_regimes: Mapping[RegimeName, object],
+) -> MappingProxyType[RegimeName, tuple[int, ...]]:
+    """Evaluate every regime's `active` predicate exactly once.
+
+    The single canonical activity schedule for the model: every other
+    subsystem that needs to know which periods a regime is active in
+    (reachability, age specialization, broadcast pruning, model-input
+    validation) consumes this mapping instead of re-evaluating
+    `Regime.active` or calling `AgeGrid.get_periods_where` itself.
+    """
+    return MappingProxyType(
+        {
+            regime_name: tuple(ages.get_periods_where(regime.active))  # ty: ignore[unresolved-attribute]
+            for regime_name, regime in user_regimes.items()
+        }
+    )
+
+
 def prepare_model_structure(
     *,
     user_regimes: Mapping[RegimeName, FinalizedUserRegime],
     ages: AgeGrid,
+    active_periods_by_regime: MappingProxyType[RegimeName, tuple[int, ...]],
 ) -> PreparedModelStructure:
-    """Prepare normalized declarations and static phase graphs once."""
+    """Prepare normalized declarations and static phase graphs once.
+
+    `active_periods_by_regime` must be the single canonical activity
+    mapping from `compute_active_periods_by_regime`, computed once by the
+    caller — this function does not evaluate `Regime.active` itself.
+    """
     raw_phase_specs = normalize_all_regime_phases(user_regimes=user_regimes)
     age_normalization = normalize_age_specialization(
         user_regimes=user_regimes,
         phased_specs=raw_phase_specs,
         ages=ages,
+        active_periods_by_regime=active_periods_by_regime,
     )
     phased_specs = age_normalization.phased_specs
     transitions_by_phase: Mapping[PhaseName, Mapping[RegimeName, object]] = {
@@ -192,11 +220,8 @@ def prepare_model_structure(
     }
     try:
         reachability = build_model_reachability(
-            ages=ages.exact_values,
-            active_by_regime={
-                regime_name: regime.active
-                for regime_name, regime in user_regimes.items()
-            },
+            n_periods=ages.n_periods,
+            active_periods_by_regime=active_periods_by_regime,
             transitions_by_phase=transitions_by_phase,
             terminal_regimes={
                 regime_name
@@ -206,18 +231,6 @@ def prepare_model_structure(
         )
     except ValueError as error:
         raise ModelInitializationError(str(error)) from error
-    active_periods_by_regime = MappingProxyType(
-        {
-            regime_name: tuple(
-                period
-                for period, active_regimes in enumerate(
-                    reachability.solution.active_regimes_by_period
-                )
-                if regime_name in active_regimes
-            )
-            for regime_name in user_regimes
-        }
-    )
     return PreparedModelStructure(
         representative_user_regimes=age_normalization.representative_user_regimes,
         phased_specs=phased_specs,
@@ -256,6 +269,9 @@ def process_regimes(
     prepared_structure = prepared_structure or prepare_model_structure(
         user_regimes=user_regimes,
         ages=ages,
+        active_periods_by_regime=compute_active_periods_by_regime(
+            ages=ages, user_regimes=user_regimes
+        ),
     )
     representative_user_regimes = prepared_structure.representative_user_regimes
     phased_specs = prepared_structure.phased_specs

--- a/src/_lcm/regime_building/processing.py
+++ b/src/_lcm/regime_building/processing.py
@@ -466,13 +466,12 @@ def _state_handoff_errors(
             for target in phase_reachability.targets(period=period, source=source):
                 target_slice = phase_slices[target]
                 for state_name, target_grid in target_slice.grid_states.items():
-                    handoff = _classify_state_handoff(
+                    if _has_valid_state_handoff(
                         source_slice=source_slice,
                         target=target,
                         target_grid=target_grid,
                         state_name=state_name,
-                    )
-                    if handoff is not None:
+                    ):
                         continue
                     status = phase_reachability.edge_status(
                         period=period,
@@ -481,8 +480,9 @@ def _state_handoff_errors(
                     )
                     error_messages.append(
                         f"{phase_name} phase, period {period} "
-                        f"(age {ages.exact_values[period]}), source '{source}' -> "
-                        f"period {period + 1} (age {ages.exact_values[period + 1]}), "
+                        f"(age {_display_age(ages, period)}), source '{source}' -> "
+                        f"period {period + 1} "
+                        f"(age {_display_age(ages, period + 1)}), "
                         f"target '{target}' retains a {status.name} edge. The target "
                         f"declares stochastic process '{state_name}', but the source "
                         f"does not carry '{state_name}' and defines no entry law, so "
@@ -493,36 +493,32 @@ def _state_handoff_errors(
     return error_messages
 
 
-def _classify_state_handoff(
+def _display_age(ages: AgeGrid, period: int) -> float:
+    """Return period's age as a decimal float, never a raw `Fraction`."""
+    return float(ages.exact_values[period])
+
+
+def _has_valid_state_handoff(
     *,
     source_slice: RegimePhaseSpec,
     target: RegimeName,
     target_grid: Grid | AgeSpecializedGrid,
     state_name: StateName,
-) -> Literal["carried", "deterministic", "stochastic", "target_local"] | None:
-    """Classify how one target state obtains its next-period value."""
+) -> bool:
+    """Return whether one target state obtains a valid next-period value.
+
+    Every target state on a retained edge must be supplied by one of: a
+    carried/shared state, a deterministic law, a stochastic law, an explicit
+    entry/reset law, or a legitimate target-local non-process state.
+    """
     if state_name in source_slice.grid_states:
-        return "carried"
+        return True
 
     law = source_slice.state_transitions.get(state_name)
     if law is not None and (not isinstance(law, Mapping) or target in law):
-        selected_law = (
-            cast(
-                "Mapping[RegimeName, UserFunction | MarkovTransition]",
-                law,
-            )[target]
-            if isinstance(law, Mapping)
-            else law
-        )
-        return (
-            "stochastic"
-            if isinstance(selected_law, MarkovTransition)
-            else "deterministic"
-        )
+        return True
 
-    if not isinstance(target_grid, _ContinuousStochasticProcess):
-        return "target_local"
-    return None
+    return not isinstance(target_grid, _ContinuousStochasticProcess)
 
 
 def _build_solution_phase(

--- a/src/_lcm/regime_building/processing.py
+++ b/src/_lcm/regime_building/processing.py
@@ -42,7 +42,8 @@ from _lcm.regime_building.age_normalization import (
     PeriodizedEconFunction,
     PeriodizedUserFunction,
     assert_continuation_grids_agree,
-    continuation_grid_signature_from_schedule,
+    continuation_group_key,
+    continuation_info_lookup,
     expand_groups_to_periods,
     group_periods_by_key,
     normalize_age_specialization,
@@ -2253,9 +2254,8 @@ def _build_Q_and_F_per_period(
 
     When the model has `AgeSpecializedGrid` states, period `t`'s continuation
     `V_{t+1}` is interpolated on the target regimes' grids **at period `t+1`**
-    (`period_to_regime_v_interp`), and the group signature folds in those grids'
-    explicit user signatures (`grid_schedule`, via
-    `continuation_grid_signature_from_schedule`) so periods with different
+    (`period_to_regime_v_interp`), and `continuation_group_key` folds in those
+    grids' explicit user signatures (`grid_schedule`) so periods with different
     continuation grids do not false-share a compiled `Q_and_F`. With no
     age-specialized objects the grouping collapses to the target configuration
     exactly as an age-invariant model.
@@ -2282,46 +2282,22 @@ def _build_Q_and_F_per_period(
 
     """
 
-    def continuation_info(
-        period: int,
-    ) -> MappingProxyType[RegimeName, VInterpolationInfo]:
-        """All-regime interpolation info for period `t`'s continuation V_{t+1}.
-
-        Uses each target's grid at period `t+1` where age-specialized (from the
-        schedule-built per-period map), falling back to its representative grid
-        otherwise. The last period's continuation is the zero template.
-        """
-        if period_to_regime_v_interp is None:
-            return regime_to_v_interpolation_info
-        per_period = period_to_regime_v_interp.get(
-            period + 1, cast("MappingProxyType[RegimeName, VInterpolationInfo]", {})
-        )
-        return MappingProxyType(
-            {
-                regime_name: per_period.get(regime_name, info)
-                for regime_name, info in regime_to_v_interpolation_info.items()
-            }
-        )
-
-    def group_key(period: int) -> tuple[tuple[RegimeName, ...], Hashable]:
-        complete = (
-            ()
-            if period == phase_reachability.n_periods - 1
-            else phase_reachability.targets(period=period, source=source_regime_name)
-        )
-        # The explicit user grid signatures of the continuation targets at t+1 —
-        # periods with different continuation grids get distinct kernels.
-        continuation_sig = continuation_grid_signature_from_schedule(
-            grid_schedule=grid_schedule,
-            target_period=period + 1,
-            target_regimes=complete,
-        )
-        signature = (
-            periodized_tree_signature(functions, period),
-            periodized_tree_signature(constraints, period),
-            continuation_sig,
-        )
-        return (complete, signature)
+    # `continuation_info`: all-regime interpolation info for period `t`'s
+    # continuation V_{t+1}. The last period's continuation is the zero template.
+    # `group_key` folds in the continuation targets' explicit user grid signatures
+    # at t+1 (`grid_schedule`), so periods with different continuation grids do
+    # not false-share a compiled kernel.
+    continuation_info = continuation_info_lookup(
+        period_to_regime_v_interp=period_to_regime_v_interp,
+        regime_to_v_interpolation_info=regime_to_v_interpolation_info,
+    )
+    group_key = continuation_group_key(
+        phase_reachability=phase_reachability,
+        source_regime_name=source_regime_name,
+        functions=functions,
+        constraints=constraints,
+        grid_schedule=grid_schedule,
+    )
 
     configs = group_periods_by_key(active_periods, group_key)
 

--- a/src/_lcm/simulation/simulate.py
+++ b/src/_lcm/simulation/simulate.py
@@ -46,7 +46,7 @@ from _lcm.utils.logging import (
     validation_enabled,
 )
 from lcm.ages import AgeGrid
-from lcm.exceptions import InvalidValueFunctionError
+from lcm.exceptions import InvalidSimulationInputError, InvalidValueFunctionError
 from lcm.result import SimulationResult
 from lcm.typing import Float1D, FloatND, Int1D, IntND, ScalarFloat, ScalarInt
 
@@ -299,7 +299,14 @@ def _simulate_subject_chunk(
                     period_to_regime_to_V_arr=period_to_regime_to_V_arr,
                     flat_params=flat_params,
                     regime_names_to_ids=regime_names_to_ids,
-                    active_regimes_next_period=(
+                    decision_targets_next_period=(
+                        ()
+                        if period == ages.n_periods - 1
+                        else regime.solution.reachability.targets(
+                            period=period, source=regime_name
+                        )
+                    ),
+                    realization_targets_next_period=(
                         ()
                         if period == ages.n_periods - 1
                         else regime.simulation.reachability.targets(
@@ -383,6 +390,46 @@ def _concatenate_chunk_results(
     return combined
 
 
+def _require_next_period_values(
+    *,
+    next_period_values: Mapping[RegimeName, FloatND],
+    required_targets: tuple[RegimeName, ...],
+    source_regime_name: RegimeName,
+    source_period: int,
+) -> MappingProxyType[RegimeName, FloatND]:
+    """Validate and select the solution-graph continuation values a decision needs.
+
+    Args:
+        next_period_values: The caller-supplied value-function arrays for the
+            target period (`source_period + 1`), keyed by regime name.
+        required_targets: This source's retained *solution*-graph targets —
+            every one must have an entry in `next_period_values`.
+        source_regime_name: The source regime making the decision.
+        source_period: The source period (0-indexed).
+
+    Returns:
+        Immutable mapping of just the required targets to their value arrays.
+
+    Raises:
+        InvalidSimulationInputError: If any required target is missing from
+            `next_period_values`.
+
+    """
+    missing = tuple(sorted(set(required_targets) - next_period_values.keys()))
+    if missing:
+        msg = (
+            f"Missing continuation values for source regime '{source_regime_name}' "
+            f"at period {source_period} (target period {source_period + 1}). "
+            f"Required solution-graph targets: {required_targets}. "
+            f"Missing: {missing}. Supply a solution produced by this model or "
+            f"provide all required arrays."
+        )
+        raise InvalidSimulationInputError(msg)
+    return MappingProxyType(
+        {target: next_period_values[target] for target in required_targets}
+    )
+
+
 def _simulate_regime_in_period(
     *,
     regime_name: RegimeName,
@@ -398,7 +445,8 @@ def _simulate_regime_in_period(
     ],
     flat_params: FlatParams,
     regime_names_to_ids: RegimeNamesToIds,
-    active_regimes_next_period: tuple[RegimeName, ...],
+    decision_targets_next_period: tuple[RegimeName, ...],
+    realization_targets_next_period: tuple[RegimeName, ...],
     key: PRNGKeyND,
     logger: logging.Logger,
     n_subjects: int,
@@ -424,7 +472,15 @@ def _simulate_regime_in_period(
         period_to_regime_to_V_arr: Value function arrays for all periods and regimes.
         flat_params: Model parameters for all regimes.
         regime_names_to_ids: Mapping from regime names to integer IDs.
-        active_regimes_next_period: Tuple of active regime names in the next period.
+        decision_targets_next_period: This source's retained *solution*-graph
+            targets next period — the continuation values the decision/Q
+            evaluation reads. A caller-supplied `period_to_regime_to_V_arr`
+            missing one of these raises `InvalidSimulationInputError`.
+        realization_targets_next_period: This source's retained
+            *simulation*-graph targets next period — the admissible set for
+            the realized regime draw. May differ from
+            `decision_targets_next_period` under a `Phased` regime
+            transition.
         key: JAX random key for stochastic operations.
         n_subjects: Total number of subjects (the full population), used to keep RNG
             key generation independent of how subjects are chunked.
@@ -453,8 +509,11 @@ def _simulate_regime_in_period(
     # argmax_and_max_Q_over_a function, as the current Q-function requires the
     # next period's value function. In the last period, we pass an empty dict.
     next_period_values = period_to_regime_to_V_arr.get(period + 1, MappingProxyType({}))
-    next_regime_to_V_arr = MappingProxyType(
-        {target: next_period_values[target] for target in active_regimes_next_period}
+    next_regime_to_V_arr = _require_next_period_values(
+        next_period_values=next_period_values,
+        required_targets=decision_targets_next_period,
+        source_regime_name=regime_name,
+        source_period=period,
     )
 
     # The Q-function values contain the information of how much value each
@@ -548,7 +607,7 @@ def _simulate_regime_in_period(
             regime_names_to_ids=regime_names_to_ids,
             states_per_regime=states,
             new_subject_regime_ids=new_subject_regime_ids,
-            active_regimes_next_period=active_regimes_next_period,
+            active_regimes_next_period=realization_targets_next_period,
             key=next_regime_key,
             subjects_in_regime=subject_ids_in_regime,
             n_subjects=n_subjects,

--- a/src/_lcm/solution/backward_induction.py
+++ b/src/_lcm/solution/backward_induction.py
@@ -40,8 +40,7 @@ def _states_for_period(
     V_{t+1} on period-(t+1)'s grid). Same shape as the base, so the shared compiled
     kernel is not retraced. Age-invariant regimes return the base axis unchanged.
     """
-    # getattr (not direct access) so a duck-typed mock regime without the field works.
-    axes = getattr(regime.solution, "period_state_axes", None)
+    axes = regime.solution.period_state_axes
     if axes is not None and period in axes:
         return {**state_action_space.states, **axes[period]}
     return state_action_space.states

--- a/src/_lcm/transition_checks.py
+++ b/src/_lcm/transition_checks.py
@@ -337,17 +337,6 @@ def _validate_regime_transition_probs(
             f"function of the '{regime_name}' regime."
         )
 
-    inactive = set(regime_transition_probs) - set(active_regimes_next_period)
-    for r in inactive:
-        if jnp.any(regime_transition_probs[r] > 0):
-            period_detail = "" if period is None else f" in period {period}"
-            raise InvalidRegimeTransitionProbabilitiesError(
-                f"Regime '{r}' is inactive at age {next_age} but has positive "
-                f"transition probability from '{regime_name}' between ages {age} and "
-                f"{next_age}{period_detail}. Either make '{r}' active or ensure its "
-                "probability is 0."
-            )
-
     sum_all = jnp.sum(all_probs, axis=0)
     if not jnp.allclose(sum_all, 1.0):
         detail = _format_sum_violation(
@@ -359,6 +348,17 @@ def _validate_regime_transition_probs(
             f"and {next_age} do not sum to 1.0. {detail}\n"
             f"Check the 'next_regime' function of the '{regime_name}' regime."
         )
+
+    inactive = set(regime_transition_probs) - set(active_regimes_next_period)
+    for r in inactive:
+        if jnp.any(regime_transition_probs[r] > 0):
+            period_detail = "" if period is None else f" in period {period}"
+            raise InvalidRegimeTransitionProbabilitiesError(
+                f"Regime '{r}' is inactive at age {next_age} but has positive "
+                f"transition probability from '{regime_name}' between ages {age} and "
+                f"{next_age}{period_detail}. Either make '{r}' active or ensure its "
+                "probability is 0."
+            )
 
 
 def _format_sum_violation(
@@ -488,14 +488,19 @@ def _state_transition_unused_in_period(
     regime: Regime,
     period: int,
 ) -> bool:
-    """Return whether a state transition has no retained edge this period."""
+    """Return whether a state transition has no retained edge this period.
+
+    A coarse (`target_regime_name is None`) state law applies regardless of
+    the regime-transition graph's own target set — an empty `period_targets`
+    is a fact about *which regime* is reached, not about whether a coarse
+    state law still needs checking. Only a per-target state law can be
+    unused, and only when its specific target isn't retained this period.
+    """
+    if transition.target_regime_name is None:
+        return False
     period_targets = regime.solution.reachability.targets(
         period=period, source=regime.name
     )
-    if not period_targets:
-        return True
-    if transition.target_regime_name is None:
-        return False
     return transition.target_regime_name not in period_targets
 
 

--- a/src/_lcm/user_regime_validation.py
+++ b/src/_lcm/user_regime_validation.py
@@ -45,7 +45,7 @@ def _grid_mapping_errors(
     suffix = " or Phased" if allow_phase_variants else ""
     if allow_age_specialized_grid:
         # An age-varying continuous-state grid is a valid state (states only).
-        allowed = allowed | AgeSpecializedGrid  # type: ignore[operator]
+        allowed = allowed | AgeSpecializedGrid
         suffix += " or AgeSpecializedGrid"
     error_messages: list[str] = []
     for k, v in mapping.items():

--- a/src/lcm/exceptions.py
+++ b/src/lcm/exceptions.py
@@ -35,6 +35,15 @@ class InvalidInitialConditionsError(PyLCMError):
     """Raised when the initial conditions (states or regimes) are invalid."""
 
 
+class InvalidSimulationInputError(PyLCMError):
+    """Raised when a caller-supplied `period_to_regime_to_V_arr` is incomplete.
+
+    Every solution-graph continuation target for the current
+    `(period, source regime)` decision must have a value-function array
+    present; a missing one is a simulation-input error, not a solver defect.
+    """
+
+
 class InvalidParamsError(PyLCMError):
     """Raised when the params structure does not match the params template."""
 

--- a/src/lcm/model.py
+++ b/src/lcm/model.py
@@ -43,7 +43,11 @@ from _lcm.regime_building.finalize import (
     FinalizedUserRegime,
     finalize_regimes,
 )
-from _lcm.regime_building.processing import Regime, prepare_model_structure
+from _lcm.regime_building.processing import (
+    Regime,
+    compute_active_periods_by_regime,
+    prepare_model_structure,
+)
 from _lcm.simulation.compile import compile_all_simulation_phases
 from _lcm.simulation.initial_conditions import (
     canonicalize_initial_conditions,
@@ -235,6 +239,16 @@ class Model:
         self._warned_n_subjects = set()
         self._simulate_compile_lock = threading.Lock()
 
+        # The single canonical activity schedule: every regime's `active`
+        # predicate is evaluated exactly once, here, and threaded through
+        # pruning, validation, and model-structure preparation below. Its
+        # `.active` predicate is unaffected by slot merging/finalization, so
+        # the raw `regimes` argument is the correct — and only — evaluation
+        # point.
+        active_periods_by_regime = compute_active_periods_by_regime(
+            ages=ages, user_regimes=regimes
+        )
+
         model_slots = {
             "functions": functions,
             "constraints": constraints,
@@ -251,6 +265,7 @@ class Model:
             user_regimes=merged_regimes,
             broadcast_variables=broadcast_variables,
             ages=ages,
+            active_periods_by_regime=active_periods_by_regime,
         )
         self.user_regimes = finalize_regimes(
             user_regimes=pruned_regimes,
@@ -263,6 +278,7 @@ class Model:
             n_subjects=n_subjects,
             broadcast_variables=broadcast_variables,
             ages=self.ages,
+            active_periods_by_regime=active_periods_by_regime,
         )
         self.regime_names_to_ids = MappingProxyType(
             dict(
@@ -275,6 +291,7 @@ class Model:
         prepared_structure = prepare_model_structure(
             user_regimes=self.user_regimes,
             ages=self.ages,
+            active_periods_by_regime=active_periods_by_regime,
         )
         self.reachability = prepared_structure.reachability
         self._regimes, self._params_template = build_regimes_and_template(

--- a/src/lcm/persistence.py
+++ b/src/lcm/persistence.py
@@ -118,7 +118,7 @@ def load_snapshot(
     """
     path = Path(path)
 
-    with (path / "metadata.json").open() as fh:
+    with (path / "metadata.json").open(encoding="utf-8") as fh:
         metadata = json.load(fh)
 
     snapshot_type = metadata["snapshot_type"]

--- a/src/lcm/regime.py
+++ b/src/lcm/regime.py
@@ -77,6 +77,14 @@ class Regime:
       probability. The key set declares the regime's reachable targets;
       omitted regimes are structurally unreachable.
 
+    A bare callable or bare `MarkovTransition` declares conservative support
+    over every regime active in the next period — every temporally
+    compatible candidate must therefore have a valid state handoff (a
+    carried state, a deterministic/stochastic law, or an explicit
+    target-local/entry law). Use a per-target mapping to declare narrower
+    support instead. Runtime-zero transition probabilities do not narrow
+    this topology; only the declared form does.
+
     `Phased` gives each phase its own variant (matching form required; for
     per-target dicts, identical key sets).
     """

--- a/src/lcm/transition.py
+++ b/src/lcm/transition.py
@@ -58,6 +58,14 @@ class MarkovTransition:
 
     A bare callable (without the wrapper) is deterministic at both levels.
 
+    At the regime level, a bare callable or a bare `MarkovTransition` (as
+    opposed to a per-target dict) declares conservative support over every
+    regime active in the next period: every temporally compatible candidate
+    must have a valid state handoff, and the check runs regardless of what
+    probability the transition function happens to return at runtime. Use a
+    per-target dict on `Regime.transition` to declare narrower, structural
+    support — a runtime-zero probability does not narrow it.
+
     """
 
     func: Callable[..., FloatND]

--- a/tests/regime_building/test_activity_single_source.py
+++ b/tests/regime_building/test_activity_single_source.py
@@ -1,0 +1,82 @@
+"""Regime activity must be evaluated once, through one canonical schedule.
+
+Promoted from the Pro-review reachability audit: the construction-time
+reachability graph evaluated `Regime.active` on exact `Fraction` ages
+(`AgeGrid.exact_values`), while every other consumer (age specialization,
+model-input validation, broadcast pruning) evaluated the same predicate
+through `AgeGrid.get_periods_where`, which first rounds each age through a
+float32 round-trip. For a sub-annual `AgeGrid` step, the two representations
+can disagree on which periods a regime is active in, silently desynchronizing
+the reachability graph from every other activity-derived structure.
+"""
+
+from jax import numpy as jnp
+
+from lcm import AgeGrid, Model, Regime, categorical
+from lcm.typing import ScalarFloat, ScalarInt
+
+# Period 5 of `AgeGrid(start=20, stop=21, step="M")` has exact age
+# `Fraction(245, 12)` = 20.416666666666668, but float32(Fraction(245, 12)) =
+# 20.41666603088379. This threshold sits strictly between the two, so a
+# `>=` predicate classifies period 5 differently depending on which
+# representation evaluates it.
+_THRESHOLD = 20.41666634877523
+
+
+@categorical(ordered=False)
+class RegimeId:
+    solo: ScalarInt
+    term: ScalarInt
+
+
+def _zero_utility() -> ScalarFloat:
+    return jnp.float32(0)
+
+
+def _next_term() -> ScalarInt:
+    return RegimeId.term
+
+
+def _active_from_threshold(age: float) -> bool:
+    return age >= _THRESHOLD
+
+
+def test_subannual_activity_uses_one_canonical_schedule(x64_disabled: None) -> None:
+    """The reachability graph's active-period set must equal `get_periods_where`'s.
+
+    Both must classify period 5 the same way; the reachability graph must not
+    derive its own, Fraction-based activity set that disagrees with the
+    canonical `AgeGrid.get_periods_where`-based set every other subsystem
+    (age specialization, model-input validation, broadcast pruning) uses. The
+    disagreement only manifests once ages round-trip through float32, so this
+    test forces `jax_enable_x64=False` regardless of the suite's `--precision`
+    flag.
+    """
+    del x64_disabled
+    ages = AgeGrid(start=20, stop=21, step="M")
+    assert float(ages.exact_values[5]) == 245 / 12  # confirms the age of interest
+
+    model = Model(
+        regimes={
+            "solo": Regime(
+                transition=_next_term,
+                active=_active_from_threshold,
+                functions={"utility": _zero_utility},
+            ),
+            "term": Regime(transition=None, functions={"utility": _zero_utility}),
+        },
+        ages=ages,
+        regime_id_class=RegimeId,
+        enable_jit=False,
+    )
+
+    expected_periods = ages.get_periods_where(_active_from_threshold)
+    graph_periods = tuple(
+        period
+        for period, regimes in enumerate(
+            model.reachability.solution.active_regimes_by_period
+        )
+        if "solo" in regimes
+    )
+
+    assert graph_periods == expected_periods

--- a/tests/regime_building/test_age_normalization.py
+++ b/tests/regime_building/test_age_normalization.py
@@ -57,8 +57,15 @@ def _next_regime(age: float):  # noqa: ARG001
 def _normalized(regimes: dict[str, UserRegime], ages: AgeGrid):
     finalized = finalize_regimes(user_regimes=regimes, derived_categoricals={})
     phased = normalize_all_regime_phases(user_regimes=finalized)
+    active_periods_by_regime = {
+        regime_name: tuple(ages.get_periods_where(regime.active))
+        for regime_name, regime in finalized.items()
+    }
     return finalized, normalize_age_specialization(
-        user_regimes=finalized, phased_specs=phased, ages=ages
+        user_regimes=finalized,
+        phased_specs=phased,
+        ages=ages,
+        active_periods_by_regime=active_periods_by_regime,
     )
 
 

--- a/tests/regime_building/test_age_specialization.py
+++ b/tests/regime_building/test_age_specialization.py
@@ -12,8 +12,10 @@ Two contracts, promoted from the Pro-review counterexample RT1:
 import pytest
 
 from _lcm.grids import DiscreteGrid
+from _lcm.regime_building.age_normalization import periodized_tree_signature
 from _lcm.regime_building.age_specialization import (
     INVARIANT,
+    _tree_signature,
     node_signature,
     tree_signature,
 )
@@ -78,6 +80,38 @@ def test_tree_signature_recurses_into_the_nested_transition_mapping():
     assert tree_signature(transitions, age=60.0) != tree_signature(
         transitions, age=61.0
     )
+
+
+def test_tree_signature_helper_is_invariant_to_key_insertion_order():
+    """`_tree_signature` sorts keys, so insertion order cannot affect the result."""
+    tree_a = {"b": "second", "a": "first"}
+    tree_b = {"a": "first", "b": "second"}
+
+    assert _tree_signature(tree_a, leaf_signature=str) == _tree_signature(
+        tree_b, leaf_signature=str
+    )
+
+
+def test_tree_signature_helper_recurses_regardless_of_leaf_signature():
+    """A different `leaf_signature` still descends into nested mappings."""
+    nested = {"outer": {"inner": "value"}}
+
+    assert _tree_signature(nested, leaf_signature=lambda leaf: len(str(leaf))) == (
+        ("outer", (("inner", len("value")),)),
+    )
+
+
+def test_tree_signature_wrappers_share_recursive_semantics():
+    """`tree_signature` (age) and `periodized_tree_signature` (period) agree.
+
+    Both are thin wrappers over the same recursive helper, so an
+    age-invariant tree and a period-invariant tree with identical structure
+    (only the leaf-signature source differs) recurse and sort keys the same
+    way.
+    """
+    tree = {"b": lambda x: x, "a": {"nested": lambda x: x}}
+
+    assert tree_signature(tree, age=60.0) == periodized_tree_signature(tree, period=3)
 
 
 def test_age_specialized_regime_transition_is_rejected(binary_category_class):

--- a/tests/regime_building/test_reachability.py
+++ b/tests/regime_building/test_reachability.py
@@ -5,7 +5,6 @@ import pytest
 
 from _lcm.reachability import (
     EdgeStatus,
-    active_periods_from_predicates,
     build_model_reachability,
     build_phase_reachability,
 )
@@ -30,13 +29,16 @@ def test_forcedout_cannot_transition_back_to_canwork() -> None:
     """A later-life regime cannot transition into an earlier-life regime."""
     ages = tuple(range(60, 69))
     cutoff = 65
-    active = active_periods_from_predicates(
-        ages=ages,
-        active_by_regime={
-            "canwork": lambda age: age < cutoff,
-            "forcedout": lambda age: age >= cutoff,
-        },
-    )
+    active_by_regime = {
+        "canwork": lambda age: age < cutoff,
+        "forcedout": lambda age: age >= cutoff,
+    }
+    active = {
+        regime: frozenset(
+            period for period, age in enumerate(ages) if bool(is_active(age))
+        )
+        for regime, is_active in active_by_regime.items()
+    }
     graph = build_phase_reachability(
         n_periods=len(ages),
         active_periods_by_regime=active,
@@ -68,10 +70,8 @@ def test_coarse_transition_retains_all_activity_compatible_regimes() -> None:
     regime_names = ("source", "low", "high")
     coarse_transition = object()
     graph = build_model_reachability(
-        ages=(20, 21),
-        active_by_regime={
-            regime_name: lambda _age: True for regime_name in regime_names
-        },
+        n_periods=2,
+        active_periods_by_regime=dict.fromkeys(regime_names, (0, 1)),
         transitions_by_phase={
             "solution": {
                 "source": coarse_transition,
@@ -139,11 +139,11 @@ def test_unknown_target_is_rejected() -> None:
 def test_solution_and_simulation_graphs_use_the_same_builder() -> None:
     """Phase-specific declarations produce phase-specific temporal graphs."""
     graph = build_model_reachability(
-        ages=(20, 21),
-        active_by_regime={
-            "source": lambda _age: True,
-            "solve_target": lambda _age: True,
-            "simulate_target": lambda _age: True,
+        n_periods=2,
+        active_periods_by_regime={
+            "source": (0, 1),
+            "solve_target": (0, 1),
+            "simulate_target": (0, 1),
         },
         transitions_by_phase={
             "solution": {

--- a/tests/regime_building/test_reachability.py
+++ b/tests/regime_building/test_reachability.py
@@ -200,3 +200,90 @@ def test_solver_runtime_does_not_import_regime_declaration_topology() -> None:
     ]
 
     assert imports == []
+
+
+def _solver_runtime_paths() -> list[Path]:
+    package_root = Path(__file__).parents[2] / "src" / "_lcm"
+    return [
+        *sorted((package_root / "solution").rglob("*.py")),
+        package_root / "simulation" / "compile.py",
+        package_root / "simulation" / "simulate.py",
+        package_root / "simulation" / "transitions.py",
+    ]
+
+
+def test_solver_runtime_does_not_call_activity_predicates() -> None:
+    """Solver runtime modules consume the graph, not `Regime.active` directly.
+
+    Only `compute_active_periods_by_regime` (the single canonical activity
+    schedule) may call an activity predicate or `AgeGrid.get_periods_where`;
+    every other consumer, including the solve/simulate runtime, reads the
+    prepared `active_periods_by_regime` mapping instead.
+    """
+    calls = [
+        (path, node.lineno)
+        for path in _solver_runtime_paths()
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in {"active", "get_periods_where"}
+    ]
+
+    assert calls == []
+
+
+def test_solver_runtime_does_not_inspect_regime_transition_mapping_keys() -> None:
+    """Solver runtime modules never read `.transition` / `.state_transitions`.
+
+    Which regime pairs are reachable is a graph property; a solver module
+    inspecting the raw declared transition or state-transition mapping to
+    decide targets would bypass the single-source-of-truth graph.
+    """
+    accesses = [
+        (path, node.lineno)
+        for path in _solver_runtime_paths()
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Attribute)
+        and node.attr in {"transition", "state_transitions"}
+    ]
+
+    assert accesses == []
+
+
+def test_continuation_targets_are_not_derived_from_law_bundle_keys() -> None:
+    """`carry_targets` (a law-bundle-keyed target set) must not reappear.
+
+    Continuation/process-target membership is `phase_reachability.union_targets`
+    (or an equivalent graph query) — never a set of regime names collected from
+    `flat_nested_transitions` or other state-law-bundle keys.
+    """
+    package_root = Path(__file__).parents[2] / "src" / "_lcm"
+    hits = [
+        (path, lineno)
+        for path in package_root.rglob("*.py")
+        for lineno, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        )
+        if "carry_targets" in line
+    ]
+
+    assert hits == []
+
+
+def test_active_periods_are_computed_at_a_single_call_site() -> None:
+    """`AgeGrid.get_periods_where` is combined with `Regime.active` exactly once.
+
+    `compute_active_periods_by_regime` is that single canonical evaluation
+    point; a second call site would let two subsystems compute active
+    periods independently and risk disagreement (e.g. Fraction vs.
+    float32-rounded ages).
+    """
+    src_root = Path(__file__).parents[2] / "src"
+    hits = [
+        path
+        for path in src_root.rglob("*.py")
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if "get_periods_where(" in line and ".active" in line
+    ]
+
+    assert hits == [src_root / "_lcm" / "regime_building" / "processing.py"]

--- a/tests/regime_building/test_target_only_process_rejected.py
+++ b/tests/regime_building/test_target_only_process_rejected.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from lcm import (
@@ -35,6 +36,19 @@ def _one_probability() -> ScalarFloat:
 
 def _next_target() -> ScalarInt:
     return RegimeId.target
+
+
+_PROCESS_SOLVE_PARAMS = {
+    "discount_factor": 1.0,
+    "source__shock__rho": 0.5,
+    "source__shock__sigma": 0.3,
+    "source__shock__mu": 0.0,
+    "source__shock__n_std": 2.0,
+    "target__shock__rho": 0.5,
+    "target__shock__sigma": 0.3,
+    "target__shock__mu": 0.0,
+    "target__shock__n_std": 2.0,
+}
 
 
 def _source_is_early(age: float) -> bool:
@@ -113,10 +127,113 @@ def test_activity_compatible_target_only_process_is_rejected(
 
 
 def test_process_carried_by_source_and_target_is_accepted() -> None:
-    """A source value supplies the conditioning state for the target process."""
+    """A source value supplies the conditioning state for the target process.
+
+    Beyond construction, `.solve()` must actually receive the target's shared
+    process in its continuation: the source's period-0 value must be finite
+    and reflect the target's nonzero terminal payoff, not silently treat the
+    continuation as zero because the process-only target was dropped from
+    the generated transition DAG.
+    """
     model = _build_overlapping_model(coarse=False, carry_process=True)
 
     assert model.reachability.solution.targets(period=0, source="source") == ("target",)
+
+    solution = model.solve(params=_PROCESS_SOLVE_PARAMS, log_level="debug")
+
+    source_v = solution[0]["source"]
+    assert bool(jnp.all(jnp.isfinite(source_v)))
+    assert not bool(jnp.allclose(source_v, 0.0))
+
+
+def test_process_only_target_matches_equivalent_target_with_inert_nonprocess_law() -> (
+    None
+):
+    """Adding an inert non-process law to a target must not change its value.
+
+    Two economically identical models: one where `target` carries only the
+    shared process state, one where `target` also carries an inert
+    non-process state whose entry law makes the old
+    `flat_nested_transitions`-derived route non-empty for `target`. The
+    inert state contributes exactly zero to utility, so `source`'s period-0
+    continuation value must be identical either way — the existence of a
+    continuation target is a property of the reachability graph, not of
+    whether some unrelated state happens to have a law-of-motion entry.
+    """
+    process = TauchenAR1Process(
+        n_points=3, gauss_hermite=False, rho=0.5, sigma=0.3, mu=0.0, n_std=2.0
+    )
+
+    def _process_only_model() -> Model:
+        return Model(
+            regimes={
+                "source": Regime(
+                    transition={"target": MarkovTransition(_one_probability)},
+                    active=_source_is_early,
+                    states={"shock": process},
+                    functions={"utility": _shock_utility},
+                ),
+                "target": Regime(
+                    transition=None,
+                    states={"shock": process},
+                    functions={"utility": _shock_utility},
+                ),
+            },
+            ages=AgeGrid(start=20, stop=22, step="Y"),
+            regime_id_class=RegimeId,
+            enable_jit=False,
+        )
+
+    def _shock_and_inert_utility(shock: ScalarFloat, extra: ScalarFloat) -> ScalarFloat:
+        return shock + jnp.float32(0) * extra
+
+    def _process_and_inert_law_model() -> Model:
+        return Model(
+            regimes={
+                "source": Regime(
+                    transition={"target": MarkovTransition(_one_probability)},
+                    active=_source_is_early,
+                    states={"shock": process},
+                    state_transitions={
+                        "extra": {"target": lambda: jnp.float32(0.0)},
+                    },
+                    functions={"utility": _shock_utility},
+                ),
+                "target": Regime(
+                    transition=None,
+                    states={
+                        "shock": process,
+                        "extra": LinSpacedGrid(start=0, stop=1, n_points=2),
+                    },
+                    functions={"utility": _shock_and_inert_utility},
+                ),
+            },
+            ages=AgeGrid(start=20, stop=22, step="Y"),
+            regime_id_class=RegimeId,
+            enable_jit=False,
+        )
+
+    process_only = _process_only_model()
+    process_and_inert_law = _process_and_inert_law_model()
+
+    assert process_only.reachability.solution.targets(period=0, source="source") == (
+        "target",
+    )
+    assert process_and_inert_law.reachability.solution.targets(
+        period=0, source="source"
+    ) == ("target",)
+
+    solve_params = {"discount_factor": 1.0}
+    v_process_only = process_only.solve(params=solve_params, log_level="debug")
+    v_process_and_inert_law = process_and_inert_law.solve(
+        params=solve_params, log_level="debug"
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(v_process_only[0]["source"]),
+        np.asarray(v_process_and_inert_law[0]["source"]),
+        atol=1e-6,
+    )
 
 
 def test_explicit_entry_law_for_target_only_process_is_accepted() -> None:

--- a/tests/simulation/test_reachability_phase_split.py
+++ b/tests/simulation/test_reachability_phase_split.py
@@ -1,0 +1,124 @@
+"""Solution-graph continuation values are a simulation-input contract.
+
+Promoted from the Pro-review reachability audit: forward simulation's
+decision/Q evaluation reads continuation value-function arrays for every
+target the *solution* graph names for the current `(period, source)` edge.
+A caller-supplied `period_to_regime_to_V_arr` missing one of those targets
+must raise a descriptive `InvalidSimulationInputError`, not a bare `KeyError`
+and not a silent zero/empty fallback.
+"""
+
+from types import MappingProxyType
+
+import jax.numpy as jnp
+import pytest
+
+from lcm import AgeGrid, MarkovTransition, Model, Regime, categorical
+from lcm.typing import ScalarFloat, ScalarInt
+
+
+@categorical(ordered=False)
+class _RegimeId:
+    source: ScalarInt
+    low: ScalarInt
+    high: ScalarInt
+
+
+def _zero_utility() -> ScalarFloat:
+    return jnp.float32(0)
+
+
+def _low_utility() -> ScalarFloat:
+    return jnp.float32(0)
+
+
+def _high_utility() -> ScalarFloat:
+    return jnp.float32(10)
+
+
+def _probability_high(probability_high: ScalarFloat) -> ScalarFloat:
+    return probability_high
+
+
+def _probability_low(probability_high: ScalarFloat) -> ScalarFloat:
+    return 1 - probability_high
+
+
+def _source_is_active(age: float) -> bool:
+    return age < 1
+
+
+def _target_is_active(age: float) -> bool:
+    return age >= 1
+
+
+def _build_model() -> Model:
+    return Model(
+        regimes={
+            "source": Regime(
+                transition={
+                    "low": MarkovTransition(_probability_low),
+                    "high": MarkovTransition(_probability_high),
+                },
+                active=_source_is_active,
+                functions={"utility": _zero_utility},
+            ),
+            "low": Regime(
+                transition=None,
+                active=_target_is_active,
+                functions={"utility": _low_utility},
+            ),
+            "high": Regime(
+                transition=None,
+                active=_target_is_active,
+                functions={"utility": _high_utility},
+            ),
+        },
+        ages=AgeGrid(start=0, stop=1, step="Y"),
+        regime_id_class=_RegimeId,
+        enable_jit=False,
+    )
+
+
+def test_missing_solution_graph_value_raises_descriptive_simulation_input_error() -> (
+    None
+):
+    """A `period_to_regime_to_V_arr` missing a solution-graph target fails closed."""
+    model = _build_model()
+    params = {"discount_factor": 1.0, "probability_high": 0.5}
+    solution = model.solve(params=params, log_level="debug")
+
+    assert model.reachability.solution.targets(period=0, source="source") == (
+        "high",
+        "low",
+    )
+
+    # Drop "high"'s period-1 value array, which the period-0 decision at
+    # "source" needs to compute its continuation value.
+    incomplete_solution = MappingProxyType(
+        {
+            **solution,
+            1: MappingProxyType({k: v for k, v in solution[1].items() if k != "high"}),
+        }
+    )
+
+    initial_conditions = {
+        "age": jnp.array([0.0]),
+        "regime_id": jnp.array([model.regime_names_to_ids["source"]]),
+    }
+
+    with pytest.raises(Exception) as excinfo:  # noqa: PT011
+        model.simulate(
+            params=params,
+            initial_conditions=initial_conditions,
+            period_to_regime_to_V_arr=incomplete_solution,
+            log_level="debug",
+        )
+
+    assert not isinstance(excinfo.value, KeyError), (
+        "A missing solution-graph continuation value must raise a descriptive "
+        "InvalidSimulationInputError, not a bare KeyError."
+    )
+    message = str(excinfo.value)
+    assert "source" in message
+    assert "high" in message

--- a/tests/simulation/test_simulate_certainty_equivalent.py
+++ b/tests/simulation/test_simulate_certainty_equivalent.py
@@ -2,6 +2,7 @@
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from lcm import PowerMean
 from lcm_examples.epstein_zin import (
@@ -10,7 +11,13 @@ from lcm_examples.epstein_zin import (
     get_model,
     get_params,
 )
-from tests.test_certainty_equivalent import _reference_backward_induction
+from tests.test_certainty_equivalent import (
+    _Health,
+    _make_scale_equivariant_model,
+    _reference_backward_induction,
+    _RegimeId,
+    _scaled_model_params,
+)
 
 
 def test_simulated_period0_consumption_matches_reference_policy():
@@ -123,3 +130,31 @@ def test_bequest_scale_scales_the_dead_regime_utility():
     np.testing.assert_allclose(
         dead["utility"].to_numpy(), 0.3 * np.sqrt(dead["wealth"].to_numpy()), atol=1e-6
     )
+
+
+@pytest.mark.parametrize("risk_aversion", [2.0, 50.0])
+def test_simulated_consumption_is_equivariant_to_rescaling_the_model(
+    x64_enabled: None,  # noqa: ARG001
+    risk_aversion: float,
+):
+    """Scaling a homogeneous model by `k > 0` scales its simulated choices by `k`."""
+    scale = 1e-7
+    params = _scaled_model_params(risk_aversion)
+
+    def simulate(model_scale: float) -> np.ndarray:
+        model = _make_scale_equivariant_model(model_scale)
+        result = model.simulate(
+            params=params,
+            initial_conditions={
+                "age": jnp.full(2, 25.0),
+                "wealth": jnp.array([2.8, 12.0]) * model_scale,
+                "health": jnp.array([_Health.bad, _Health.good]),
+                "regime_id": jnp.full(2, _RegimeId.alive),
+            },
+            period_to_regime_to_V_arr=None,
+            log_level="debug",
+        )
+        df = result.to_dataframe(use_labels=False)
+        return df.query("period == 0")["consumption"].to_numpy()
+
+    np.testing.assert_allclose(simulate(scale) / scale, simulate(1.0), rtol=1e-6)

--- a/tests/solution/test_backward_induction.py
+++ b/tests/solution/test_backward_induction.py
@@ -23,6 +23,9 @@ class MockSolutionPhase:
     _base_state_action_space: StateActionSpace
     grids: MappingProxyType[StateOrActionName, Grid]
     compute_intermediates: dict = dataclasses.field(default_factory=dict)
+    period_state_axes: (
+        MappingProxyType[int, MappingProxyType[StateOrActionName, object]] | None
+    ) = None
 
     def state_action_space(self, regime_params):  # noqa: ARG002
         return self._base_state_action_space

--- a/tests/solution/test_reachability.py
+++ b/tests/solution/test_reachability.py
@@ -34,8 +34,8 @@ def _probability_high(probability_high: ScalarFloat) -> ScalarFloat:
     return probability_high
 
 
-def _one_probability() -> ScalarFloat:
-    return jnp.float32(1)
+def _complement_of_dormant_probability() -> ScalarFloat:
+    return jnp.float32(0.9)
 
 
 def _positive_dormant_probability() -> ScalarFloat:
@@ -97,7 +97,11 @@ def test_runtime_zero_probability_keeps_static_continuation_targets() -> None:
 
 
 def test_positive_granular_probability_outside_graph_is_rejected() -> None:
-    """A dormant declaration cannot receive positive transition probability."""
+    """A dormant declaration cannot receive positive transition probability.
+
+    The two probabilities sum to exactly 1.0, so this isolates the
+    inactive-target check from the (separately tested) sum-to-1 check.
+    """
 
     @categorical(ordered=False)
     class _DormantRegimeId:
@@ -109,7 +113,7 @@ def test_positive_granular_probability_outside_graph_is_rejected() -> None:
         regimes={
             "source": Regime(
                 transition={
-                    "target": MarkovTransition(_one_probability),
+                    "target": MarkovTransition(_complement_of_dormant_probability),
                     "dormant": MarkovTransition(_positive_dormant_probability),
                 },
                 active=lambda age: age < 1,

--- a/tests/test_Q_and_F.py
+++ b/tests/test_Q_and_F.py
@@ -3,7 +3,9 @@ from types import MappingProxyType
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
+from dags import concatenate_functions
 from numpy.testing import assert_array_equal
 
 from _lcm.grids import DiscreteGrid, LinSpacedGrid, categorical
@@ -18,9 +20,12 @@ from _lcm.regime_building.Q_and_F import (
     _get_feasibility,
     _get_joint_weights_function,
     _get_U_and_F,
+    get_compute_intermediates,
+    get_Q_and_F,
     get_Q_and_F_terminal,
 )
-from lcm import AgeGrid
+from _lcm.regime_building.V import VInterpolationInfo
+from lcm import AgeGrid, PowerMean
 from lcm.model import Model
 from lcm.regime import MarkovTransition
 from lcm.regime import Regime as UserRegime
@@ -377,3 +382,181 @@ def test_partial_state_laws_solve_with_declared_targets():
     for regime_to_V_arr in period_to_regime_to_V_arr.values():
         for V_arr in regime_to_V_arr.values():
             assert not jnp.any(jnp.isnan(V_arr))
+
+
+def _sum_utility(utility_level: FloatND) -> FloatND:
+    return utility_level
+
+
+def _epstein_zin_H(utility: FloatND, E_next_V: FloatND) -> FloatND:
+    return utility + E_next_V
+
+
+def _low_and_high_probs(regime_prob_low: FloatND) -> MappingProxyType[str, FloatND]:
+    return MappingProxyType(
+        {"low": regime_prob_low, "high": 1.0 - regime_prob_low},
+    )
+
+
+# A target regime without states: its value function array is a scalar, so the
+# interpolator is the identity and each target contributes a single lottery node.
+_STATELESS_V_INFO = VInterpolationInfo(
+    state_names=(),
+    discrete_states=MappingProxyType({}),
+    continuous_states=MappingProxyType({}),
+)
+
+
+def _build_two_target_closure(builder: Callable, *, certainty_equivalent) -> Callable:
+    """Build `Q_and_F` (or the diagnostics twin) over two stateless target regimes."""
+    return builder(
+        flat_param_names=frozenset({"certainty_equivalent__risk_aversion"}),
+        functions=MappingProxyType({"utility": _sum_utility, "H": _epstein_zin_H}),
+        constraints=MappingProxyType({}),
+        period_targets=("low", "high"),
+        transitions=MappingProxyType({}),
+        stochastic_transition_names=frozenset(),
+        compute_regime_transition_probs=concatenate_functions(
+            functions={"regime_transition_probs": _low_and_high_probs},
+            targets="regime_transition_probs",
+            enforce_signature=False,
+            set_annotations=True,
+        ),
+        regime_to_v_interpolation_info=MappingProxyType(
+            {"low": _STATELESS_V_INFO, "high": _STATELESS_V_INFO}
+        ),
+        certainty_equivalent=certainty_equivalent,
+    )
+
+
+def _two_target_call_kwargs(
+    *,
+    values: tuple[float, float],
+    regime_prob_low: float,
+    utility_level: float,
+    risk_aversion: float,
+    dtype,
+) -> dict:
+    return {
+        "next_regime_to_V_arr": MappingProxyType(
+            {
+                "low": jnp.asarray(values[0], dtype=dtype),
+                "high": jnp.asarray(values[1], dtype=dtype),
+            }
+        ),
+        "utility_level": jnp.asarray(utility_level, dtype=dtype),
+        "regime_prob_low": jnp.asarray(regime_prob_low, dtype=dtype),
+        "age": jnp.asarray(25),
+        "period": jnp.asarray(0),
+        "certainty_equivalent__risk_aversion": jnp.asarray(risk_aversion, dtype=dtype),
+    }
+
+
+def test_power_mean_regime_lottery_stays_finite_in_float64(x64_enabled: None):
+    """A `(1e-50, 2e-50)` regime lottery at risk aversion 8 keeps its exact value."""
+    Q_and_F = _build_two_target_closure(get_Q_and_F, certainty_equivalent=PowerMean())
+    got = jax.jit(
+        lambda: Q_and_F(
+            **_two_target_call_kwargs(
+                values=(1e-50, 2e-50),
+                regime_prob_low=0.5,
+                utility_level=0.0,
+                risk_aversion=8.0,
+                dtype=jnp.float64,
+            )
+        )[0]
+    )()
+    np.testing.assert_allclose(float(got), 1.102862741485982e-50, rtol=5e-5, atol=0.0)
+
+
+def test_power_mean_regime_lottery_stays_finite_in_float32(x64_disabled: None):
+    """A `(1e-8, 2e-8)` regime lottery at risk aversion 8 keeps its exact value."""
+    Q_and_F = _build_two_target_closure(get_Q_and_F, certainty_equivalent=PowerMean())
+    got = jax.jit(
+        lambda: Q_and_F(
+            **_two_target_call_kwargs(
+                values=(1e-8, 2e-8),
+                regime_prob_low=0.5,
+                utility_level=0.0,
+                risk_aversion=8.0,
+                dtype=jnp.float32,
+            )
+        )[0]
+    )()
+    np.testing.assert_allclose(float(got), 1.102862741485982e-8, rtol=5e-5, atol=0.0)
+
+
+# Risk aversion and lottery scale at which the naive
+# `inverse(Σ w · transform(v))` route overflows float64.
+_FLOAT64_ACTION_CASES = [(8.0, 1e-50), (12.0, 1e-30), (20.0, 1e-20), (50.0, 1e-8)]
+
+
+@pytest.mark.parametrize(("risk_aversion", "scale"), _FLOAT64_ACTION_CASES)
+def test_bellman_prefers_the_higher_certainty_equivalent_at_any_scale(
+    x64_enabled: None,
+    risk_aversion: float,
+    scale: float,
+):
+    """The action with the larger certainty equivalent wins however small values are.
+
+    The two actions face the same two-point lottery `(scale, 2 * scale)`
+    under different regime probabilities. The even lottery has the higher
+    power mean by more than the first action's utility advantage, so it is
+    optimal at every scale.
+    """
+    values = (scale, 2.0 * scale)
+    skewed = PowerMean().aggregate(
+        values=jnp.asarray(values, dtype=jnp.float64),
+        weights=jnp.asarray((0.9, 0.1), dtype=jnp.float64),
+        params={"risk_aversion": jnp.asarray(risk_aversion, dtype=jnp.float64)},
+    )
+    even = PowerMean().aggregate(
+        values=jnp.asarray(values, dtype=jnp.float64),
+        weights=jnp.asarray((0.5, 0.5), dtype=jnp.float64),
+        params={"risk_aversion": jnp.asarray(risk_aversion, dtype=jnp.float64)},
+    )
+    assert float(even) > float(skewed) > 0.0
+    utility_advantage = 0.4 * (float(even) - float(skewed))
+
+    Q_and_F = _build_two_target_closure(get_Q_and_F, certainty_equivalent=PowerMean())
+    Q_per_action = jax.jit(
+        lambda: jnp.asarray(
+            [
+                Q_and_F(
+                    **_two_target_call_kwargs(
+                        values=values,
+                        regime_prob_low=prob_low,
+                        utility_level=utility,
+                        risk_aversion=risk_aversion,
+                        dtype=jnp.float64,
+                    )
+                )[0]
+                for prob_low, utility in ((0.9, utility_advantage), (0.5, 0.0))
+            ]
+        )
+    )()
+    expected = jnp.asarray([utility_advantage + float(skewed), float(even)])
+    np.testing.assert_allclose(
+        np.asarray(Q_per_action), np.asarray(expected), rtol=8e-5
+    )
+    assert int(jnp.argmax(Q_per_action)) == 1
+
+
+def test_diagnostic_intermediates_reproduce_the_Bellman_Q(x64_enabled: None):
+    """The NaN diagnostics recompute the same `Q` the backward induction used."""
+    call_kwargs = _two_target_call_kwargs(
+        values=(1e-50, 2e-50),
+        regime_prob_low=0.25,
+        utility_level=3e-51,
+        risk_aversion=8.0,
+        dtype=jnp.float64,
+    )
+    Q_and_F = _build_two_target_closure(get_Q_and_F, certainty_equivalent=PowerMean())
+    compute_intermediates = _build_two_target_closure(
+        get_compute_intermediates, certainty_equivalent=PowerMean()
+    )
+    Q_arr = jax.jit(lambda: Q_and_F(**call_kwargs)[0])()
+    diagnostic_Q_arr = jax.jit(lambda: compute_intermediates(**call_kwargs)[3])()
+    np.testing.assert_allclose(
+        np.asarray(diagnostic_Q_arr), np.asarray(Q_arr), rtol=0.0, atol=0.0
+    )

--- a/tests/test_certainty_equivalent.py
+++ b/tests/test_certainty_equivalent.py
@@ -1,6 +1,7 @@
 """Tests for nonlinear certainty equivalents over the continuation value."""
 
 from collections.abc import Callable
+from decimal import Decimal, localcontext
 from typing import Any
 
 import jax.numpy as jnp
@@ -9,7 +10,10 @@ import pytest
 
 from lcm import (
     AgeGrid,
+    DiscreteGrid,
+    H_epstein_zin,
     LinSpacedGrid,
+    MarkovTransition,
     Model,
     Phased,
     PowerMean,
@@ -19,7 +23,15 @@ from lcm import (
 )
 from lcm.exceptions import InvalidNameError, RegimeInitializationError
 from lcm.solvers import DCEGM
-from lcm.typing import BoolND, ContinuousAction, ContinuousState, FloatND, ScalarInt
+from lcm.typing import (
+    BoolND,
+    ContinuousAction,
+    ContinuousState,
+    DiscreteState,
+    FloatND,
+    Period,
+    ScalarInt,
+)
 from lcm_examples.epstein_zin import get_model, get_params
 
 
@@ -373,3 +385,274 @@ def test_epstein_zin_solved_values_match_numpy_reference(risk_aversion: float):
             rtol=5e-5,
             err_msg=f"period={period}",
         )
+
+
+def _stable_power_mean(
+    values: tuple[float, ...],
+    weights: tuple[float, ...],
+    risk_aversion: float,
+) -> float:
+    """Evaluate the weighted power mean of a positive lottery in decimal arithmetic.
+
+    An independent reference for `(Σ w · v^(1-ra))^(1/(1-ra))` on the
+    mass-normalised lottery, carried at 120 significant digits so it is
+    unaffected by the floating-point range that makes the naive
+    `inverse(Σ w · transform(v))` route overflow. `risk_aversion = 1` is the
+    weighted geometric mean.
+    """
+    with localcontext() as context:
+        context.prec = 120
+        vals = tuple(Decimal(str(v)) for v in values)
+        raw_weights = tuple(Decimal(str(w)) for w in weights)
+        mass = sum(raw_weights, start=Decimal(0))
+        normalized = tuple(w / mass for w in raw_weights)
+        exponent = Decimal(1) - Decimal(str(risk_aversion))
+        logs = tuple(v.ln() for v in vals)
+        if exponent == 0:
+            log_mean = sum(
+                (w * log_v for w, log_v in zip(normalized, logs, strict=True)),
+                start=Decimal(0),
+            )
+            return float(log_mean.exp())
+        # A negative exponent makes the smallest log the safe anchor, a positive
+        # exponent the largest; either keeps every scaled exponent nonpositive.
+        anchor = min(logs) if exponent < 0 else max(logs)
+        scaled = sum(
+            (
+                w * (exponent * (log_v - anchor)).exp()
+                for w, log_v in zip(normalized, logs, strict=True)
+            ),
+            start=Decimal(0),
+        )
+        return float((anchor + scaled.ln() / exponent).exp())
+
+
+# Risk aversion and lottery scale combinations at which the naive
+# `inverse(Σ w · transform(v))` route overflows the dtype.
+_FLOAT64_STRESS_CASES = [(8.0, 1e-50), (12.0, 1e-30), (20.0, 1e-20), (50.0, 1e-8)]
+_FLOAT32_STRESS_CASES = [(8.0, 1e-8), (12.0, 1e-5), (20.0, 1e-3)]
+
+
+@pytest.mark.parametrize(("risk_aversion", "scale"), _FLOAT64_STRESS_CASES)
+def test_power_mean_aggregate_matches_reference_at_float64_scales(
+    x64_enabled: None,
+    risk_aversion: float,
+    scale: float,
+):
+    """The power mean of a tiny positive lottery equals its high-precision value."""
+    values = (scale, 2.0 * scale)
+    weights = (0.9, 0.1)
+    got = PowerMean().aggregate(
+        values=jnp.asarray(values, dtype=jnp.float64),
+        weights=jnp.asarray(weights, dtype=jnp.float64),
+        params={"risk_aversion": jnp.asarray(risk_aversion, dtype=jnp.float64)},
+    )
+    expected = _stable_power_mean(values, weights, risk_aversion)
+    np.testing.assert_allclose(float(got), expected, rtol=1e-12, atol=0.0)
+
+
+@pytest.mark.parametrize(("risk_aversion", "scale"), _FLOAT32_STRESS_CASES)
+def test_power_mean_aggregate_matches_reference_at_float32_scales(
+    x64_disabled: None,
+    risk_aversion: float,
+    scale: float,
+):
+    """The float32 power mean of a tiny positive lottery stays at its exact value."""
+    values = (scale, 2.0 * scale)
+    weights = (0.9, 0.1)
+    got = PowerMean().aggregate(
+        values=jnp.asarray(values, dtype=jnp.float32),
+        weights=jnp.asarray(weights, dtype=jnp.float32),
+        params={"risk_aversion": jnp.asarray(risk_aversion, dtype=jnp.float32)},
+    )
+    expected = _stable_power_mean(values, weights, risk_aversion)
+    np.testing.assert_allclose(float(got), expected, rtol=5e-5, atol=0.0)
+
+
+def test_power_mean_aggregate_is_geometric_mean_at_unit_risk_aversion():
+    """At `risk_aversion = 1` the power mean is the weighted geometric mean."""
+    got = PowerMean().aggregate(
+        values=jnp.array([1.0, 9.0]),
+        weights=jnp.array([0.5, 0.5]),
+        params={"risk_aversion": jnp.asarray(1.0)},
+    )
+    np.testing.assert_allclose(float(got), 3.0, rtol=1e-6)
+
+
+@pytest.mark.parametrize("risk_aversion", [1.0 - 1e-6, 1.0 + 1e-6])
+def test_power_mean_aggregate_is_continuous_around_unit_risk_aversion(
+    risk_aversion: float,
+):
+    """Just off `risk_aversion = 1` the power mean is still the geometric mean."""
+    got = PowerMean().aggregate(
+        values=jnp.array([1.0, 9.0]),
+        weights=jnp.array([0.5, 0.5]),
+        params={"risk_aversion": jnp.asarray(risk_aversion)},
+    )
+    np.testing.assert_allclose(float(got), 3.0, rtol=1e-5)
+
+
+def test_power_mean_aggregate_is_linear_expectation_at_zero_risk_aversion():
+    """At `risk_aversion = 0` the power mean is the probability-weighted mean."""
+    got = PowerMean().aggregate(
+        values=jnp.array([1.0, 9.0]),
+        weights=jnp.array([0.25, 0.75]),
+        params={"risk_aversion": jnp.asarray(0.0)},
+    )
+    np.testing.assert_allclose(float(got), 7.0, rtol=1e-6)
+
+
+def test_power_mean_aggregate_drops_zero_weight_entries():
+    """A zero-probability branch leaves the certainty equivalent unchanged."""
+    kept = PowerMean().aggregate(
+        values=jnp.array([1.0, 9.0]),
+        weights=jnp.array([0.5, 0.5]),
+        params={"risk_aversion": jnp.asarray(3.0)},
+    )
+    padded = PowerMean().aggregate(
+        values=jnp.array([1.0, 9.0, 1e-30]),
+        weights=jnp.array([0.5, 0.5, 0.0]),
+        params={"risk_aversion": jnp.asarray(3.0)},
+    )
+    np.testing.assert_allclose(float(padded), float(kept), rtol=1e-12)
+
+
+def test_power_mean_aggregate_is_homogeneous_of_degree_one():
+    """Rescaling the lottery by `k > 0` rescales the certainty equivalent by `k`."""
+    weights = jnp.array([0.3, 0.7])
+    params = {"risk_aversion": jnp.asarray(6.0)}
+    unit = PowerMean().aggregate(
+        values=jnp.array([1.0, 4.0]), weights=weights, params=params
+    )
+    scaled = PowerMean().aggregate(
+        values=jnp.array([1e-12, 4e-12]), weights=weights, params=params
+    )
+    np.testing.assert_allclose(float(scaled), 1e-12 * float(unit), rtol=1e-5)
+
+
+def test_quasi_arithmetic_mean_aggregate_is_transform_sum_inverse():
+    """A generic quasi-arithmetic mean aggregates as `g⁻¹(Σ w · g(v))`.
+
+    Each callable receives exactly the runtime parameters its own signature
+    declares: `transform` sees `theta`, `inverse` sees `theta` and `offset`.
+    """
+
+    def g(value: FloatND, theta: FloatND) -> FloatND:
+        return value * theta
+
+    def g_inv(value: FloatND, theta: FloatND, offset: FloatND) -> FloatND:
+        return value / theta + offset
+
+    got = QuasiArithmeticMean(transform=g, inverse=g_inv).aggregate(
+        values=jnp.array([1.0, 3.0]),
+        weights=jnp.array([0.25, 0.75]),
+        params={"theta": jnp.asarray(2.0), "offset": jnp.asarray(0.5)},
+    )
+    # g: (2, 6); Σ w g(v) = 5; g_inv(5) = 5 / 2 + 0.5
+    np.testing.assert_allclose(float(got), 3.0, rtol=1e-6)
+
+
+@categorical(ordered=True)
+class _Health:
+    bad: ScalarInt
+    good: ScalarInt
+
+
+def _health_probs(health: DiscreteState) -> FloatND:
+    return jnp.where(
+        health == _Health.good, jnp.array([0.1, 0.9]), jnp.array([0.8, 0.2])
+    )
+
+
+def _survival_probs(health: DiscreteState, period: Period) -> FloatND:
+    alive_next = jnp.where(health == _Health.good, 0.9, 0.7) * (period < 1)
+    return jnp.array([alive_next, 1.0 - alive_next])
+
+
+def _make_scale_equivariant_model(scale: float) -> Model:
+    """Build a two-regime Epstein-Zin model whose value function scales with `scale`.
+
+    Every primitive is homogeneous of degree one in `scale` - the grids, the
+    income flow and both utilities - and `H_epstein_zin` and the power mean
+    are themselves homogeneous of degree one. The solved value function of
+    the model at `scale` is therefore exactly `scale` times the value
+    function at `scale = 1`, and the optimal consumption grid point is
+    identical.
+    """
+
+    def next_wealth(
+        wealth: ContinuousState, consumption: ContinuousAction
+    ) -> ContinuousState:
+        return jnp.clip(wealth - consumption + 0.5 * scale, 0.5 * scale, 12.0 * scale)
+
+    def utility_dead(wealth: ContinuousState) -> FloatND:
+        return 0.5 * wealth + 1e-3 * scale
+
+    def utility_alive(consumption: ContinuousAction) -> FloatND:
+        return consumption
+
+    alive = Regime(
+        transition=MarkovTransition(_survival_probs),
+        states={
+            "wealth": LinSpacedGrid(start=0.5 * scale, stop=12.0 * scale, n_points=6),
+            "health": DiscreteGrid(_Health),
+        },
+        state_transitions={
+            "wealth": next_wealth,
+            "health": {"alive": MarkovTransition(_health_probs)},
+        },
+        actions={
+            "consumption": LinSpacedGrid(
+                start=0.5 * scale, stop=5.0 * scale, n_points=7
+            )
+        },
+        constraints={"budget": _budget},
+        functions={"utility": utility_alive, "H": H_epstein_zin},
+        certainty_equivalent=PowerMean(),
+        active=lambda age: age < 27,
+    )
+    dead = Regime(
+        transition=None,
+        states={"wealth": LinSpacedGrid(start=0.0, stop=12.0 * scale, n_points=25)},
+        functions={"utility": utility_dead},
+    )
+    return Model(
+        regimes={"alive": alive, "dead": dead},
+        ages=AgeGrid(start=25, stop=27, step="Y"),
+        regime_id_class=_RegimeId,
+    )
+
+
+def _scaled_model_params(risk_aversion: float) -> dict:
+    return {
+        "alive": {
+            "H": {
+                "discount_factor": 0.9,
+                "intertemporal_elasticity_of_substitution": 2.0,
+            },
+            "certainty_equivalent": {"risk_aversion": risk_aversion},
+        },
+        "dead": {},
+    }
+
+
+@pytest.mark.parametrize("risk_aversion", [2.0, 50.0])
+def test_solved_values_are_equivariant_to_rescaling_the_model(
+    x64_enabled: None,
+    risk_aversion: float,
+):
+    """Scaling a homogeneous model by `k > 0` scales its solved values by `k`."""
+    scale = 1e-7
+    params = _scaled_model_params(risk_aversion)
+    unit = _make_scale_equivariant_model(1.0).solve(params=params, log_level="debug")
+    scaled = _make_scale_equivariant_model(scale).solve(
+        params=params, log_level="debug"
+    )
+    for period in unit:
+        for regime_name in unit[period]:
+            np.testing.assert_allclose(
+                np.asarray(scaled[period][regime_name]) / scale,
+                np.asarray(unit[period][regime_name]),
+                rtol=1e-6,
+                err_msg=f"period={period}, regime={regime_name}",
+            )

--- a/tests/test_pandas_utils.py
+++ b/tests/test_pandas_utils.py
@@ -610,7 +610,16 @@ def test_initial_conditions_heterogeneous_state_sets() -> None:
 
 
 def test_initial_conditions_process_grid_heterogeneous_state_sets() -> None:
-    """A process state (income) only present in one regime is NaN-filled elsewhere."""
+    """A process state (income) only present in one regime is NaN-filled elsewhere.
+
+    `earner` and `retiree` each transition to `dead` only, via a per-target
+    dict — not a bare coarse transition. A bare transition declares
+    conservative support over every regime active next period, and `retiree`
+    neither carries `income` nor defines an entry law for it, so a coarse
+    transition from `earner` would fail strict state-handoff validation. The
+    per-target dict is required here, not an arbitrary workaround: it narrows
+    `earner`'s declared targets to `dead`, which needs no `income` handoff.
+    """
     from lcm import UniformIIDProcess  # noqa: PLC0415
 
     @categorical(ordered=False)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -266,13 +266,13 @@ def test_snapshot_contains_environment_files(tmp_path, model_and_params):
     assert (snap_dir / "metadata.json").exists()
     assert (snap_dir / "REPRODUCE.md").exists()
 
-    with (snap_dir / "metadata.json").open() as fh:
+    with (snap_dir / "metadata.json").open(encoding="utf-8") as fh:
         metadata = json.load(fh)
     assert metadata["snapshot_type"] == "solve"
     assert "platform" in metadata
     assert "fields" in metadata
 
-    reproduce = (snap_dir / "REPRODUCE.md").read_text()
+    reproduce = (snap_dir / "REPRODUCE.md").read_text(encoding="utf-8")
     assert _get_platform() in reproduce
     assert "pixi install --frozen" in reproduce
 

--- a/tests/test_validate_regime_transition_probs.py
+++ b/tests/test_validate_regime_transition_probs.py
@@ -6,7 +6,9 @@ import pytest
 from _lcm.transition_checks import (
     _format_sum_violation,
     _validate_regime_transition_probs,
+    validate_state_transitions_all_periods,
 )
+from _lcm.utils.logging import get_logger
 from lcm import (
     AgeGrid,
     DiscreteGrid,
@@ -15,9 +17,12 @@ from lcm import (
     Model,
     categorical,
 )
-from lcm.exceptions import InvalidRegimeTransitionProbabilitiesError
+from lcm.exceptions import (
+    InvalidRegimeTransitionProbabilitiesError,
+    InvalidStateTransitionProbabilitiesError,
+)
 from lcm.regime import Regime as UserRegime
-from lcm.typing import DiscreteAction, FloatND, ScalarInt
+from lcm.typing import DiscreteAction, FloatND, ScalarFloat, ScalarInt
 from lcm_examples.mortality import RegimeId as MortalityRegimeId
 from lcm_examples.mortality import get_model, get_params
 
@@ -349,4 +354,103 @@ def test_simulate_with_solve_raises_for_invalid_regime_transition_probs():
             params=params,
             initial_conditions=initial_conditions,
             period_to_regime_to_V_arr=None,
+        )
+
+
+def test_dual_invalid_regime_probs_report_sum_error_first():
+    """When both the sum-to-one and graph-membership checks fail, sum wins.
+
+    Restores the validation order (range in `[0, 1]` -> sum-to-one ->
+    positive mass confined to active regimes) so a doubly-broken
+    `next_regime` reports a stable, deterministic message regardless of
+    which check would otherwise run first.
+    """
+    probs = MappingProxyType(
+        {
+            "working_life": jnp.array([0.5]),
+            "dead": jnp.array([0.3]),
+        }
+    )
+    with pytest.raises(
+        InvalidRegimeTransitionProbabilitiesError,
+        match=r"do not sum to 1\.0",
+    ):
+        _validate_regime_transition_probs(
+            regime_transition_probs=probs,
+            active_regimes_next_period=("working_life",),
+            regime_name="working_life",
+            age=25.0,
+            next_age=26.0,
+        )
+
+
+@categorical(ordered=False)
+class _AuxOutcome:
+    low: ScalarInt
+    high: ScalarInt
+
+
+@categorical(ordered=False)
+class _SoloTermRegimeId:
+    solo: ScalarInt
+    term: ScalarInt
+
+
+def _zero_utility() -> ScalarFloat:
+    return jnp.float32(0)
+
+
+def _one_probability() -> ScalarFloat:
+    return jnp.float32(1)
+
+
+def _malformed_aux_probs() -> FloatND:
+    """Deliberately invalid: [0.5, 0.6] does not sum to 1."""
+    return jnp.array([0.5, 0.6])
+
+
+def test_coarse_state_transition_is_checked_with_empty_period_targets():
+    """A coarse stochastic state law is checked even with no retained regime target.
+
+    `solo` is active only at period 1 (age 21) and `term` only at period 0
+    (age 20) — temporally disjoint, so `solo`'s only candidate target
+    (`term`) is never adjacent-period compatible and `solo`'s
+    regime-transition graph retains no target at any period it is active
+    (`targets(period=1, source="solo") == ()`). The coarse
+    (`target_regime_name is None`) `MarkovTransition` on state `aux` must
+    still be numerically validated at period 1 regardless — that emptiness
+    is a fact about the regime transition, not about whether the coarse
+    state law applies.
+    """
+    model = Model(
+        regimes={
+            "solo": UserRegime(
+                transition={"term": MarkovTransition(_one_probability)},
+                active=lambda age: age >= 21,
+                states={"aux": DiscreteGrid(_AuxOutcome)},
+                state_transitions={"aux": MarkovTransition(_malformed_aux_probs)},
+                constraints={"aux_is_valid": lambda aux: aux >= 0},
+                functions={"utility": _zero_utility},
+            ),
+            "term": UserRegime(
+                transition=None,
+                active=lambda age: age < 21,
+                functions={"utility": _zero_utility},
+            ),
+        },
+        ages=AgeGrid(start=20, stop=22, step="Y"),
+        regime_id_class=_SoloTermRegimeId,
+        enable_jit=False,
+    )
+    assert model.reachability.solution.targets(period=1, source="solo") == ()
+
+    flat_params = model._process_params({"discount_factor": 1.0})
+    logger = get_logger(log_level="debug")
+
+    with pytest.raises(InvalidStateTransitionProbabilitiesError):
+        validate_state_transitions_all_periods(
+            regimes=model._regimes,
+            flat_params=flat_params,
+            ages=model.ages,
+            logger=logger,
         )


### PR DESCRIPTION
Closes #412.

Targets `reachability`, not `main`.

## The defect

With a `PowerMean` certainty equivalent, `Q_and_F` built the continuation as
`inverse(Σ w · transform(v))` — per-target `transform`, weighted reduction,
one final `inverse`. For `risk_aversion > 1` and small positive continuation
values, the intermediate `v^(1-ra)` overflows the dtype before any summation
happens, so a finite certainty equivalent collapses to `0` and the Bellman
argmax reverses.

On this branch `PowerMean` had no `aggregate` at all — the whole stable path
had to be written, not just dispatched to.

## The repair

Aggregation is now a method on the certainty equivalent, and there is exactly
one call site in the engine.

- `QuasiArithmeticMean.aggregate(values=..., weights=..., params=...)` is the
  generic `g⁻¹(Σ w · g(v))`, unchanged in behaviour for user-supplied
  transform pairs.
- `PowerMean.aggregate` overrides it with an anchored weight/deviation log
  form, `log CE = a + [log(W) + log1p(E/W)] / (1-ra)`, which stays finite
  wherever the mathematical power mean is and keeps the geometric-mean limit
  exact arbitrarily close to `risk_aversion = 1`.
- `Q_and_F` hands over the **whole joint lottery in one piece** — every
  stochastic node of every reachable target, each weighted by its
  regime-transition probability — instead of reducing per target and
  inverting at the end. Flattening before aggregating is what lets the power
  mean anchor the transform; a per-target `transform -> reduce -> inverse`
  decomposition structurally cannot. The ordering constraint is preserved:
  the transform is still applied before every expectation, over stochastic
  state transitions and over regime transitions alike.
- `get_Q_and_F` and `get_compute_intermediates` now share one
  `_get_compute_E_next_V` builder, so the Bellman `Q` and the NaN diagnostics
  cannot disagree by construction. This removes ~140 lines of duplicated
  per-target setup.
- The linear (`certainty_equivalent=None`) path keeps its existing
  accumulation and arithmetic exactly — no heavy exact path is imposed on
  expected-utility models.

`resolve_certainty_equivalent` now returns one arg-to-flat-name mapping
instead of separate transform/inverse mappings, since `aggregate` receives the
union and each callable takes the subset its own signature declares.

## Evidence ingested

Both attachments on the issue: the round-4 archive excerpts inlined in the
body and `issue412-gridsearch-powermean-evidence.zip` from the comment
(reproducer, oracle, mutation family, action-reversal matrix, logs,
`REPAIR-ACCEPTANCE.md`, `disposition.yaml`, F6/R4 finding JSONs).

The packet's own reproducer is signature-bound to the audited DC-EGM snapshot
(`5b4339e2`) — it calls `get_Q_and_F(..., scalar_targets=...)`, which does not
exist on `reachability`. Its substance has therefore been ported into the
project's own suite rather than vendored: the decimal oracle, the pinned
witnesses, the seven-case risk/scale family, and the acceptance list.

## Acceptance coverage

Every item of `REPAIR-ACCEPTANCE.md`:

| Required regression | Where |
|---|---|
| Pinned scalar float32 `(1e-8, 2e-8)` @ ra 8 | `test_power_mean_regime_lottery_stays_finite_in_float32` |
| Pinned scalar float64 `(1e-50, 2e-50)` @ ra 8 | `test_power_mean_regime_lottery_stays_finite_in_float64` |
| Stateful-only lottery, both precisions | `test_solved_values_are_equivariant_to_rescaling_the_model` (stochastic health nodes), `..._matches_reference_at_float{32,64}_scales` |
| Seven-case risk/scale action-order family | `test_bellman_prefers_the_higher_certainty_equivalent_at_any_scale` (4 float64 cases) + `..._matches_reference_at_float32_scales` (3 float32 cases) |
| Mixed shock-by-regime lottery | the rescaling model: 2 health nodes in `alive` × the `dead` target |
| Positive common-rescaling invariance | `test_power_mean_aggregate_is_homogeneous_of_degree_one`, both rescaling tests |
| Risk aversion near 1 / geometric mean | `test_power_mean_aggregate_is_geometric_mean_at_unit_risk_aversion`, `..._is_continuous_around_unit_risk_aversion` (ra = 1 ± 1e-6) |
| Risk aversion 0 / linear parity | `test_power_mean_aggregate_is_linear_expectation_at_zero_risk_aversion`, existing `test_zero_risk_aversion_reduces_to_expected_utility` |
| Zero-weight and unit-mass | `test_power_mean_aggregate_drops_zero_weight_entries` |
| Solve / simulation / diagnostics consistency | `test_diagnostic_intermediates_reproduce_the_Bellman_Q`, `test_simulated_consumption_is_equivariant_to_rescaling_the_model` |

All values are checked against a 120-digit `decimal` oracle (the packet's
`stable_power_mean`, reimplemented in `tests/test_certainty_equivalent.py`),
under JIT, in both precisions.

Each new test was confirmed red on the pre-fix source before the repair
landed.

## Resource gate

Epstein–Zin example, 25 periods, 400 × 2 wealth-health × 600 consumption,
float64, CPU. Shared box with a concurrent test run, so cold-compile numbers
are noisy; the ranges below are min/max over two runs each.

| | before | after |
|---|---|---|
| linear cold compile | 0.92 – 1.94 s | 0.92 – 0.93 s |
| linear warm runtime | 0.34 – 0.42 s | 0.34 – 0.85 s |
| power-mean cold compile | 0.76 – 1.85 s | 2.26 – 2.39 s |
| power-mean warm runtime | 0.446 s | 0.50 – 0.53 s |
| power-mean peak RSS | 659 – 670 MiB | 599 – 606 MiB |

The linear path is unchanged within noise. The power-mean path costs roughly
+12% warm runtime and a longer cold compile — the anchored form emits
`log`/`min`/`max`/`expm1`/`log1p` where the naive route emitted a single
`pow` — and peak RSS drops slightly, since one concatenated reduction
replaces a per-target reduction chain.

## Not addressed

Provenance. `PROVENANCE-AND-SCOPE.md` names PR #395 as the likely first-bad
commit but marks it `hypothesis_only`; no bisect was run here. The repair is
independent of which commit introduced the seam.
