### PR TITLE
Cancel a PR's orphaned workflow runs when the PR is closed

### DIFF
--- a/.github/workflows/cancel-closed-pr-runs.yml
+++ b/.github/workflows/cancel-closed-pr-runs.yml
@@ -4,6 +4,9 @@ name: Cancel runs of closed PRs
 # `main.yml`'s concurrency group only supersedes a run when a NEWER run appears on the
 # same head ref -- closing a PR is not a new run, so it never fires. Orphaned runs then
 # sit in the self-hosted GPU queue and block every later PR behind them.
+#
+# Scope: PRs closed WITHOUT merging. A merged PR's runs are left to finish -- see the
+# job-level `if` below.
 on:
   # `pull_request_target` (not `pull_request`) so the token is writable for fork PRs
   # too. This is only safe because nothing here checks out or executes PR code: the job
@@ -18,6 +21,13 @@ permissions:
 jobs:
   cancel:
     name: Cancel orphaned runs for this PR's head ref
+    # `closed` also fires on merge; merged PRs are deliberately left alone so their runs
+    # finish. Be aware of the cost: a `benchmark-pr` run sits in concurrency group
+    # `gpu-benchmarks-<head_ref>` while the post-merge `benchmark-main` run sits in
+    # `gpu-benchmarks-main`, so merging does NOT supersede it. With
+    # `timeout-minutes: 14400` (10 days) and a "wait for GPU to be free" spin loop, such
+    # a run can hold the benchmark runner for a long time -- cancel it by hand if so.
+    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/cancel-closed-pr-runs.yml
+++ b/.github/workflows/cancel-closed-pr-runs.yml
@@ -1,0 +1,87 @@
+---
+name: Cancel runs of closed PRs
+# GitHub does not cancel a PR's queued/in-progress runs when the PR is closed, and
+# `main.yml`'s concurrency group only supersedes a run when a NEWER run appears on the
+# same head ref -- closing a PR is not a new run, so it never fires. Orphaned runs then
+# sit in the self-hosted GPU queue and block every later PR behind them.
+on:
+  # `pull_request_target` (not `pull_request`) so the token is writable for fork PRs
+  # too. This is only safe because nothing here checks out or executes PR code: the job
+  # reads the head ref as an env var and calls the REST API. Do NOT add a checkout step.
+  pull_request_target:
+    types:
+      - closed
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+jobs:
+  cancel:
+    name: Cancel orphaned runs for this PR's head ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Cancel queued and in-progress runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SELF_RUN_ID: ${{ github.run_id }}
+          # Read via `$ENV` in jq and `-f` in gh, never interpolated into a shell word
+          # or a URL: a branch name is attacker-controlled on a fork PR.
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |-
+          set -euo pipefail
+
+          # A head ref can back more than one PR (e.g. a stack branch retargeted from
+          # one base to another). Cancelling then would kill a LIVE PR's runs, so bail
+          # if any other open PR still points at this exact head repo + ref.
+          # `--paginate` applies --jq per page, so sum rather than reading one number.
+          still_open=$(gh api "repos/${REPO}/pulls" -X GET \
+            -f state=open -f per_page=100 --paginate \
+            --jq '[.[] | select(.head.ref == $ENV.HEAD_REF
+                   and .head.repo.full_name == $ENV.HEAD_REPO)] | length' \
+            | awk '{s += $1} END {print s + 0}')
+          if [ "${still_open}" -gt 0 ]; then
+            echo "::notice::${HEAD_REF} still backs ${still_open} open PR(s); skipping."
+            exit 0
+          fi
+
+          # `-f` so gh URL-encodes the branch name. `branch=` filters on head_branch;
+          # `event=pull_request` keeps pushes to main out of scope even if a branch
+          # name ever collided (and excludes this reaper's own run by construction).
+          mapfile -t runs < <(gh api "repos/${REPO}/actions/runs" -X GET \
+            -f branch="${HEAD_REF}" -f event=pull_request -f per_page=100 \
+            --jq '.workflow_runs[]
+                  | select(.status == "queued" or .status == "in_progress"
+                           or .status == "waiting" or .status == "requested"
+                           or .status == "pending")
+                  | .id')
+          if [ "${#runs[@]}" -eq 0 ]; then
+            echo "::notice::No active runs for ${HEAD_REF}."
+            exit 0
+          fi
+          for run_id in "${runs[@]}"; do
+            [ "${run_id}" = "${SELF_RUN_ID}" ] && continue
+            echo "Cancelling run ${run_id} (${HEAD_REF})"
+            gh api -X POST "repos/${REPO}/actions/runs/${run_id}/cancel" >/dev/null \
+              || echo "::warning::cancel call failed for ${run_id}"
+          done
+
+          # A long-running self-hosted job can ignore the ordinary cancel -- observed on
+          # the GPU runner, where the graceful cancel never took and the queue stayed
+          # blocked. Give each run a bounded grace period, then force it.
+          for run_id in "${runs[@]}"; do
+            [ "${run_id}" = "${SELF_RUN_ID}" ] && continue
+            status=unknown
+            for _ in $(seq 1 12); do
+              status=$(gh api "repos/${REPO}/actions/runs/${run_id}" --jq .status)
+              [ "${status}" = "completed" ] && break
+              sleep 10
+            done
+            if [ "${status}" != "completed" ]; then
+              echo "::warning::run ${run_id} ignored cancel after 120s; forcing"
+              gh api -X POST "repos/${REPO}/actions/runs/${run_id}/force-cancel" \
+                >/dev/null || echo "::warning::force-cancel failed for ${run_id}"
+            fi
+          done


### PR DESCRIPTION
Closes the gap that blocked the GPU queue for 84 minutes today.

## The problem

GitHub does not cancel a PR's queued or in-progress runs when the PR is closed.
`main.yml`'s concurrency guard cannot cover this:

```yaml
concurrency:
  group: ${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

That only supersedes a run when a **newer run appears on the same head ref**. Closing a PR
is not a new run, so it never fires.

With a single self-hosted GPU runner, the orphans become head-of-line blockers.

**Observed 2026-08-03.** PR #413 (`grid-search-ez` → `reachability`) was open from 11:21:03
to 11:23:48 — 2m45s. Its run `30809182760` outlived it by ~84 minutes, sitting in the GPU
queue in front of #414 until the runs were cancelled by hand at 12:45. #390's run also had
to be **force**-cancelled: its 32-bit GPU job ignored the ordinary cancel endpoint entirely.

## The fix

A reaper on `pull_request_target: [closed]` that cancels runs for that head ref.

Five things worth reviewing:

- **Scope: PRs closed *without* merging.** `closed` also fires on merge, so the job is
  guarded by `if: github.event.pull_request.merged == false`. Merged PRs' runs are
  deliberately left to finish.
- **`pull_request_target`, not `pull_request`** — the token is read-only for fork PRs on
  `pull_request`, so the reaper would silently no-op on exactly the PRs least likely to be
  cleaned up by hand. This is only safe because the job never checks out or executes PR
  code; it reads the head ref and calls the REST API. **Do not add a checkout step.**
- **No injection surface.** On a fork PR the head ref is attacker-controlled, so it reaches
  jq via `$ENV` and gh via `-f` (which also URL-encodes it) — never a shell word or a raw
  query string. Branch names may legally contain `&` and `#`.
- **Live-PR guard.** A head ref can back more than one PR — retargeting a stack branch is
  the obvious case here. The job bails if any *other* open PR still points at the same head
  repo + ref, so closing one cannot cancel a live one's runs.
- **Bounded escalation to `force-cancel`.** 120s grace, then force. Without this the
  workflow would not have fixed today's incident: the graceful cancel was ignored.

## Known cost of exempting merged PRs

This is documented at the guard so it isn't rediscovered the hard way. `benchmark-pr` runs
in concurrency group `gpu-benchmarks-<head_ref>`, while the post-merge `benchmark-main` run
uses `gpu-benchmarks-main` — **different groups, so merging does not supersede the PR's
benchmark run.** With `timeout-minutes: 14400` (10 days) and a `while nvidia-smi … sleep 60`
wait-for-GPU loop, a benchmark run started on a PR can hold the benchmark runner well past
the merge. Cancel it by hand if that happens.

## Verification

Ran against live API state before committing:

| check | result |
|---|---|
| `-f branch="feat/dcegm"` filters correctly (slash in ref) | matches, 3 runs |
| `$ENV` works in gh's jq (gojq) | yes |
| live-PR guard on `reachability` (#414 open) | `still_open=1` → **skips** |
| run query for `grid-search-ez` | finds `30809182760` |
| that run's status when #413 closed | `queued` → inside the filter, **would have been reaped** |
| `set -e` survives `[ … ] && continue` | survives |
| `bash -n` on the extracted `run:` block | OK |
| `yamllint`, `check-github-workflows`, full `prek` | pass |

Not exercised end-to-end on GitHub — `pull_request_target` runs the version of the workflow
on the **base** branch, so it does nothing until this lands on `main`. The first real test
is the next PR closed without merging.
