### PR TITLE
PERF Cut dense-reference grids and batch-size splaying cost in tests/solution

### DIFF
--- a/tests/solution/test_egm_batch_size_combos.py
+++ b/tests/solution/test_egm_batch_size_combos.py
@@ -44,12 +44,15 @@ _INVARIANCE_RTOL = 1e-12 if X64_ENABLED else 1e-4
 _INVARIANCE_ATOL = 1e-12 if X64_ENABLED else 1e-4
 
 N_PERIODS = 4
-N_WEALTH = 40
+N_WEALTH = 12
 BAND_START = 5.0
 BAND_WIDTH = 40.0
 
-CONSUMPTION_GRID = LinSpacedGrid(start=0.25, stop=100.0, n_points=2000)
-SAVINGS_GRID = IrregSpacedGrid(points=tuple(110.0 * (i / 149) ** 3 for i in range(150)))
+# Block assembly is a scheduling property, so it is detected at any model size:
+# these grids are sized for the cheapest solve that still exercises the
+# flatten-and-transpose path, not for resolution.
+CONSUMPTION_GRID = LinSpacedGrid(start=0.25, stop=100.0, n_points=60)
+SAVINGS_GRID = IrregSpacedGrid(points=tuple(110.0 * (i / 29) ** 3 for i in range(30)))
 
 
 @categorical(ordered=False)
@@ -159,7 +162,7 @@ def _model(health_batch_size: int) -> Model:
     )
     dead = UserRegime(
         transition=None,
-        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=200)},
+        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=40)},
         functions={"utility": bequest},
     )
     return Model(
@@ -262,7 +265,7 @@ def _two_combo_model(batch_size: int) -> Model:
     )
     dead = UserRegime(
         transition=None,
-        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=200)},
+        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=40)},
         functions={"utility": bequest},
     )
     return Model(

--- a/tests/solution/test_egm_batch_size_euler.py
+++ b/tests/solution/test_egm_batch_size_euler.py
@@ -33,12 +33,15 @@ from lcm.typing import (
 )
 
 N_PERIODS = 4
-N_WEALTH = 23  # deliberately prime-ish: no batch size below divides it evenly
+N_WEALTH = 11  # prime, so every block size but 1 leaves a ragged final block
 BAND_START = 5.0
 BAND_WIDTH = 40.0
 
-CONSUMPTION_GRID = LinSpacedGrid(start=0.25, stop=100.0, n_points=2000)
-SAVINGS_GRID = IrregSpacedGrid(points=tuple(110.0 * (i / 149) ** 3 for i in range(150)))
+# Block assembly is a scheduling property, so it is detected at any model size:
+# these grids are sized for the cheapest solve that still exercises a ragged
+# final block, not for resolution.
+CONSUMPTION_GRID = LinSpacedGrid(start=0.25, stop=100.0, n_points=60)
+SAVINGS_GRID = IrregSpacedGrid(points=tuple(110.0 * (i / 29) ** 3 for i in range(30)))
 
 
 @categorical(ordered=False)
@@ -129,7 +132,7 @@ def _model(batch_size: int) -> Model:
     )
     dead = UserRegime(
         transition=None,
-        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=200)},
+        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=40)},
         functions={"utility": bequest},
     )
     return Model(
@@ -147,7 +150,7 @@ def _solve(batch_size: int) -> PeriodToRegimeToVArr:
     return _model(batch_size).solve(params=_params(), log_level="debug")
 
 
-@pytest.mark.parametrize("batch_size", [1, 4, 8, N_WEALTH])
+@pytest.mark.parametrize("batch_size", [1, 4, N_WEALTH])
 def test_euler_grid_batch_size_leaves_value_function_unchanged(batch_size: int):
     """Splaying the Euler grid into blocks does not change the solved V.
 

--- a/tests/solution/test_egm_batch_size_savings.py
+++ b/tests/solution/test_egm_batch_size_savings.py
@@ -35,7 +35,10 @@ from tests.solution.test_egm_batch_size_euler import (
     utility,
 )
 
-N_SAVINGS = 149  # prime: no batch size below divides it evenly
+# Prime, so every block size but 1 leaves a ragged final block. Sized for the
+# cheapest solve that still shows that; invariance under the partition does not
+# depend on resolution.
+N_SAVINGS = 17
 
 
 @functools.cache
@@ -74,7 +77,7 @@ def _model(savings_batch_size: int) -> Model:
     )
     dead = UserRegime(
         transition=None,
-        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=200)},
+        states={"wealth": LinSpacedGrid(start=1.0, stop=120.0, n_points=40)},
         functions={"utility": bequest},
     )
     return Model(
@@ -88,7 +91,7 @@ def _solve(savings_batch_size: int) -> PeriodToRegimeToVArr:
     return _model(savings_batch_size).solve(params=_params(), log_level="debug")
 
 
-@pytest.mark.parametrize("savings_batch_size", [1, 7, 16, N_SAVINGS])
+@pytest.mark.parametrize("savings_batch_size", [1, 7, N_SAVINGS])
 def test_savings_grid_batch_size_leaves_value_function_unchanged(savings_batch_size):
     """Splaying the savings grid into blocks does not change the solved V.
 

--- a/tests/solution/test_egm_passive_asset_row.py
+++ b/tests/solution/test_egm_passive_asset_row.py
@@ -63,12 +63,15 @@ AIME_MAX = 20.0
 # Pension annuity drawn from accumulated AIME, added to next wealth.
 PENSION_RATE = 0.2
 
-WEALTH_GRID = LinSpacedGrid(start=1.0, stop=100.0, n_points=120)
+WEALTH_GRID = LinSpacedGrid(start=1.0, stop=100.0, n_points=60)
 AIME_GRID = LinSpacedGrid(start=0.0, stop=AIME_MAX, n_points=6)
+# Dense enough that the brute-force oracle's own resolution error stays well
+# below the comparison tolerance; unlike the state grids above, this one
+# cannot shrink without reintroducing that oracle-side bias.
 CONSUMPTION_GRID = LinSpacedGrid(start=0.25, stop=120.0, n_points=600)
-SAVINGS_GRID = IrregSpacedGrid(points=tuple(100.0 * (i / 119) ** 3 for i in range(120)))
+SAVINGS_GRID = IrregSpacedGrid(points=tuple(100.0 * (i / 59) ** 3 for i in range(60)))
 
-N_BRUTE_UNSTABLE_NODES = 16
+N_BRUTE_UNSTABLE_NODES = 8
 
 
 @categorical(ordered=False)
@@ -294,7 +297,7 @@ def test_asset_row_carry_rows_are_the_euler_grid_not_the_envelope_workspace():
     assert template is not None
     n_euler = int(WEALTH_GRID.to_jax().shape[0])
     # The envelope workspace would have been ceil(1.2 * (n_savings + n_constrained))
-    # = ceil(1.2 * (120 + 64)) = 221 rows; the persisted carry is the 120 Euler nodes.
+    # = ceil(1.2 * (60 + 64)) = 149 rows; the persisted carry is the 60 Euler nodes.
     assert template.value.shape[-1] == n_euler
     assert template.marginal_utility.shape[-1] == n_euler
     assert template.endog_grid.shape[-1] == n_euler


### PR DESCRIPTION
## Summary

Two commits, both cutting cost in `tests/solution` without weakening any assertion:

1. **`test_egm_passive_asset_row.py`** — shrink the state grids feeding a dense
   brute-force oracle (the file the dispatch named as the chief Workstream B cost).
2. **The `batch_size` splaying cluster** (`_euler`, `_combos`, `_savings`) — size each
   model for the cheapest solve that still exercises a ragged final block, and keep one
   block size per structurally distinct schedule.

No oracle is frozen into a stored fixture, no tolerance is relaxed, and every reduced
test is verified to still fail under a mutation the original caught.

## 1. `test_egm_passive_asset_row.py`

`WEALTH_GRID` and `SAVINGS_GRID` were both 120 nodes, past what the dense comparison
needs. `CONSUMPTION_GRID` is deliberately left at 600: it sets the *brute-force oracle's
own* resolution error, and shrinking it to 150 or 300 reintroduces oracle bias that
breaks the existing `rtol=1e-3`. `N_BRUTE_UNSTABLE_NODES` is halved in proportion to
`WEALTH_GRID`, so the same absolute wealth range stays excluded.

| Grid | Before | After |
| --- | ---: | ---: |
| `WEALTH_GRID` | 120 | 60 |
| `SAVINGS_GRID` | 120 | 60 |
| `CONSUMPTION_GRID` | 600 | 600 (unchanged) |
| `N_BRUTE_UNSTABLE_NODES` | 16 | 8 |

Isolated single-process runs (`-n 0 --precision=64`) on `hmg-office`: **373.72s →
169.14s** wall, **2.99 GiB → 2.36 GiB** peak RSS. All 7 tests pass at their original
tolerances.

**Mutation:** `next_wealth_dcegm` returning `savings + labor_income` (dropping
`pension_income`) — a one-sided law-of-motion bug that breaks the DC-EGM side but not the
oracle. Still fails at the reduced grid.

## 2. The `batch_size` splaying cluster

These tests assert a *scheduling* invariant — a splayed solve must reproduce the
unsplayed one — at exact equality (`rtol=1e-12`). Detection of a mis-assembled block does
not depend on model size, so the grids carried resolution the assertions never used, and
each file covered the ragged-final-block case twice.

Grids are sized down (consumption 2000 → 60, savings 150 → 30, terminal wealth 200 → 40),
the deliberately prime grid lengths are preserved (`N_WEALTH` 23 → 11, `N_SAVINGS`
149 → 17) so every block size but 1 still leaves a ragged tail, and one redundant block
size is dropped per file. What remains is one per distinct schedule: the degenerate
single-node block, a size leaving a ragged tail, and the boundary size equal to the grid
length (which falls back to the vmap).

**208.10s → 179.93s (−13.5%)** for the three files, 13 tests → 11.

**Mutations**, one realistic wrong-block-reassembly defect per splay site — all three
caught, with the surviving test in each being the boundary size that takes the unmutated
vmap path:

| Site | Mutation | Result |
| --- | --- | --- |
| `asset_row.py` | rolled `V_vec` out of `lax.map` | 2 failed, 1 passed |
| `step_core.py` | rolled the savings axis | 2 failed, 1 passed |
| `step.py` | reversed the flattened combo product | 2 failed, 3 passed |

### Honest limitation: grid size was not the lever here

Shrinking the grids alone bought only **7%** (208.10s → 193.00s). Most of the remaining
13.5% came from dropping the redundant parametrisations. Measured directly:

- The first solve of a model is **93% compilation** (8.59s first call vs 0.56s second).
- In *fresh processes*, the original grids and the reduced grids cost the **same** 5.70s
  per solve. Grid size has no measurable effect on the cost of building the program.
- What remains is Python tracing and HLO lowering, one program set per distinct
  `batch_size`, which no grid reduction reaches.

So this commit is worth what it says and no more. The dominant cost of this cluster is
structural, and reducing it further would mean dropping coverage, not shrinking models.
An earlier revision of this description attributed the saving to grid size; that was
wrong and is corrected here.

## CI status at merge time

Recorded honestly rather than waited out. This branch was rebased onto `feat/dcegm`
@ `e4b00795` immediately before merging, so CI had not finished on the final sha.

- **Merged without a green `cpu` run on the final sha.** Verified locally instead: the
  four changed files pass (18 tests) on the rebased base, re-run after the rebase
  specifically because `e4b00795` carries an EGM kernel refactor touching
  `src/_lcm/egm/step.py` — one of the splay sites these tests exercise. Not verified
  under CI's `-n 4` + coverage configuration.
- `ty`, `notebooks` — green on the preceding sha.
- `gpu32` — **failing, inherited from the base.** `feat/dcegm` fails identically,
  `gpu32.yml` contains none of this branch's changes, and the failure is at collection in
  `test_analytical_solution.py`, which this PR does not touch. Root cause is a
  concurrent-writer race on XLA's GPU per-fusion autotune cache
  (`xla_gpu_per_fusion_autotune_cache_dir`) under four xdist workers sharing one cache
  directory; `jax_persistent_cache_enable_xla_caches = "none"` is the candidate fix.
  Tracked separately; not attributable to this PR.

## Workstream A (Mahler-Yum gate files) — deferred

`tests/test_mahler_yum_continuous_outer.py` and `tests/test_mahler_yum_implicit_pilot.py`
do not exist anywhere in `feat/dcegm`'s history. They live on `origin/collective-regimes`,
which diverged from `feat/dcegm` at their shared merge-base. Deferred to a separate pass
against that branch, per HMG. This PR covers Workstream B only.

## Test plan

- [x] `test_egm_passive_asset_row.py` passes at original tolerances with the shrunk grids
- [x] The three `batch_size` files pass, 11 tests, on the rebased base
- [x] Mutation proof for the dense-reference oracle (dropped `pension_income`)
- [x] Mutation proof for all three splay sites (wrong block reassembly)
- [x] `prek run --files <the four files>` clean
- [ ] CI `cpu` — merged before it reported

https://claude.ai/code/session_01F7rvG9fy53DdKW28jam2zL
